### PR TITLE
docs: document branch and PR workflow conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,6 +241,9 @@ When working on this project:
 6. Preserve the current sandbox limits and request boundary logic unless the task explicitly changes them.
 7. Record recurring project-specific lessons in the section below when they are likely to prevent future mistakes.
 8. Notify the user when `AGENTS.md` or `README.md` has changed so those docs can be reviewed explicitly.
+9. When the user asks for branch/commit/PR workflow, use the available MCP/devtools for branch creation, commits, pushes, and PRs. Only fall back to `gh` CLI when those tools are not available. Never assume Claude Code or any other external workflow helper.
+10. For branch/commit/PR workflow, commit subjects and PR titles must use conventional-commit style and should choose the most appropriate type from this set: `feat`, `perf`, `fix`, `refactor`, `docs`, `build`, `types`, `chore`, `examples`, `test`, `style`, `ci`. The project maps them as follows: `feat` → 🚀 Enhancements (minor), `perf` → 🔥 Performance (patch), `fix` → 🩹 Fixes (patch), `refactor` → 💅 Refactors (patch), `docs` → 📖 Documentation (patch), `build` → 📦 Build (patch), `types` → 🌊 Types (patch), `chore` → 🏡 Chore, `examples` → 🏀 Examples, `test` → ✅ Tests, `style` → 🎨 Styles, `ci` → 🤖 CI.
+11. PRs created for the user must include a body. If the work clearly addresses an existing issue and the issue identifier is known, include it in the PR body using the appropriate GitHub-style reference.
 
 ## Project Context & Learnings
 


### PR DESCRIPTION
## Summary
- add explicit AGENTS.md guidance for branch, commit, push, and PR requests
- require conventional-commit style commit subjects and PR titles from the approved type list
- document that PRs must include a body and should use MCP/devtools first, with `gh` only as fallback

## Type of change
- [ ] Feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [x] Documentation
- [ ] Refactor

## Test plan
- not run (documentation-only change)
