### PR TITLE
feat: add restriction aliases

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ src/core-openapi.d.ts         Ambient type declarations for the `#core-openapi` 
 
 #### CLI mode
 
-1. `src/cli/index.ts` parses CLI arguments and restriction flags.
+1. `src/cli/index.ts` parses CLI arguments and restriction flags (`-r`, `--restrict`, and `--restriction`).
 2. It accepts `--spec` / `-s` to select the bundled core OpenAPI snapshot exposed by `query`.
 3. It sets `globalThis.executionEnvironment = 'cli'`.
 4. It exposes credential lookup helpers on `globalThis` for tools and subcommands.
@@ -88,7 +88,7 @@ src/core-openapi.d.ts         Ambient type declarations for the `#core-openapi` 
 
 1. `src/index.ts` starts the HTTP server and exposes `/mcp` and `/health`.
 2. It sets `globalThis.executionEnvironment = 'server'`.
-3. It extracts auth from request headers and restrictions from query parameters.
+3. It extracts auth from request headers and restrictions from `restriction`, `restrict`, and `r` query parameters.
 4. It stores auth in request-local context and forwards the request to the shared MCP server.
 5. It configures the HTTP transport in POST-only mode (`disableSse: true`) because the optional long-lived GET/SSE channel proved unstable behind Cumulocity microservice ingress.
 
@@ -242,7 +242,7 @@ When working on this project:
 7. Record recurring project-specific lessons in the section below when they are likely to prevent future mistakes.
 8. Notify the user when `AGENTS.md` or `README.md` has changed so those docs can be reviewed explicitly.
 9. When the user asks for branch/commit/PR workflow, use the available MCP/devtools for branch creation, commits, pushes, and PRs. Only fall back to `gh` CLI when those tools are not available. Never assume Claude Code or any other external workflow helper.
-10. For branch/commit/PR workflow, commit subjects and PR titles must use conventional-commit style and should choose the most appropriate type from this set: `feat`, `perf`, `fix`, `refactor`, `docs`, `build`, `types`, `chore`, `examples`, `test`, `style`, `ci`. The project maps them as follows: `feat` → 🚀 Enhancements (minor), `perf` → 🔥 Performance (patch), `fix` → 🩹 Fixes (patch), `refactor` → 💅 Refactors (patch), `docs` → 📖 Documentation (patch), `build` → 📦 Build (patch), `types` → 🌊 Types (patch), `chore` → 🏡 Chore, `examples` → 🏀 Examples, `test` → ✅ Tests, `style` → 🎨 Styles, `ci` → 🤖 CI.
+10. For branch/commit/PR workflow, branch names should use the same conventional type prefixes as commits and PR titles where appropriate. Prefer prefixes such as `feat/`, `test/`, `chore/`, `fix/`, `docs/`, `refactor/`, `build/`, `types/`, `examples/`, `style/`, `perf/`, and `ci/`. Commit subjects and PR titles must use conventional-commit style and should choose the most appropriate type from this set: `feat`, `perf`, `fix`, `refactor`, `docs`, `build`, `types`, `chore`, `examples`, `test`, `style`, `ci`. The project maps them as follows: `feat` → 🚀 Enhancements (minor), `perf` → 🔥 Performance (patch), `fix` → 🩹 Fixes (patch), `refactor` → 💅 Refactors (patch), `docs` → 📖 Documentation (patch), `build` → 📦 Build (patch), `types` → 🌊 Types (patch), `chore` → 🏡 Chore, `examples` → 🏀 Examples, `test` → ✅ Tests, `style` → 🎨 Styles, `ci` → 🤖 CI.
 11. PRs created for the user must include a body. If the work clearly addresses an existing issue and the issue identifier is known, include it in the PR body using the appropriate GitHub-style reference.
 
 ## Project Context & Learnings
@@ -265,6 +265,7 @@ This section captures project-specific knowledge, tool quirks, and lessons learn
 - Server builds should not use `noExternal: [/^.*$/]`. The microservice bundle is allowed to depend on runtime `node_modules`, and the release image must install those dependencies inside the Linux image rather than copying host `node_modules` from macOS.
 - `scripts/package-microservices.mjs` intentionally targets `linux/amd64` by default to avoid Apple Silicon release images failing with `exec format error` in Cumulocity.
 - Restrictions are both discoverability metadata and enforcement logic; both layers matter.
+- When creating branches for user-requested work, prefer conventional prefixes that match the intended change type, especially `feat/`, `test/`, and `chore/`.
 - Server-mode auth must stay request-local.
 - For deployed microservice mode, prefer POST-only streamable HTTP over long-lived GET/SSE. The optional SSE channel can go inactive behind Cumulocity ingress and break later tool calls even when initialization and tool discovery succeeded.
 

--- a/README.md
+++ b/README.md
@@ -195,27 +195,27 @@ Supported wildcards:
 
 ### Path Pattern Examples
 
-| Pattern            | Matches                                                  | Does not match                          |
-| ------------------ | -------------------------------------------------------- | --------------------------------------- |
-| `/inventory`       | `/inventory`                                             | `/inventory/managedObjects`             |
-| `/inventory/**`    | `/inventory`, `/inventory/managedObjects`, `/inventory/x/y` | `/alarm/alarms`                         |
-| `/i*`              | `/inventory`, `/identity`, `/i`                          | `/inventory/managedObjects`             |
-| `/i*/**`           | `/inventory`, `/inventory/managedObjects`, `/identity/x` | `/alarm/alarms`                         |
-| `/inventory/m*`    | `/inventory/managedObjects`, `/inventory/measurements`   | `/inventory/events`, `/inventory/m/x`   |
-| `/inventory/*/child` | `/inventory/device-1/child`, `/inventory/x/child`     | `/inventory/child`, `/inventory/a/b/child` |
-| `/inventory/**/child` | `/inventory/child`, `/inventory/a/b/child`           | `/inventory/a/b/sibling`                |
+| Pattern               | Matches                                                     | Does Not Match                             |
+| --------------------- | ----------------------------------------------------------- | ------------------------------------------ |
+| `/inventory`          | `/inventory`                                                | `/inventory/managedObjects`                |
+| `/inventory/**`       | `/inventory`, `/inventory/managedObjects`, `/inventory/x/y` | `/alarm/alarms`                            |
+| `/i*`                 | `/inventory`, `/identity`, `/i`                             | `/inventory/managedObjects`                |
+| `/i*/**`              | `/inventory`, `/inventory/managedObjects`, `/identity/x`    | `/alarm/alarms`                            |
+| `/inventory/m*`       | `/inventory/managedObjects`, `/inventory/measurements`      | `/inventory/events`, `/inventory/m/x`      |
+| `/inventory/*/child`  | `/inventory/device-1/child`, `/inventory/x/child`           | `/inventory/child`, `/inventory/a/b/child` |
+| `/inventory/**/child` | `/inventory/child`, `/inventory/a/b/child`                  | `/inventory/a/b/sibling`                   |
 
 ### Common Rule Examples
 
-| Rule                             | Effect                                                           |
-| -------------------------------- | ---------------------------------------------------------------- |
-| `/inventory/**`                  | Block all methods on `/inventory` and everything below it        |
-| `DELETE:/inventory/**`           | Block only DELETE on `/inventory` and everything below it        |
-| `/alarm/alarms`                  | Block all methods on the exact path `/alarm/alarms`              |
-| `GET:/measurement/measurements`  | Block only GET on the exact path `/measurement/measurements`     |
-| `POST:/inventory/managedObjects` | Block creating new managed objects                               |
-| `/i*/**`                         | Block all routes whose first path segment starts with `i`        |
-| `/user/**`                       | Block all user management paths                                  |
+| Rule                             | Effect                                                       |
+| -------------------------------- | ------------------------------------------------------------ |
+| `/inventory/**`                  | Block all methods on `/inventory` and everything below it    |
+| `DELETE:/inventory/**`           | Block only DELETE on `/inventory` and everything below it    |
+| `/alarm/alarms`                  | Block all methods on the exact path `/alarm/alarms`          |
+| `GET:/measurement/measurements`  | Block only GET on the exact path `/measurement/measurements` |
+| `POST:/inventory/managedObjects` | Block creating new managed objects                           |
+| `/i*/**`                         | Block all routes whose first path segment starts with `i`    |
+| `/user/**`                       | Block all user management paths                              |
 
 ### Important Notes
 
@@ -226,7 +226,7 @@ Supported wildcards:
 
 ### CLI Mode
 
-Pass restrictions as CLI arguments. Repeat `-r` / `--restriction` for multiple rules:
+Pass restrictions as CLI arguments. Repeat `-r`, `--restrict`, or `--restriction` for multiple rules:
 
 ```sh
 # Block all inventory access
@@ -237,14 +237,18 @@ mc8yp -r "DELETE:/inventory/**" -r "/alarm/**"
 
 # Block everything under user management
 mc8yp --restriction "/user/**"
+
+# Same thing using the long alias
+mc8yp --restrict "/user/**"
 ```
 
 ### Microservice Mode (HTTP)
 
-Pass restrictions as `restriction` query parameters on the MCP endpoint URL:
+Pass restrictions as `restriction`, `restrict`, or `r` query parameters on the MCP endpoint URL:
 
 ```
-/mcp?restriction=/inventory/**&restriction=DELETE:/alarm/**
+/mcp?restriction=/inventory/**&restrict=DELETE:/alarm/**
+/mcp?r=/inventory/**&r=DELETE:/alarm/**
 ```
 
 ### How Restrictions Work

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,7 +17,7 @@ const main = defineCommand({
     restriction: {
       type: 'string',
       description: 'Restriction rule to deny API access (e.g. "GET:/inventory/**"). Can be repeated.',
-      alias: 'r',
+      alias: ['r', 'restrict'],
     },
     spec: {
       type: 'string',

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,8 @@ const transport = new HttpTransport(server, {
 const app = new H3().all('/mcp', async (event) => {
   // Extract authentication from request headers
   const credentials = extractAuthFromHeaders(event.req)
-  const restriction = getQuery(event).restriction
-  const restrictionSources = (Array.isArray(restriction) ? restriction : [restriction]).filter(
+  const query = getQuery(event)
+  const restrictionSources = [query.restriction, query.restrict, query.r].flatMap((value) => Array.isArray(value) ? value : [value]).filter(
     (value): value is string => typeof value === 'string' && value.length > 0,
   )
   const { parsedRules, failedRules } = parseRestrictionRule(restrictionSources)
@@ -29,7 +29,7 @@ const app = new H3().all('/mcp', async (event) => {
     throw new HTTPError({
       status: 400,
       statusText: 'Invalid restriction query',
-      message: 'One or more restriction query parameters could not be parsed.',
+      message: 'One or more restriction query parameters (?restriction, ?restrict, ?r) could not be parsed.',
       data: {
         failedRules,
       },


### PR DESCRIPTION
## Summary
- add `restrict` and `r` as supported HTTP query aliases alongside `restriction`
- add `--restrict` as a CLI alias alongside `-r` and `--restriction`
- update `README.md` and `AGENTS.md` to document restriction aliases and branch naming conventions

## Type of change
- [x] Feature
- [ ] Bug fix
- [ ] Hotfix
- [ ] Spike / exploration
- [ ] Documentation
- [ ] Refactor

## Test plan
- `pnpm test:run`
- `pnpm lint`
- `pnpm typecheck`
