### PR TITLE
feat: add allow-list path matching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ src/core-openapi.d.ts         Ambient type declarations for the `#core-openapi` 
 
 #### CLI mode
 
-1. `src/cli/index.ts` parses CLI arguments and restriction flags (`-r`, `--restrict`, and `--restriction`).
+1. `src/cli/index.ts` parses CLI arguments and access-policy flags (`-r`, `--restrict`, `--restriction`, `-a`, `--allow`, and `--allowed`).
 2. It accepts `--spec` / `-s` to select the bundled core OpenAPI snapshot exposed by `query`.
 3. It sets `globalThis.executionEnvironment = 'cli'`.
 4. It exposes credential lookup helpers on `globalThis` for tools and subcommands.
@@ -88,7 +88,7 @@ src/core-openapi.d.ts         Ambient type declarations for the `#core-openapi` 
 
 1. `src/index.ts` starts the HTTP server and exposes `/mcp` and `/health`.
 2. It sets `globalThis.executionEnvironment = 'server'`.
-3. It extracts auth from request headers and restrictions from `restriction`, `restrict`, and `r` query parameters.
+3. It extracts auth from request headers, restrictions from `restriction`, `restrict`, and `r` query parameters, and allow rules from `allowed`, `allow`, and `a` query parameters.
 4. It stores auth in request-local context and forwards the request to the shared MCP server.
 5. It configures the HTTP transport in POST-only mode (`disableSse: true`) because the optional long-lived GET/SSE channel proved unstable behind Cumulocity microservice ingress.
 
@@ -129,13 +129,17 @@ src/core-openapi.d.ts         Ambient type declarations for the `#core-openapi` 
 
 ### Restrictions
 
-Restrictions are deny rules with the format `[METHOD:]<path-pattern>`.
+Restrictions and allow rules both use the format `[METHOD:]<path-pattern>`.
+
+- Restrictions are deny rules.
+- Allow rules are allow-list entries. When any allow rule exists, requests must match at least one allow rule unless a restriction blocks them first.
+- Restrictions take priority over allow rules.
 
 The restriction system is implemented in two places:
 
 - `src/codemode/openapi-restrictions.ts` annotates blocked OpenAPI operations with `x-mc8yp-*` metadata.
-- `src/utils/restrictions.ts` enforces restriction parsing and query handling.
-- `src/utils/restriction-matcher.ts` owns restriction compilation and path matching.
+- `src/utils/restrictions.ts` parses both deny rules and allow rules and handles CLI/query input.
+- `src/utils/restriction-matcher.ts` owns rule compilation, path matching, and restriction-vs-allow precedence.
 - `src/codemode/network-permissions.ts` enforces secure-exec network decisions for live execute requests.
 
 This dual behavior is intentional: agents can still inspect restricted operations for context, but cannot execute them through the same MCP connection.
@@ -194,7 +198,7 @@ pnpm prerelease    # lint + typecheck + build
 - TypeScript strict mode enabled
 - Node.js `>=24.0.0`
 - Keep the MCP registration surface in `src/server.ts`, `src/tools/`, and `src/prompts/`
-- Keep restriction parsing and query handling logic in `src/utils/restrictions.ts`, and keep restriction compilation/matching logic in `src/utils/restriction-matcher.ts`
+- Keep restriction/allow parsing and query handling logic in `src/utils/restrictions.ts`, and keep rule compilation/matching logic in `src/utils/restriction-matcher.ts`
 - Keep sandbox/runtime behavior in `src/codemode/execute.ts` rather than duplicating execution logic in tools
 - Prefer mode-aware behavior instead of branching deep in unrelated modules
 
@@ -202,16 +206,18 @@ pnpm prerelease    # lint + typecheck + build
 
 - If a change affects tool behavior, inspect both the tool definition and the codemode runtime.
 - If a change affects core OpenAPI selection, update the `#core-openapi` plugin in `tsdown.config.ts` and the ambient declaration in `src/core-openapi.d.ts`.
-- If a change affects restrictions, verify both spec annotation behavior and live request blocking.
+- If a change affects restrictions or allow rules, verify both spec annotation behavior and live request blocking.
 - If a change affects auth, verify the CLI and server paths separately.
 - If a change affects public MCP behavior, update `README.md` as well as this file.
+- Prefer running ESLint autofix (`pnpm lint:fix` or `eslint --fix` on targeted files) before manually fixing simple lint issues by hand.
+- Do not introduce tiny one-line helper/utility functions for trivial logic; inline that logic directly where it is used instead.
 
 ## Testing
 
 - Tests live in `test/`
 - Use `*.test.ts` for tests and `*.bench.ts` for benchmarks
 - Prefer adding targeted tests near the affected behavior:
-  - restriction parsing/matching changes: `test/restriction-core.test.ts` or `test/restrictions.test.ts`
+  - restriction/allow parsing or matching changes: `test/restriction-core.test.ts` or `test/restrictions.test.ts`
   - OpenAPI annotation changes: `test/openapi-restrictions.test.ts`
   - codemode runtime changes: `test/excute.test.ts`
   - concurrency behavior: `test/semaphore.test.ts`
@@ -227,7 +233,7 @@ Run these before finishing meaningful changes:
 When making changes to the project:
 
 - **`AGENTS.md`** — Update with repo-specific architecture, workflows, conventions, and implementation notes for coding agents
-- **`README.md`** — Update for any user-facing MCP behavior changes, new prompts/tools, changed CLI usage, changed restrictions behavior, deployment changes, or credential changes
+- **`README.md`** — Update for any user-facing MCP behavior changes, new prompts/tools, changed CLI usage, changed restriction/allow behavior, deployment changes, or credential changes
 
 ## Agent Guidelines
 
@@ -236,7 +242,7 @@ When working on this project:
 1. Start from the actual controlling surface. For most feature work that is `src/tools/`, `src/prompts/`, `src/codemode/execute.ts`, or restriction/auth utilities.
 2. Treat CLI mode and microservice mode as separate execution environments with different auth and tool availability.
 3. Run focused tests first when changing a narrow subsystem, then run the full validation set if the change is broader.
-4. Do not remove restriction annotations from the OpenAPI view just because execution is blocked; visibility and enforcement are intentionally separate.
+4. Do not remove blocked-operation annotations from the OpenAPI view just because execution is blocked; visibility and enforcement are intentionally separate for both restrictions and allow lists.
 5. Keep public MCP tool and prompt descriptions aligned with actual runtime behavior.
 6. Preserve the current sandbox limits and request boundary logic unless the task explicitly changes them.
 7. Record recurring project-specific lessons in the section below when they are likely to prevent future mistakes.
@@ -264,7 +270,7 @@ This section captures project-specific knowledge, tool quirks, and lessons learn
 - The CLI build inlines all `core-openapi/*.json` snapshots; each server build inlines exactly one.
 - Server builds should not use `noExternal: [/^.*$/]`. The microservice bundle is allowed to depend on runtime `node_modules`, and the release image must install those dependencies inside the Linux image rather than copying host `node_modules` from macOS.
 - `scripts/package-microservices.mjs` intentionally targets `linux/amd64` by default to avoid Apple Silicon release images failing with `exec format error` in Cumulocity.
-- Restrictions are both discoverability metadata and enforcement logic; both layers matter.
+- Restrictions and allow rules are both discoverability metadata and enforcement logic; both layers matter.
 - When creating branches for user-requested work, prefer conventional prefixes that match the intended change type, especially `feat/`, `test/`, and `chore/`.
 - Server-mode auth must stay request-local.
 - For deployed microservice mode, prefer POST-only streamable HTTP over long-lived GET/SSE. The optional SSE channel can go inactive behind Cumulocity ingress and break later tool calls even when initialization and tool discovery succeeded.

--- a/README.md
+++ b/README.md
@@ -154,27 +154,42 @@ async () => {
 
 ### Prompts
 
-| Prompt            | Description                                                                                                                               |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `code-mode-guide` | Full reference for the `query` and `execute` tools, including available types, examples, and restriction info for the current connection. |
+| Prompt            | Description                                                                                                                                 |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `code-mode-guide` | Full reference for the `query` and `execute` tools, including available types, examples, and access-policy info for the current connection. |
 
-## API Restrictions
+## API Access Policy
 
-Restrictions are deny rules that block specific API operations. They can be applied per-connection to limit what an AI agent can access.
+mc8yp supports two per-connection rule types:
+
+- **Restrictions** — deny rules that block matching API operations
+- **Allow rules** — allow-list rules that permit matching API operations and block everything else when at least one allow rule is configured
+
+If both apply to the same operation, **restrictions take priority**.
+
+Example: allowing `/inventory/**` but restricting `/inventory/managedObjects` still blocks `/inventory/managedObjects`.
+
+Both rule types use the same syntax.
+
+### Restrictions
+
+Restrictions are deny rules that block specific API operations.
+
+### Allow Rules
+
+Allow rules are the inverse of restrictions. They define what is permitted. When one or more allow rules are configured, any operation that does not match at least one allow rule is blocked.
 
 ### Rule Format
 
-A restriction can be written in either of these forms:
+A restriction or allow rule can be written in either of these forms:
 
 ```txt
 <path-pattern>
 <method>:<path-pattern>
 ```
 
-A restriction is always a deny rule.
-
-- **Without a method prefix** — blocks all HTTP methods for matching paths
-- **With a method prefix** — blocks only that method (for example `GET:`, `DELETE:`, `POST:`)
+- **Without a method prefix** — matches all HTTP methods for matching paths
+- **With a method prefix** — matches only that method (for example `GET:`, `DELETE:`, `POST:`)
 - **The `:` separator is only present when a method prefix is provided**
 - **Supported methods** — `DELETE`, `GET`, `HEAD`, `OPTIONS`, `PATCH`, `POST`, `PUT`, `TRACE`, or `*`
 - Method names are case-insensitive when parsed (`get:/inventory/**` becomes `GET:/inventory/**`)
@@ -183,7 +198,7 @@ A restriction is always a deny rule.
 
 Patterns are matched against the request **pathname**.
 
-- Query strings and fragments are **not allowed in restriction patterns**
+- Query strings and fragments are **not allowed in rule patterns**
 - Incoming request query strings are ignored for matching, so `/inventory/**` also matches requests such as `/inventory?pageSize=5`
 - Patterns must start with `/`
 - Matching is path-segment aware: `/` separates segments
@@ -207,26 +222,28 @@ Supported wildcards:
 
 ### Common Rule Examples
 
-| Rule                             | Effect                                                       |
-| -------------------------------- | ------------------------------------------------------------ |
-| `/inventory/**`                  | Block all methods on `/inventory` and everything below it    |
-| `DELETE:/inventory/**`           | Block only DELETE on `/inventory` and everything below it    |
-| `/alarm/alarms`                  | Block all methods on the exact path `/alarm/alarms`          |
-| `GET:/measurement/measurements`  | Block only GET on the exact path `/measurement/measurements` |
-| `POST:/inventory/managedObjects` | Block creating new managed objects                           |
-| `/i*/**`                         | Block all routes whose first path segment starts with `i`    |
-| `/user/**`                       | Block all user management paths                              |
+| Rule                             | Restriction Effect                                           | Allow-list Effect                                             |
+| -------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------- |
+| `/inventory/**`                  | Block all methods on `/inventory` and everything below it    | Permit all methods on `/inventory` and everything below it    |
+| `DELETE:/inventory/**`           | Block only DELETE on `/inventory` and everything below it    | Permit only DELETE on `/inventory` and everything below it    |
+| `/alarm/alarms`                  | Block all methods on the exact path `/alarm/alarms`          | Permit all methods on the exact path `/alarm/alarms`          |
+| `GET:/measurement/measurements`  | Block only GET on the exact path `/measurement/measurements` | Permit only GET on the exact path `/measurement/measurements` |
+| `POST:/inventory/managedObjects` | Block creating new managed objects                           | Permit creating new managed objects                           |
+| `/i*/**`                         | Block all routes whose first path segment starts with `i`    | Permit all routes whose first path segment starts with `i`    |
+| `/user/**`                       | Block all user management paths                              | Permit all user management paths                              |
 
 ### Important Notes
 
 - `/inventory/**` already matches `/inventory` itself, so you do **not** need both `/inventory` and `/inventory/**`
 - `/i**` is **not valid** because `**` must be its own segment. Use `/i*/**` if you want to match a first segment starting with `i` and everything below it
 - `*:/inventory/**` is allowed and means the same thing as `/inventory/**`
-- Restriction patterns may not contain empty segments (`//`), `.` or `..` segments, query strings, or fragments
+- Rule patterns may not contain empty segments (`//`), `.` or `..` segments, query strings, or fragments
 
 ### CLI Mode
 
-Pass restrictions as CLI arguments. Repeat `-r`, `--restrict`, or `--restriction` for multiple rules:
+Pass restrictions and allow rules as CLI arguments.
+
+Repeat `-r`, `--restrict`, or `--restriction` for deny rules:
 
 ```sh
 # Block all inventory access
@@ -242,24 +259,40 @@ mc8yp --restriction "/user/**"
 mc8yp --restrict "/user/**"
 ```
 
+Repeat `-a`, `--allow`, or `--allowed` for allow rules:
+
+```sh
+# Only permit inventory access
+mc8yp -a "/inventory/**"
+
+# Permit GET inventory access and POST alarms
+mc8yp --allow "GET:/inventory/**" --allowed "POST:/alarm/**"
+
+# Allow inventory broadly, but still block one path with a restriction
+mc8yp -a "/inventory/**" -r "/inventory/managedObjects"
+```
+
 ### Microservice Mode (HTTP)
 
-Pass restrictions as `restriction`, `restrict`, or `r` query parameters on the MCP endpoint URL:
+Pass restrictions as `restriction`, `restrict`, or `r` query parameters on the MCP endpoint URL.
+Pass allow rules as `allowed`, `allow`, or `a` query parameters.
 
 ```
 /mcp?restriction=/inventory/**&restrict=DELETE:/alarm/**
 /mcp?r=/inventory/**&r=DELETE:/alarm/**
+/mcp?allow=/inventory/**&allowed=POST:/alarm/**
+/mcp?a=/inventory/**&r=/inventory/managedObjects
 ```
 
-### How Restrictions Work
+### How Access Policy Works
 
-1. **OpenAPI spec annotation**: The `query` tool annotates blocked operations in the spec with `x-mc8yp-restricted` and related `x-mc8yp-*` metadata fields. The operations remain visible so the agent understands what exists, but they are clearly marked as blocked.
+1. **OpenAPI spec annotation**: The `query` tool annotates blocked operations in the spec with `x-mc8yp-restricted` and related `x-mc8yp-*` metadata fields. The operations remain visible so the agent understands what exists, but they are clearly marked as blocked. This includes both deny-rule matches and operations outside a configured allow list.
 
-2. **Sandbox request enforcement**: The `execute` tool checks restrictions inside the generated sandbox request helper, where the actual HTTP method and normalized path are both available. Matching requests are blocked before any `fetch` is attempted.
+2. **Sandbox request enforcement**: The `execute` tool checks restrictions and allow rules inside the generated sandbox request helper, where the actual HTTP method and normalized path are both available. Matching deny rules block first. If any allow rules are configured, requests must also match at least one allow rule.
 
 3. **Network boundary**: The secure-exec permission layer independently restricts network access to the configured tenant host. Other network operations are denied.
 
-When an `execute` request is blocked by MCP restrictions, the tool returns explanatory text stating that the operation was intentionally denied by MCP connection policy, no request was sent to Cumulocity, and retrying through the same connection will not help.
+When an `execute` request is blocked by MCP connection policy, the tool returns explanatory text stating that the operation was intentionally denied or not allow-listed, no request was sent to Cumulocity, and retrying through the same connection will not help.
 
 ## Build And Packaging
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,7 +5,7 @@ import pkgjson from '../../package.json' with { type: 'json' }
 import { getCoreOpenApiLabel, getCoreOpenApiVersion, setCoreOpenApiVersion, specs } from '#core-openapi'
 import { createC8YMcpServer } from '../server'
 import { getCredentialsByTenantUrl, getStoredC8yAuth } from '../utils/credentials'
-import { parseRestrictionRule } from '../utils/restrictions'
+import { parseAllowRule, parseRestrictionRule } from '../utils/restrictions'
 
 const main = defineCommand({
   meta: {
@@ -18,6 +18,11 @@ const main = defineCommand({
       type: 'string',
       description: 'Restriction rule to deny API access (e.g. "GET:/inventory/**"). Can be repeated.',
       alias: ['r', 'restrict'],
+    },
+    allowed: {
+      type: 'string',
+      description: 'Allow rule to permit API access (e.g. "GET:/inventory/**"). Can be repeated. When present, non-matching operations are blocked unless another allow rule matches them.',
+      alias: ['a', 'allow'],
     },
     spec: {
       type: 'string',
@@ -45,16 +50,29 @@ const main = defineCommand({
     setCoreOpenApiVersion(selected.version)
     consola.info(`Using core OpenAPI snapshot: ${getCoreOpenApiLabel()}`)
 
-    const raw = args.restriction
-    const restrictionSources = (Array.isArray(raw) ? raw : raw ? [raw] : []).filter(
+    const rawRestrictions = args.restriction
+    const restrictionSources = (Array.isArray(rawRestrictions) ? rawRestrictions : rawRestrictions ? [rawRestrictions] : []).filter(
       (value): value is string => typeof value === 'string' && value.length > 0,
     )
-    const { parsedRules: restrictions, failedRules } = parseRestrictionRule(restrictionSources)
+    const { parsedRules: restrictions, failedRules: failedRestrictions } = parseRestrictionRule(restrictionSources)
 
-    if (failedRules.length > 0) {
+    if (failedRestrictions.length > 0) {
       throw new Error([
         'One or more restriction flags could not be parsed:',
-        ...failedRules.map((rule) => `- ${rule.rule}: ${rule.reason}`),
+        ...failedRestrictions.map((rule) => `- ${rule.rule}: ${rule.reason}`),
+      ].join('\n'))
+    }
+
+    const rawAllowed = args.allowed
+    const allowSources = (Array.isArray(rawAllowed) ? rawAllowed : rawAllowed ? [rawAllowed] : []).filter(
+      (value): value is string => typeof value === 'string' && value.length > 0,
+    )
+    const { parsedRules: allowRules, failedRules: failedAllowRules } = parseAllowRule(allowSources)
+
+    if (failedAllowRules.length > 0) {
+      throw new Error([
+        'One or more allow flags could not be parsed:',
+        ...failedAllowRules.map((rule) => `- ${rule.rule}: ${rule.reason}`),
       ].join('\n'))
     }
 
@@ -62,12 +80,16 @@ const main = defineCommand({
       consola.info(`Applying ${restrictions.length} restriction rule(s):`, restrictions.map((r) => r.source))
     }
 
+    if (allowRules.length > 0) {
+      consola.info(`Applying ${allowRules.length} allow rule(s):`, allowRules.map((rule) => rule.source))
+    }
+
     const server = createC8YMcpServer()
 
     // Start the server with stdio transport
     const transport = new StdioTransport(server)
     consola.info('Starting MCP server over stdio transport...')
-    transport.listen({ restrictions })
+    transport.listen({ restrictions, allowRules })
   },
 })
 

--- a/src/codemode/execute.ts
+++ b/src/codemode/execute.ts
@@ -13,7 +13,7 @@ import {
   matchesCompiledRule,
 } from '../utils/restriction-matcher'
 import { HTTP_METHODS } from '../utils/restrictions'
-import type { RestrictionRule } from '../utils/restrictions'
+import type { AllowRule, RestrictionRule } from '../utils/restrictions'
 
 const NO_DEFAULT_EXPORT_MESSAGE = 'Execution completed without returning a value.'
 const QUERY_ENTRY_PATH = '/codemode-query.mjs'
@@ -35,14 +35,21 @@ interface ExecuteErrorEnvelope {
 
 type ExecuteEnvelope = ExecuteSuccessEnvelope | ExecuteErrorEnvelope
 
-function serializeExecuteConfig(tenantUrl: string, headers: Record<string, string>, restrictions: readonly RestrictionRule[]): string {
+function serializeExecuteConfig(
+  tenantUrl: string,
+  headers: Record<string, string>,
+  restrictions: readonly RestrictionRule[],
+  allowRules: readonly AllowRule[],
+): string {
   const normalizedTenantUrl = new URL(tenantUrl).toString()
-  const serializedRestrictions = restrictions.map(({ method, pathPattern, source }) => ({ method, pathPattern, source }))
+  const serializedRestrictions = restrictions.map(({ type, method, pathPattern, source }) => ({ type, method, pathPattern, source }))
+  const serializedAllowRules = allowRules.map(({ type, method, pathPattern, source }) => ({ type, method, pathPattern, source }))
 
   return JSON.stringify({
     tenantUrl: normalizedTenantUrl,
     authHeaders: headers,
     restrictions: serializedRestrictions,
+    allowRules: serializedAllowRules,
   })
 }
 
@@ -60,12 +67,16 @@ function createQueryRuntime() {
   })
 }
 
-function createExecuteRuntime(tenantUrl: string, restrictions: readonly RestrictionRule[]) {
+function createExecuteRuntime(
+  tenantUrl: string,
+  restrictions: readonly RestrictionRule[],
+  allowRules: readonly AllowRule[],
+) {
   return new NodeRuntime({
     systemDriver: createNodeDriver({
       useDefaultNetwork: true,
       permissions: {
-        network: (request) => createNetworkPermissionDecision(tenantUrl, request, restrictions),
+        network: (request) => createNetworkPermissionDecision(tenantUrl, request, restrictions, allowRules),
       },
     }),
     runtimeDriverFactory: createNodeRuntimeDriverFactory(),
@@ -85,8 +96,16 @@ function normalizeCode(functionCode: string): string {
   return normalized
 }
 
-function buildQueryScript(sourceCode: string, restrictions: readonly RestrictionRule[]): string {
-  const restrictedSpec = applyRestrictionsToOpenApiSpec(getCoreOpenApiSpec() as Parameters<typeof applyRestrictionsToOpenApiSpec>[0], restrictions)
+function buildQueryScript(
+  sourceCode: string,
+  restrictions: readonly RestrictionRule[],
+  allowRules: readonly AllowRule[],
+): string {
+  const restrictedSpec = applyRestrictionsToOpenApiSpec(
+    getCoreOpenApiSpec() as Parameters<typeof applyRestrictionsToOpenApiSpec>[0],
+    restrictions,
+    allowRules,
+  )
   const functionExpression = normalizeCode(sourceCode)
 
   return [
@@ -101,8 +120,13 @@ function buildQueryScript(sourceCode: string, restrictions: readonly Restriction
   ].join('\n\n')
 }
 
-export function buildExecutePrelude(tenantUrl: string, headers: Record<string, string>, restrictions: readonly RestrictionRule[] = []): string {
-  const serializedConfig = JSON.stringify(serializeExecuteConfig(tenantUrl, headers, restrictions))
+export function buildExecutePrelude(
+  tenantUrl: string,
+  headers: Record<string, string>,
+  restrictions: readonly RestrictionRule[] = [],
+  allowRules: readonly AllowRule[] = [],
+): string {
+  const serializedConfig = JSON.stringify(serializeExecuteConfig(tenantUrl, headers, restrictions, allowRules))
 
   return [
     'const cumulocity = Object.freeze((() => {',
@@ -110,12 +134,15 @@ export function buildExecutePrelude(tenantUrl: string, headers: Record<string, s
     '  if (!config || typeof config !== "object") {',
     '    throw new TypeError("Invalid execute configuration.");',
     '  }',
-    '  const { tenantUrl, authHeaders, restrictions } = config;',
+    '  const { tenantUrl, authHeaders, restrictions, allowRules } = config;',
     '  if (typeof tenantUrl !== "string") {',
     '    throw new TypeError("Execute configuration must contain a string tenant URL.");',
     '  }',
-    '  if (!Array.isArray(restrictions) || restrictions.some((rule) => !rule || typeof rule !== "object" || typeof rule.method !== "string" || typeof rule.pathPattern !== "string" || typeof rule.source !== "string")) {',
+    '  if (!Array.isArray(restrictions) || restrictions.some((rule) => !rule || typeof rule !== "object" || typeof rule.type !== "string" || typeof rule.method !== "string" || typeof rule.pathPattern !== "string" || typeof rule.source !== "string")) {',
     '    throw new TypeError("Execute configuration must contain valid restriction rules.");',
+    '  }',
+    '  if (!Array.isArray(allowRules) || allowRules.some((rule) => !rule || typeof rule !== "object" || typeof rule.type !== "string" || typeof rule.method !== "string" || typeof rule.pathPattern !== "string" || typeof rule.source !== "string")) {',
+    '    throw new TypeError("Execute configuration must contain valid allow rules.");',
     '  }',
     '  const resolveUrl = (descriptor) => {',
     '    return new URL(descriptor, tenantUrl.endsWith("/") ? tenantUrl : tenantUrl + "/");',
@@ -135,15 +162,30 @@ export function buildExecutePrelude(tenantUrl: string, headers: Record<string, s
     `  const compileRestrictionRule = ${compileRestrictionRule.toString()};`,
     `  const matchesCompiledRule = ${matchesCompiledRule.toString()};`,
     '  const compiledRestrictions = restrictions.map(compileRestrictionRule);',
-    '  const findBlockingRestrictions = (method, pathname) => {',
+    '  const compiledAllowRules = allowRules.map(compileRestrictionRule);',
+    '  const findMatchingRules = (compiledRules, method, pathname) => {',
     '    const normalizedMethod = typeof method === "string" ? method.trim().toUpperCase() : "";',
     '    const pathSegments = pathname === "/" ? [] : pathname.slice(1).split("/");',
-    '    return compiledRestrictions.filter((rule) => {',
+    '    return compiledRules.filter((rule) => {',
     '      if (!normalizedMethod) {',
     '        return rule.method === "*" && matchCompiledSegments(rule.segments, pathSegments);',
     '      }',
     '      return matchesCompiledRule(rule, normalizedMethod, pathSegments);',
     '    });',
+    '  };',
+    '  const evaluateAccessPolicy = (method, pathname) => {',
+    '    const matchingRestrictions = findMatchingRules(compiledRestrictions, method, pathname);',
+    '    if (matchingRestrictions.length > 0) {',
+    '      return { blocked: true, blockedBy: "restriction", matchingRestrictions };',
+    '    }',
+    '    if (compiledAllowRules.length === 0) {',
+    '      return { blocked: false };',
+    '    }',
+    '    const matchingAllowRules = findMatchingRules(compiledAllowRules, method, pathname);',
+    '    if (matchingAllowRules.length > 0) {',
+    '      return { blocked: false };',
+    '    }',
+    '    return { blocked: true, blockedBy: "allow" };',
     '  };',
     '  const validateRequestMethod = (method) => {',
     '    if (typeof method !== "string" || method.trim().length === 0) {',
@@ -155,22 +197,42 @@ export function buildExecutePrelude(tenantUrl: string, headers: Record<string, s
     '    }',
     '    return normalizedMethod;',
     '  };',
-    '  const formatBlockedRequestMessage = (method, path, matchingRules) => [',
-    '    "Request blocked by MCP connection policy.",',
-    '    "",',
-    '    "This operation is intentionally denied by the current MCP connection configuration.",',
-    '    "It did not fail at the Cumulocity API and it was not executed against the tenant.",',
-    '    "Retrying or trying the same operation again through this connection will not succeed.",',
-    '    "",',
-    '    "Report this to the user as a connection-level access restriction.",',
-    '    "If the operation is needed, the MCP restrictions for this connection must be updated by whoever manages that configuration.",',
-    '    "",',
-    '    "Blocked operation:",',
-    '    "Method: " + method,',
-    '    "Path: " + path,',
-    '    "Matching restrictions:",',
-    '    ...matchingRules.map((rule) => "- " + rule),',
-    '  ].join("\\n");',
+    '  const formatBlockedRequestMessage = (method, path, accessDecision) => {',
+    '    if (accessDecision.blockedBy === "allow") {',
+    '      return [',
+    '        "Request blocked by MCP connection policy.",',
+    '        "",',
+    '        "This operation is intentionally blocked because it is not included in the current MCP connection allow list.",',
+    '        "It did not fail at the Cumulocity API and it was not executed against the tenant.",',
+    '        "Retrying or trying the same operation again through this connection will not succeed.",',
+    '        "",',
+    '        "Report this to the user as a connection-level access restriction.",',
+    '        "If the operation is needed, the MCP allow list for this connection must be updated by whoever manages that configuration.",',
+    '        "",',
+    '        "Blocked operation:",',
+    '        "Method: " + method,',
+    '        "Path: " + path,',
+    '        "Configured allow rules:",',
+    '        ...(allowRules.length > 0 ? allowRules.map((rule) => "- " + rule.source) : ["- (none)"]),',
+    '      ].join("\\n");',
+    '    }',
+    '    return [',
+    '      "Request blocked by MCP connection policy.",',
+    '      "",',
+    '      "This operation is intentionally denied by the current MCP connection configuration.",',
+    '      "It did not fail at the Cumulocity API and it was not executed against the tenant.",',
+    '      "Retrying or trying the same operation again through this connection will not succeed.",',
+    '      "",',
+    '      "Report this to the user as a connection-level access restriction.",',
+    '      "If the operation is needed, the MCP restrictions for this connection must be updated by whoever manages that configuration.",',
+    '      "",',
+    '      "Blocked operation:",',
+    '      "Method: " + method,',
+    '      "Path: " + path,',
+    '      "Matching restrictions:",',
+    '      ...accessDecision.matchingRestrictions.map((rule) => "- " + rule.source),',
+    '    ].join("\\n");',
+    '  };',
     '  const normalizeBody = (headers, body) => {',
     '    if (body == null || typeof body === "string") {',
     '      return body;',
@@ -202,9 +264,9 @@ export function buildExecutePrelude(tenantUrl: string, headers: Record<string, s
     '      }',
     '      const method = validateRequestMethod(init.method);',
     '      const resolvedUrl = resolveUrl(path);',
-    '      const blockedRules = findBlockingRestrictions(method, resolvedUrl.pathname);',
-    '      if (blockedRules.length > 0) {',
-    '        throw new Error(formatBlockedRequestMessage(method, resolvedUrl.pathname, blockedRules.map((rule) => rule.source)));',
+    '      const accessDecision = evaluateAccessPolicy(method, resolvedUrl.pathname);',
+    '      if (accessDecision.blocked) {',
+    '        throw new Error(formatBlockedRequestMessage(method, resolvedUrl.pathname, accessDecision));',
     '      }',
     '      const headers = new Headers(init.headers ?? {});',
     '      for (const [key, value] of Object.entries(authHeaders)) {',
@@ -235,11 +297,12 @@ export function buildExecuteScript(
   tenantUrl: string,
   headers: Record<string, string>,
   restrictions: readonly RestrictionRule[] = [],
+  allowRules: readonly AllowRule[] = [],
 ): string {
   const functionExpression = normalizeCode(sourceCode)
 
   return [
-    buildExecutePrelude(tenantUrl, headers, restrictions),
+    buildExecutePrelude(tenantUrl, headers, restrictions, allowRules),
     `const __mc8ypExecute = (${functionExpression});`,
     '',
     'const __mc8ypErrorMessage = (error) => error instanceof Error ? error.message : String(error);',
@@ -281,9 +344,14 @@ function extractDefaultExport(exportsObject: unknown): unknown {
   throw new Error(NO_DEFAULT_EXPORT_MESSAGE)
 }
 
-async function runExecuteScript(code: string, tenantUrl: string, restrictions: readonly RestrictionRule[]): Promise<unknown> {
+async function runExecuteScript(
+  code: string,
+  tenantUrl: string,
+  restrictions: readonly RestrictionRule[],
+  allowRules: readonly AllowRule[],
+): Promise<unknown> {
   const release = await runtimeSemaphore.acquire()
-  const runtime = createExecuteRuntime(tenantUrl, restrictions)
+  const runtime = createExecuteRuntime(tenantUrl, restrictions, allowRules)
 
   try {
     const result = await runtime.run<unknown>(code, EXECUTE_ENTRY_PATH)
@@ -322,17 +390,31 @@ async function runModule(code: string, entryPath: string, runtime: NodeRuntime):
   }
 }
 
-export async function query(functionCode: string, restrictions: readonly RestrictionRule[] = []): Promise<string> {
-  const result = await runQueryScript(buildQueryScript(functionCode, restrictions))
+export async function query(
+  functionCode: string,
+  restrictions: readonly RestrictionRule[] = [],
+  allowRules: readonly AllowRule[] = [],
+): Promise<string> {
+  const result = await runQueryScript(buildQueryScript(functionCode, restrictions, allowRules))
   // dont encode as toon to make spec easier to understand
   return typeof result === 'string' ? result : JSON.stringify(result)
 }
 
-export async function execute(functionCode: string, input?: unknown, restrictions: readonly RestrictionRule[] = []): Promise<string> {
+export async function execute(
+  functionCode: string,
+  input?: unknown,
+  restrictions: readonly RestrictionRule[] = [],
+  allowRules: readonly AllowRule[] = [],
+): Promise<string> {
   const auth = await resolveC8yAuth(input)
   const authHeaders = createC8yAuthHeaders(auth)
 
-  const result = await runExecuteScript(buildExecuteScript(functionCode, auth.tenantUrl, authHeaders, restrictions), auth.tenantUrl, restrictions) as ExecuteEnvelope
+  const result = await runExecuteScript(
+    buildExecuteScript(functionCode, auth.tenantUrl, authHeaders, restrictions, allowRules),
+    auth.tenantUrl,
+    restrictions,
+    allowRules,
+  ) as ExecuteEnvelope
 
   if (result.status === 'success') {
     return encode(result.result)

--- a/src/codemode/network-permissions.ts
+++ b/src/codemode/network-permissions.ts
@@ -1,6 +1,6 @@
 import type { createNodeDriver } from 'secure-exec'
-import { findBlockingRestrictions } from '../utils/restriction-matcher'
-import type { RestrictionRule } from '../utils/restrictions'
+import { evaluateAccessPolicy, findBlockingRestrictions } from '../utils/restriction-matcher'
+import type { AllowRule, RestrictionRule } from '../utils/restrictions'
 
 type NetworkPermissionDecider = NonNullable<NonNullable<NonNullable<Parameters<typeof createNodeDriver>[0]>['permissions']>['network']>
 
@@ -11,7 +11,8 @@ type NetworkPermissionDecision = ReturnType<NetworkPermissionDecider>
 export function createNetworkPermissionDecision(
   tenantUrl: string,
   request: NetworkPermissionRequest,
-  rules: readonly RestrictionRule[] = [],
+  restrictions: readonly RestrictionRule[] = [],
+  allowRules: readonly AllowRule[] = [],
 ): NetworkPermissionDecision {
   const tenantHostname = new URL(tenantUrl).hostname
 
@@ -27,12 +28,32 @@ export function createNetworkPermissionDecision(
   }
 
   if (typeof request.url === 'string') {
+    const pathname = new URL(request.url).pathname
     const requestMethod = typeof request.method === 'string' ? request.method.trim() : undefined
-    const blockingRules = findBlockingRestrictions(rules, requestMethod, new URL(request.url).pathname)
-    if (blockingRules.length > 0) {
-      return {
-        allow: false,
-        reason: `Network connect blocked by MCP restrictions: ${blockingRules.map((rule) => rule.source).join(', ')}`,
+    const normalizedMethod = requestMethod?.toUpperCase() ?? ''
+
+    if (normalizedMethod) {
+      const decision = evaluateAccessPolicy(restrictions, allowRules, normalizedMethod, pathname)
+      if (decision.blocked) {
+        if (decision.blockedBy === 'restriction') {
+          return {
+            allow: false,
+            reason: `Network connect blocked by MCP restrictions: ${decision.matchingRestrictions.map((rule) => rule.source).join(', ')}`,
+          }
+        }
+
+        return {
+          allow: false,
+          reason: `Network connect blocked by MCP allow list: no allow rule matched ${normalizedMethod} ${pathname}. Configured allow rules: ${allowRules.map((rule) => rule.source).join(', ')}`,
+        }
+      }
+    } else {
+      const blockingRules = findBlockingRestrictions(restrictions, requestMethod, pathname)
+      if (blockingRules.length > 0) {
+        return {
+          allow: false,
+          reason: `Network connect blocked by MCP restrictions: ${blockingRules.map((rule) => rule.source).join(', ')}`,
+        }
       }
     }
   }

--- a/src/codemode/openapi-restrictions.ts
+++ b/src/codemode/openapi-restrictions.ts
@@ -8,9 +8,10 @@ import {
 } from '../utils/restrictions'
 import {
   compileRestrictionRule,
+  evaluateAccessPolicy,
   matchesCompiledRule,
 } from '../utils/restriction-matcher'
-import type { RestrictionRule } from '../utils/restrictions'
+import type { AllowRule, RestrictionRule } from '../utils/restrictions'
 
 const OPENAPI_OPERATION_METHODS = ['delete', 'get', 'head', 'options', 'patch', 'post', 'put', 'trace'] as const
 
@@ -19,23 +20,28 @@ type OpenApiPathItem = Record<string, unknown>
 type OpenApiPaths = Record<string, OpenApiPathItem>
 type OpenApiSpec = Record<string, unknown> & { paths?: OpenApiPaths }
 
-function annotateRestrictedOperation(operation: OpenApiOperation, matchingRules: readonly RestrictionRule[]): OpenApiOperation {
+function annotateBlockedOperation(operation: OpenApiOperation, ruleSources: readonly string[]): OpenApiOperation {
   return {
     ...operation,
     [RESTRICTED_OPERATION_FLAG]: true,
     [RESTRICTED_OPERATION_TYPE]: 'deny',
-    [RESTRICTED_OPERATION_RULES]: matchingRules.map((rule) => rule.source),
-    [RESTRICTED_OPERATION_MESSAGE]: 'This operation is blocked by the current MCP connection restrictions.',
-    [RESTRICTED_AGENT_NOTE]: 'The route exists, but it is intentionally restricted for this MCP connection.',
+    [RESTRICTED_OPERATION_RULES]: [...ruleSources],
+    [RESTRICTED_OPERATION_MESSAGE]: 'This operation is blocked by the current MCP connection policy.',
+    [RESTRICTED_AGENT_NOTE]: 'The route exists, but it is intentionally unavailable for this MCP connection.',
   }
 }
 
-export function applyRestrictionsToOpenApiSpec<TSpec extends OpenApiSpec>(spec: TSpec, rules: readonly RestrictionRule[]): TSpec {
-  if (!spec.paths || rules.length === 0) {
+export function applyRestrictionsToOpenApiSpec<TSpec extends OpenApiSpec>(
+  spec: TSpec,
+  restrictions: readonly RestrictionRule[],
+  allowRules: readonly AllowRule[] = [],
+): TSpec {
+  if (!spec.paths || (restrictions.length === 0 && allowRules.length === 0)) {
     return spec
   }
 
-  const compiledRules = rules.map(compileRestrictionRule)
+  const compiledRestrictions = restrictions.map(compileRestrictionRule)
+  const compiledAllowRules = allowRules.map(compileRestrictionRule)
   let nextPaths: OpenApiPaths | undefined
 
   for (const [path, pathItem] of Object.entries(spec.paths)) {
@@ -48,13 +54,19 @@ export function applyRestrictionsToOpenApiSpec<TSpec extends OpenApiSpec>(spec: 
         continue
       }
 
-      const matchingRules = compiledRules.filter((rule) => matchesCompiledRule(rule, method.toUpperCase(), pathSegments))
-      if (matchingRules.length === 0) {
+      const decision = evaluateAccessPolicy(restrictions, allowRules, method.toUpperCase(), path)
+      if (!decision.blocked) {
         continue
       }
 
+      const restrictionMatches = compiledRestrictions.filter((rule) => matchesCompiledRule(rule, method.toUpperCase(), pathSegments))
+      const allowMatches = compiledAllowRules.filter((rule) => matchesCompiledRule(rule, method.toUpperCase(), pathSegments))
+      const ruleSources = decision.blockedBy === 'restriction'
+        ? (restrictionMatches.length > 0 ? restrictionMatches : decision.matchingRestrictions).map((rule) => rule.source)
+        : (allowMatches.length > 0 ? allowMatches : allowRules).map((rule) => rule.source)
+
       nextPathItem ??= { ...pathItem }
-      nextPathItem[method] = annotateRestrictedOperation(operation as OpenApiOperation, matchingRules)
+      nextPathItem[method] = annotateBlockedOperation(operation as OpenApiOperation, ruleSources)
     }
 
     if (nextPathItem) {
@@ -68,7 +80,8 @@ export function applyRestrictionsToOpenApiSpec<TSpec extends OpenApiSpec>(spec: 
     paths: nextPaths ?? spec.paths,
     [RESTRICTION_EXTENSION_KEY]: {
       mode: 'deny',
-      rules: rules.map((rule) => rule.source),
+      restrictions: restrictions.map((rule) => rule.source),
+      allowed: allowRules.map((rule) => rule.source),
       message: 'Operations marked with x-mc8yp-restricted are intentionally blocked for the current MCP connection.',
     },
   } as TSpec

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { createC8YMcpServer } from './server'
 import { getAuthContext } from './ctx/auth'
 import process from 'node:process'
 import { extractAuthFromHeaders } from './utils/auth'
-import { parseRestrictionRule } from './utils/restrictions'
+import { parseAllowRule, parseRestrictionRule } from './utils/restrictions'
 
 globalThis.executionEnvironment = 'server'
 
@@ -23,22 +23,38 @@ const app = new H3().all('/mcp', async (event) => {
   const restrictionSources = [query.restriction, query.restrict, query.r].flatMap((value) => Array.isArray(value) ? value : [value]).filter(
     (value): value is string => typeof value === 'string' && value.length > 0,
   )
-  const { parsedRules, failedRules } = parseRestrictionRule(restrictionSources)
+  const { parsedRules: restrictions, failedRules: failedRestrictions } = parseRestrictionRule(restrictionSources)
 
-  if (failedRules.length > 0) {
+  if (failedRestrictions.length > 0) {
     throw new HTTPError({
       status: 400,
       statusText: 'Invalid restriction query',
       message: 'One or more restriction query parameters (?restriction, ?restrict, ?r) could not be parsed.',
       data: {
-        failedRules,
+        failedRules: failedRestrictions,
+      },
+    })
+  }
+
+  const allowSources = [query.allowed, query.allow, query.a].flatMap((value) => Array.isArray(value) ? value : [value]).filter(
+    (value): value is string => typeof value === 'string' && value.length > 0,
+  )
+  const { parsedRules: allowRules, failedRules: failedAllowRules } = parseAllowRule(allowSources)
+
+  if (failedAllowRules.length > 0) {
+    throw new HTTPError({
+      status: 400,
+      statusText: 'Invalid allow query',
+      message: 'One or more allow query parameters (?allowed, ?allow, ?a) could not be parsed.',
+      data: {
+        failedRules: failedAllowRules,
       },
     })
   }
 
   // Set auth context for the request
   const authContext = getAuthContext()
-  return authContext.call(credentials, () => transport.respond(event.req, { restrictions: parsedRules }))
+  return authContext.call(credentials, () => transport.respond(event.req, { restrictions, allowRules }))
 })
 
 app.get('/health', () => 'OK')

--- a/src/prompts/codemode.ts
+++ b/src/prompts/codemode.ts
@@ -20,8 +20,13 @@ export function createCodeModeGuidePrompt(server: McpServer<undefined, C8yMcpCus
     description: 'Guide for the two code-mode tools: query and execute, including available shapes and examples.',
   }, () => {
     const restrictions = server.ctx.custom?.restrictions ?? []
-    const restrictionSection = restrictions.length > 0
-      ? `\n## Current Connection Restrictions\nThe current MCP connection blocks matching operations using these deny rules:\n${restrictions.map((rule) => `- \`${rule.source}\``).join('\n')}\n\nRestricted operations stay visible in the spec and are annotated with \`x-mc8yp-restricted\` and related \`x-mc8yp-*\` fields.\n`
+    const allowRules = server.ctx.custom?.allowRules ?? []
+    const policyLines = [
+      ...restrictions.map((rule) => `- deny: \`${rule.source}\``),
+      ...allowRules.map((rule) => `- allow: \`${rule.source}\``),
+    ]
+    const restrictionSection = policyLines.length > 0
+      ? `\n## Current Connection Access Policy\n${policyLines.join('\n')}\n\nBlocked operations stay visible in the spec and are annotated with \`x-mc8yp-restricted\` and related \`x-mc8yp-*\` fields.\n`
       : ''
 
     return prompt.message(
@@ -37,7 +42,7 @@ Use \`query\` when you need to inspect the core OpenAPI spec.
 - Return the exact value you want back from that function
 - Sync and async functions are both supported
 - Strings are returned as-is; other results are returned as JSON text
-- Restricted operations stay visible and are annotated with \`x-mc8yp-restricted\` and related \`x-mc8yp-*\` fields
+- Blocked operations stay visible and are annotated with \`x-mc8yp-restricted\` and related \`x-mc8yp-*\` fields
 - Treat operations marked with \`x-mc8yp-restricted\` as intentionally unavailable on this MCP connection; inspect them for context, but do not plan to execute them
 
 ### Available Shape
@@ -86,8 +91,8 @@ Use \`execute\` when you want to call the real Cumulocity API.
 - Return the value you want from that function; async functions are usually the right choice here
 - On success, the returned value is sent back in Toon format
 - If execution is blocked or fails, execute returns a plain text error message
-- The current MCP connection may reject restricted method/path combinations before network access
-- If a request is blocked by MCP connection policy, \`execute\` returns an explanatory text message. That is an intentional connection-level restriction, not a Cumulocity API failure, and retrying through the same connection will not help
+- The current MCP connection may reject restricted method/path combinations before network access, and it may also reject requests that are outside a configured allow list
+- If a request is blocked by MCP connection policy, \`execute\` returns an explanatory text message. That is an intentional connection-level access restriction, not a Cumulocity API failure, and retrying through the same connection will not help
 
 ### Available Shape
 \`\`\`ts

--- a/src/tools/codemode.ts
+++ b/src/tools/codemode.ts
@@ -70,7 +70,7 @@ Recommended shapes:
 If your function returns a string, it is returned as-is. Otherwise the result is returned as JSON text.
 
 The current MCP connection may mark blocked operations with \`x-mc8yp-restricted\` and related \`x-mc8yp-*\` fields. These operations are intentionally unavailable even though they still exist in the OpenAPI spec.
-Treat those annotations as a hard connection-level restriction: use them to understand what exists, but do not plan to call those operations with \`execute\`.
+Treat those annotations as a hard connection-level access policy: use them to understand what exists, but do not plan to call those operations with \`execute\`.
 
 Examples:
 () => {
@@ -96,7 +96,7 @@ Examples:
     }),
   }, async (input) => {
     try {
-      return tool.text(await query(input.code, server.ctx.custom?.restrictions ?? []))
+      return tool.text(await query(input.code, server.ctx.custom?.restrictions ?? [], server.ctx.custom?.allowRules ?? []))
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       return tool.error(message)
@@ -138,7 +138,7 @@ Tool output behavior:
 - On success, the actual function result is returned in Toon format.
 - On blocked or failed execution, the tool returns a plain text message.
 
-The current MCP connection may deny certain method/path combinations. Restricted routes remain visible in the spec, and \`cumulocity.request(...)\` will reject blocked calls before sending them.
+The current MCP connection may deny certain method/path combinations and may also use an allow list. Restricted or non-allowed routes remain visible in the spec, and \`cumulocity.request(...)\` will reject blocked calls before sending them.
 When that happens, the tool returns a plain text connection-policy message. That is not a Cumulocity API failure and retrying the same operation through the same connection will not help.
 
 ${getExecuteEnvironmentNote()}
@@ -174,7 +174,7 @@ async () => {
     })),
   }, async (input) => {
     try {
-      return tool.text(await execute(input.code, input, server.ctx.custom?.restrictions ?? []))
+      return tool.text(await execute(input.code, input, server.ctx.custom?.restrictions ?? [], server.ctx.custom?.allowRules ?? []))
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       return tool.error(message)

--- a/src/types/mcp-context.ts
+++ b/src/types/mcp-context.ts
@@ -1,5 +1,6 @@
-import type { RestrictionRule } from '../utils/restrictions'
+import type { AllowRule, RestrictionRule } from '../utils/restrictions'
 
 export interface C8yMcpCustomContext extends Record<string, unknown> {
   restrictions: RestrictionRule[]
+  allowRules: AllowRule[]
 }

--- a/src/utils/restriction-matcher.ts
+++ b/src/utils/restriction-matcher.ts
@@ -1,8 +1,34 @@
-import type { RestrictionRule } from './restrictions'
+import type { AllowRule, RestrictionMethod, RestrictionRule } from './restrictions'
 
-export interface CompiledRestrictionRule extends RestrictionRule {
+interface MatchableRule {
+  method: RestrictionMethod
+  pathPattern: string
+  source: string
+}
+
+export interface CompiledRestrictionRule extends MatchableRule {
   segments: ('**' | RegExp)[]
 }
+
+export type AccessPolicyDecision
+  = | {
+    blocked: false
+    blockedBy?: undefined
+    matchingRestrictions?: undefined
+    matchingAllowRules?: undefined
+  }
+  | {
+    blocked: true
+    blockedBy: 'restriction'
+    matchingRestrictions: RestrictionRule[]
+    matchingAllowRules?: undefined
+  }
+  | {
+    blocked: true
+    blockedBy: 'allow'
+    matchingRestrictions?: undefined
+    matchingAllowRules?: undefined
+  }
 
 export function escapeRestrictionRegex(value: string): string {
   let escaped = ''
@@ -48,7 +74,7 @@ export function matchCompiledSegments(pattern: ('**' | RegExp)[], path: string[]
   return si === path.length
 }
 
-export function compileRestrictionRule(rule: RestrictionRule): CompiledRestrictionRule {
+export function compileRestrictionRule<TRule extends MatchableRule>(rule: TRule): TRule & CompiledRestrictionRule {
   return {
     ...rule,
     segments: rule.pathPattern === '/' ? [] : rule.pathPattern.slice(1).split('/').map(compileRestrictionSegment),
@@ -59,11 +85,11 @@ export function matchesCompiledRule(rule: CompiledRestrictionRule, method: strin
   return (rule.method === '*' || rule.method === method) && matchCompiledSegments(rule.segments, pathSegments)
 }
 
-export function findBlockingRestrictions(
-  rules: readonly RestrictionRule[],
+export function findMatchingRules<TRule extends MatchableRule>(
+  rules: readonly TRule[],
   method: string | undefined,
   pathname: string,
-): RestrictionRule[] {
+): TRule[] {
   const normalizedMethod = typeof method === 'string' ? method.trim().toUpperCase() : ''
   const pathSegments = pathname === '/' ? [] : pathname.slice(1).split('/')
 
@@ -75,4 +101,46 @@ export function findBlockingRestrictions(
 
     return matchesCompiledRule(compiledRule, normalizedMethod, pathSegments)
   })
+}
+
+export function findBlockingRestrictions(
+  rules: readonly RestrictionRule[],
+  method: string | undefined,
+  pathname: string,
+): RestrictionRule[] {
+  return findMatchingRules(rules, method, pathname)
+}
+
+export function evaluateAccessPolicy(
+  restrictions: readonly RestrictionRule[],
+  allowRules: readonly AllowRule[],
+  method: string,
+  pathname: string,
+): AccessPolicyDecision {
+  const matchingRestrictions = findMatchingRules(restrictions, method, pathname)
+  if (matchingRestrictions.length > 0) {
+    return {
+      blocked: true,
+      blockedBy: 'restriction',
+      matchingRestrictions,
+    }
+  }
+
+  if (allowRules.length === 0) {
+    return {
+      blocked: false,
+    }
+  }
+
+  const matchingAllowRules = findMatchingRules(allowRules, method, pathname)
+  if (matchingAllowRules.length > 0) {
+    return {
+      blocked: false,
+    }
+  }
+
+  return {
+    blocked: true,
+    blockedBy: 'allow',
+  }
 }

--- a/src/utils/restrictions.ts
+++ b/src/utils/restrictions.ts
@@ -4,11 +4,20 @@ export type HttpMethod = (typeof HTTP_METHODS)[number]
 export type RestrictionMethod = HttpMethod | '*'
 
 const HTTP_METHOD_SET: ReadonlySet<string> = new Set(HTTP_METHODS)
+const SEGMENT_PATTERN = /^[A-Za-z0-9._~*-]+$/
 
-export interface RestrictionRule {
+interface BaseRule {
   method: RestrictionMethod
   pathPattern: string
   source: string
+}
+
+export interface RestrictionRule extends BaseRule {
+  type: 'deny'
+}
+
+export interface AllowRule extends BaseRule {
+  type: 'allow'
 }
 
 export interface InvalidRestrictionRule {
@@ -16,9 +25,16 @@ export interface InvalidRestrictionRule {
   reason: string
 }
 
+export type InvalidAllowRule = InvalidRestrictionRule
+
 export interface RestrictionParseResult {
   parsedRules: RestrictionRule[]
   failedRules: InvalidRestrictionRule[]
+}
+
+export interface AllowParseResult {
+  parsedRules: AllowRule[]
+  failedRules: InvalidAllowRule[]
 }
 
 export const RESTRICTION_EXTENSION_KEY = 'x-mc8yp-restrictions'
@@ -29,7 +45,6 @@ export const RESTRICTED_OPERATION_TYPE = 'x-mc8yp-restrictionType'
 export const RESTRICTED_AGENT_NOTE = 'x-mc8yp-agentNote'
 
 export function parseRestrictionRule(input: string | readonly string[]): RestrictionParseResult {
-  const segmentPattern = /^[A-Za-z0-9._~*-]+$/
   const inputs = typeof input === 'string' ? [input] : input
   const parsedRules: RestrictionRule[] = []
   const failedRules: InvalidRestrictionRule[] = []
@@ -91,7 +106,7 @@ export function parseRestrictionRule(input: string | readonly string[]): Restric
           return false
         }
 
-        return segment.includes('**') || segment === '.' || segment === '..' || !segmentPattern.test(segment)
+        return segment.includes('**') || segment === '.' || segment === '..' || !SEGMENT_PATTERN.test(segment)
       })
       if (invalidRawPathSegment) {
         failedRules.push({
@@ -106,6 +121,7 @@ export function parseRestrictionRule(input: string | readonly string[]): Restric
       }
 
       parsedRules.push({
+        type: 'deny',
         method: (!rawMethod || rawMethod === '*') ? '*' : rawMethod as HttpMethod,
         pathPattern: rawPath,
         source,
@@ -142,7 +158,7 @@ export function parseRestrictionRule(input: string | readonly string[]): Restric
         return false
       }
 
-      return segment.includes('**') || segment === '.' || segment === '..' || !segmentPattern.test(segment)
+      return segment.includes('**') || segment === '.' || segment === '..' || !SEGMENT_PATTERN.test(segment)
     })
     if (invalidSourceSegment) {
       failedRules.push({
@@ -157,6 +173,149 @@ export function parseRestrictionRule(input: string | readonly string[]): Restric
     }
 
     parsedRules.push({
+      type: 'deny',
+      method: '*',
+      pathPattern: source,
+      source,
+    })
+  }
+
+  return {
+    parsedRules,
+    failedRules,
+  }
+}
+
+export function parseAllowRule(input: string | readonly string[]): AllowParseResult {
+  const inputs = typeof input === 'string' ? [input] : input
+  const parsedRules: AllowRule[] = []
+  const failedRules: InvalidAllowRule[] = []
+
+  for (const source of inputs) {
+    if (!source) {
+      failedRules.push({
+        rule: source,
+        reason: 'Allow value must not be empty.',
+      })
+      continue
+    }
+
+    const sep = source.indexOf(':')
+    if (sep > 0 && !source.startsWith('/')) {
+      const rawMethod = source.slice(0, sep).toUpperCase()
+      const rawPath = source.slice(sep + 1)
+
+      if (!rawPath) {
+        failedRules.push({
+          rule: source,
+          reason: 'Allow path pattern must not be empty.',
+        })
+        continue
+      }
+      if (rawMethod && rawMethod !== '*' && !HTTP_METHOD_SET.has(rawMethod)) {
+        failedRules.push({
+          rule: source,
+          reason: `Unsupported allow method "${source.slice(0, sep)}".`,
+        })
+        continue
+      }
+      if (rawPath.includes('?') || rawPath.includes('#')) {
+        failedRules.push({
+          rule: source,
+          reason: `Allow pattern "${rawPath}" must not include query strings or fragments.`,
+        })
+        continue
+      }
+      if (!rawPath.startsWith('/')) {
+        failedRules.push({
+          rule: source,
+          reason: 'Allow path pattern must start with "/".',
+        })
+        continue
+      }
+
+      const rawPathSegments = rawPath === '/' ? [] : rawPath.slice(1).split('/')
+      if (rawPathSegments.some((segment) => segment.length === 0)) {
+        failedRules.push({
+          rule: source,
+          reason: 'Allow path pattern must not contain empty segments.',
+        })
+        continue
+      }
+
+      const invalidRawPathSegment = rawPathSegments.find((segment) => {
+        if (segment === '**') {
+          return false
+        }
+
+        return segment.includes('**') || segment === '.' || segment === '..' || !SEGMENT_PATTERN.test(segment)
+      })
+      if (invalidRawPathSegment) {
+        failedRules.push({
+          rule: source,
+          reason: invalidRawPathSegment === '.' || invalidRawPathSegment === '..'
+            ? `Allow segment "${invalidRawPathSegment}" is not allowed.`
+            : invalidRawPathSegment.includes('**')
+              ? `Invalid allow segment "${invalidRawPathSegment}". "**" must be its own path segment.`
+              : `Allow segment "${invalidRawPathSegment}" contains unsupported characters.`,
+        })
+        continue
+      }
+
+      parsedRules.push({
+        type: 'allow',
+        method: (!rawMethod || rawMethod === '*') ? '*' : rawMethod as HttpMethod,
+        pathPattern: rawPath,
+        source,
+      })
+      continue
+    }
+
+    if (source.includes('?') || source.includes('#')) {
+      failedRules.push({
+        rule: source,
+        reason: `Allow pattern "${source}" must not include query strings or fragments.`,
+      })
+      continue
+    }
+    if (!source.startsWith('/')) {
+      failedRules.push({
+        rule: source,
+        reason: 'Allow path pattern must start with "/".',
+      })
+      continue
+    }
+
+    const sourceSegments = source === '/' ? [] : source.slice(1).split('/')
+    if (sourceSegments.some((segment) => segment.length === 0)) {
+      failedRules.push({
+        rule: source,
+        reason: 'Allow path pattern must not contain empty segments.',
+      })
+      continue
+    }
+
+    const invalidSourceSegment = sourceSegments.find((segment) => {
+      if (segment === '**') {
+        return false
+      }
+
+      return segment.includes('**') || segment === '.' || segment === '..' || !SEGMENT_PATTERN.test(segment)
+    })
+    if (invalidSourceSegment) {
+      failedRules.push({
+        rule: source,
+        reason: invalidSourceSegment === '.' || invalidSourceSegment === '..'
+          ? `Allow segment "${invalidSourceSegment}" is not allowed.`
+          : invalidSourceSegment.includes('**')
+            ? `Invalid allow segment "${invalidSourceSegment}". "**" must be its own path segment.`
+            : `Allow segment "${invalidSourceSegment}" contains unsupported characters.`,
+      })
+      continue
+    }
+
+    parsedRules.push({
+      type: 'allow',
       method: '*',
       pathPattern: source,
       source,

--- a/test/excute.test.ts
+++ b/test/excute.test.ts
@@ -3,8 +3,8 @@
 import { encode } from '@toon-format/toon'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { buildExecutePrelude, buildExecuteScript, execute } from '../src/codemode/execute'
-import { parseRestrictionRule } from '../src/utils/restrictions'
-import type { RestrictionRule } from '../src/utils/restrictions'
+import { parseAllowRule, parseRestrictionRule } from '../src/utils/restrictions'
+import type { AllowRule, RestrictionRule } from '../src/utils/restrictions'
 import * as client from '../src/utils/client'
 
 function parseSingleRule(input: string): RestrictionRule {
@@ -13,6 +13,17 @@ function parseSingleRule(input: string): RestrictionRule {
 
   if (!rule || result.failedRules.length > 0) {
     throw new Error(`Expected a valid restriction rule: ${input}`)
+  }
+
+  return rule
+}
+
+function parseSingleAllowRule(input: string): AllowRule {
+  const result = parseAllowRule([input])
+  const rule = result.parsedRules[0]
+
+  if (!rule || result.failedRules.length > 0) {
+    throw new Error(`Expected a valid allow rule: ${input}`)
   }
 
   return rule
@@ -67,12 +78,13 @@ function resetTestGlobals() {
 async function runGeneratedExecuteScript(
   sourceCode: string,
   restrictions: readonly RestrictionRule[] = [],
+  allowRules: readonly AllowRule[] = [],
   headers: Record<string, string> = { Authorization: 'Bearer test' },
 ): Promise<ExecuteHarnessResult> {
   resetTestGlobals()
 
   const run = new Function([
-    buildExecutePrelude('https://tenant.example.com', headers, restrictions),
+    buildExecutePrelude('https://tenant.example.com', headers, restrictions, allowRules),
     `const __mc8ypExecute = (${sourceCode});`,
     'globalThis.__done = (async () => {',
     '  try {',
@@ -135,7 +147,7 @@ afterEach(() => {
   resetTestGlobals()
 })
 
-function expectedBlockedRequestMessage(method: string, path: string, matchingRules: readonly string[]): string {
+function expectedRestrictedRequestMessage(method: string, path: string, matchingRules: readonly string[]): string {
   return [
     'Request blocked by MCP connection policy.',
     '',
@@ -154,22 +166,46 @@ function expectedBlockedRequestMessage(method: string, path: string, matchingRul
   ].join('\n')
 }
 
-function expectedBlockedResult(method: string, path: string, matchingRules: readonly string[]): { status: 'blocked', error: { message: string } } {
+function expectedAllowedRequestMessage(method: string, path: string, allowRules: readonly string[]): string {
+  return [
+    'Request blocked by MCP connection policy.',
+    '',
+    'This operation is intentionally blocked because it is not included in the current MCP connection allow list.',
+    'It did not fail at the Cumulocity API and it was not executed against the tenant.',
+    'Retrying or trying the same operation again through this connection will not succeed.',
+    '',
+    'Report this to the user as a connection-level access restriction.',
+    'If the operation is needed, the MCP allow list for this connection must be updated by whoever manages that configuration.',
+    '',
+    'Blocked operation:',
+    `Method: ${method}`,
+    `Path: ${path}`,
+    'Configured allow rules:',
+    ...allowRules.map((rule) => `- ${rule}`),
+  ].join('\n')
+}
+
+function expectedBlockedResult(message: string): { status: 'blocked', error: { message: string } } {
   return {
     status: 'blocked',
-    error: {
-      message: expectedBlockedRequestMessage(method, path, matchingRules),
-    },
+    error: { message },
   }
 }
 
 describe('buildExecuteScript', () => {
-  it('embeds restriction enforcement in the generated request wrapper', () => {
-    const script = buildExecuteScript('async () => null', 'https://tenant.example.com', { Authorization: 'Bearer test' }, [parseSingleRule('GET:/inventory/**')])
+  it('embeds restriction and allow-list enforcement in the generated request wrapper', () => {
+    const script = buildExecuteScript(
+      'async () => null',
+      'https://tenant.example.com',
+      { Authorization: 'Bearer test' },
+      [parseSingleRule('GET:/inventory/**')],
+      [parseSingleAllowRule('GET:/inventory/**')],
+    )
 
     expect(script).toContain('const compiledRestrictions = restrictions.map(compileRestrictionRule);')
-    expect(script).toContain('const method = validateRequestMethod(init.method);')
-    expect(script).toContain('const blockedRules = findBlockingRestrictions(method, resolvedUrl.pathname);')
+    expect(script).toContain('const compiledAllowRules = allowRules.map(compileRestrictionRule);')
+    expect(script).toContain('const accessDecision = evaluateAccessPolicy(method, resolvedUrl.pathname);')
+    expect(script).toContain('Configured allow rules:')
     expect(script).toContain('Request blocked by MCP connection policy.')
     expect(script).toContain('const __mc8ypExecute = (async () => null);')
     expect(script).toContain('status: "success"')
@@ -183,8 +219,13 @@ describe('buildExecuteScript', () => {
     expect(script).not.toContain('Cumulocity requests must target the configured tenant origin.')
   })
 
-  it('initializes the generated execute prelude without side effects for safe restrictions', () => {
-    const prelude = buildExecutePrelude('https://tenant.example.com', { Authorization: 'Bearer test' }, [parseSingleRule('GET:/inventory/**')])
+  it('initializes the generated execute prelude without side effects for safe restrictions and allow rules', () => {
+    const prelude = buildExecutePrelude(
+      'https://tenant.example.com',
+      { Authorization: 'Bearer test' },
+      [parseSingleRule('GET:/inventory/**')],
+      [parseSingleAllowRule('GET:/inventory/**')],
+    )
     const run = new Function(`${prelude}\nreturn globalThis.pwned;`) as () => unknown
 
     expect(run()).toBeUndefined()
@@ -203,7 +244,39 @@ describe('buildExecuteScript', () => {
     ].join('\n'), [parseSingleRule('GET:/inventory/**')])
 
     expect(result.called).toBe(false)
-    expect(result.result).toEqual(expectedBlockedResult('GET', '/inventory/managedObjects', ['GET:/inventory/**']))
+    expect(result.result).toEqual(expectedBlockedResult(expectedRestrictedRequestMessage('GET', '/inventory/managedObjects', ['GET:/inventory/**'])))
+  })
+
+  it('blocks requests outside the configured allow list before fetch is called', async () => {
+    const result = await runGeneratedExecuteScript([
+      'async () => {',
+      `${installFetchTrap.toString()}`,
+      'installFetchTrap();',
+      'return await cumulocity.request({',
+      '  method: "GET",',
+      '  path: "/alarm/alarms?pageSize=5",',
+      '});',
+      '}',
+    ].join('\n'), [], [parseSingleAllowRule('GET:/inventory/**')])
+
+    expect(result.called).toBe(false)
+    expect(result.result).toEqual(expectedBlockedResult(expectedAllowedRequestMessage('GET', '/alarm/alarms', ['GET:/inventory/**'])))
+  })
+
+  it('lets restrictions take priority over matching allow rules in the generated wrapper', async () => {
+    const result = await runGeneratedExecuteScript([
+      'async () => {',
+      `${installFetchTrap.toString()}`,
+      'installFetchTrap();',
+      'return await cumulocity.request({',
+      '  method: "GET",',
+      '  path: "/inventory/managedObjects?pageSize=5",',
+      '});',
+      '}',
+    ].join('\n'), [parseSingleRule('GET:/inventory/managedObjects')], [parseSingleAllowRule('GET:/inventory/**')])
+
+    expect(result.called).toBe(false)
+    expect(result.result).toEqual(expectedBlockedResult(expectedRestrictedRequestMessage('GET', '/inventory/managedObjects', ['GET:/inventory/managedObjects'])))
   })
 
   it('rejects requests without an explicit method before fetch is called', async () => {
@@ -269,6 +342,27 @@ describe('buildExecuteScript', () => {
     })
   })
 
+  it('allows requests that match the configured allow list', async () => {
+    const result = await runGeneratedExecuteScript([
+      'async () => {',
+      `${installEchoFetch.toString()}`,
+      'installEchoFetch();',
+      'return await cumulocity.request({',
+      '  method: "GET",',
+      '  path: "/inventory/managedObjects?pageSize=5",',
+      '});',
+      '}',
+    ].join('\n'), [], [parseSingleAllowRule('GET:/inventory/**')])
+
+    expect(result.called).toBe(true)
+    expect(result.url).toBe('https://tenant.example.com/inventory/managedObjects?pageSize=5')
+    expect(result.method).toBe('GET')
+    expect(result.result).toEqual({
+      status: 'success',
+      result: { ok: true },
+    })
+  })
+
   it('blocks query-derived restrictions for same-origin absolute URLs before fetch is called', async () => {
     const restrictions = parseRestrictionRule(['GET:/inventory/**']).parsedRules
     const result = await runGeneratedExecuteScript([
@@ -283,11 +377,18 @@ describe('buildExecuteScript', () => {
     ].join('\n'), restrictions)
 
     expect(result.called).toBe(false)
-    expect(result.result).toEqual(expectedBlockedResult('GET', '/inventory/managedObjects', ['GET:/inventory/**']))
+    expect(result.result).toEqual(expectedBlockedResult(expectedRestrictedRequestMessage('GET', '/inventory/managedObjects', ['GET:/inventory/**'])))
   })
 
   it.each(INVALID_RESTRICTION_QUERY_PAYLOADS)('reports invalid malicious restriction text from query params: %s', (payload) => {
     expect(parseRestrictionRule([payload])).toEqual({
+      parsedRules: [],
+      failedRules: [{
+        rule: payload,
+        reason: expect.any(String),
+      }],
+    })
+    expect(parseAllowRule([payload])).toEqual({
       parsedRules: [],
       failedRules: [{
         rule: payload,

--- a/test/openapi-restrictions.test.ts
+++ b/test/openapi-restrictions.test.ts
@@ -4,7 +4,9 @@ import {
   RESTRICTED_OPERATION_FLAG,
   RESTRICTED_OPERATION_MESSAGE,
   RESTRICTED_OPERATION_RULES,
+  RESTRICTED_OPERATION_TYPE,
   RESTRICTION_EXTENSION_KEY,
+  parseAllowRule,
   parseRestrictionRule,
 } from '../src/utils/restrictions'
 
@@ -14,6 +16,17 @@ function parseSingleRule(input: string) {
 
   if (!rule || result.failedRules.length > 0) {
     throw new Error(`Expected a valid restriction rule: ${input}`)
+  }
+
+  return rule
+}
+
+function parseSingleAllowRule(input: string) {
+  const result = parseAllowRule([input])
+  const rule = result.parsedRules[0]
+
+  if (!rule || result.failedRules.length > 0) {
+    throw new Error(`Expected a valid allow rule: ${input}`)
   }
 
   return rule
@@ -51,9 +64,39 @@ describe('applyRestrictionsToOpenApiSpec', () => {
     // @ts-expect-error - check for added metadata properties
     expect(restrictedOperation[RESTRICTED_OPERATION_FLAG]).toBe(true)
     // @ts-expect-error - check for added metadata properties
+    expect(restrictedOperation[RESTRICTED_OPERATION_TYPE]).toBe('deny')
+    // @ts-expect-error - check for added metadata properties
     expect(restrictedOperation[RESTRICTED_OPERATION_RULES]).toEqual(['GET:/inventory/**'])
     // @ts-expect-error - check for added metadata properties
     expect(restrictedOperation[RESTRICTED_OPERATION_MESSAGE]).toContain('blocked')
+  })
+
+  it('annotates operations outside the allow list as blocked', () => {
+    const restrictedSpec = applyRestrictionsToOpenApiSpec(spec, [], [parseSingleAllowRule('GET:/inventory/**')])
+    const blockedOperation = restrictedSpec.paths['/alarm/alarms'].get
+
+    // @ts-expect-error - check for added metadata properties
+    expect(blockedOperation[RESTRICTED_OPERATION_FLAG]).toBe(true)
+    // @ts-expect-error - check for added metadata properties
+    expect(blockedOperation[RESTRICTED_OPERATION_TYPE]).toBe('deny')
+    // @ts-expect-error - check for added metadata properties
+    expect(blockedOperation[RESTRICTED_OPERATION_RULES]).toEqual(['GET:/inventory/**'])
+    // @ts-expect-error - check for added metadata properties
+    expect(blockedOperation[RESTRICTED_OPERATION_MESSAGE]).toBe('This operation is blocked by the current MCP connection policy.')
+  })
+
+  it('lets restrictions take priority over matching allow rules', () => {
+    const restrictedSpec = applyRestrictionsToOpenApiSpec(
+      spec,
+      [parseSingleRule('GET:/inventory/managedObjects')],
+      [parseSingleAllowRule('GET:/inventory/**')],
+    )
+    const blockedOperation = restrictedSpec.paths['/inventory/managedObjects'].get
+
+    // @ts-expect-error - check for added metadata properties
+    expect(blockedOperation[RESTRICTED_OPERATION_TYPE]).toBe('deny')
+    // @ts-expect-error - check for added metadata properties
+    expect(blockedOperation[RESTRICTED_OPERATION_RULES]).toEqual(['GET:/inventory/managedObjects'])
   })
 
   it('leaves unrelated operations unchanged and adds top-level metadata', () => {
@@ -63,7 +106,20 @@ describe('applyRestrictionsToOpenApiSpec', () => {
     // @ts-expect-error - check for added metadata properties
     expect(restrictedSpec[RESTRICTION_EXTENSION_KEY]).toEqual({
       mode: 'deny',
-      rules: ['/inventory/**'],
+      restrictions: ['/inventory/**'],
+      allowed: [],
+      message: 'Operations marked with x-mc8yp-restricted are intentionally blocked for the current MCP connection.',
+    })
+  })
+
+  it('includes allow-list metadata when allow rules are configured', () => {
+    const restrictedSpec = applyRestrictionsToOpenApiSpec(spec, [parseSingleRule('/inventory/managedObjects')], [parseSingleAllowRule('GET:/inventory/**')])
+
+    // @ts-expect-error - check for added metadata properties
+    expect(restrictedSpec[RESTRICTION_EXTENSION_KEY]).toEqual({
+      mode: 'deny',
+      restrictions: ['/inventory/managedObjects'],
+      allowed: ['GET:/inventory/**'],
       message: 'Operations marked with x-mc8yp-restricted are intentionally blocked for the current MCP connection.',
     })
   })

--- a/test/restriction-core.test.ts
+++ b/test/restriction-core.test.ts
@@ -3,9 +3,10 @@ import { describe, expect, it } from 'vitest'
 import {
   compileRestrictionRule,
   findBlockingRestrictions,
+  findMatchingRules,
   matchesCompiledRule,
 } from '../src/utils/restriction-matcher'
-import { parseRestrictionRule } from '../src/utils/restrictions'
+import { parseAllowRule, parseRestrictionRule } from '../src/utils/restrictions'
 
 const INVALID_RESTRICTION_PAYLOADS = [
   '/inventory/managedObjects");globalThis.pwned=true;("',
@@ -168,6 +169,17 @@ function parseSingleRule(input: string) {
   return rule
 }
 
+function parseSingleAllowRule(input: string) {
+  const result = parseAllowRule([input])
+  const rule = result.parsedRules[0]
+
+  if (!rule || result.failedRules.length > 0) {
+    throw new Error(`Expected a valid allow rule: ${input}`)
+  }
+
+  return rule
+}
+
 function toPathSegments(path: string): string[] {
   return path === '/' ? [] : path.slice(1).split('/')
 }
@@ -176,6 +188,7 @@ describe('restriction core helpers', () => {
   it('parses safe restriction paths without normalization', () => {
     expect(parseRestrictionRule('get:/inventory/*/child')).toEqual({
       parsedRules: [{
+        type: 'deny',
         method: 'GET',
         pathPattern: '/inventory/*/child',
         source: 'get:/inventory/*/child',
@@ -184,6 +197,7 @@ describe('restriction core helpers', () => {
     })
     expect(parseRestrictionRule('/inventory/managedObjects*/**/evil')).toEqual({
       parsedRules: [{
+        type: 'deny',
         method: '*',
         pathPattern: '/inventory/managedObjects*/**/evil',
         source: '/inventory/managedObjects*/**/evil',
@@ -192,9 +206,19 @@ describe('restriction core helpers', () => {
     })
   })
 
-  it('accepts explicit wildcard method prefixes', () => {
+  it('accepts explicit wildcard method prefixes for restrictions and allow rules', () => {
     expect(parseRestrictionRule('*:/inventory/**')).toEqual({
       parsedRules: [{
+        type: 'deny',
+        method: '*',
+        pathPattern: '/inventory/**',
+        source: '*:/inventory/**',
+      }],
+      failedRules: [],
+    })
+    expect(parseAllowRule('*:/inventory/**')).toEqual({
+      parsedRules: [{
+        type: 'allow',
         method: '*',
         pathPattern: '/inventory/**',
         source: '*:/inventory/**',
@@ -227,7 +251,7 @@ describe('restriction core helpers', () => {
     expect(matchesCompiledRule(compiledRule, method, toPathSegments(path))).toBe(expected)
   })
 
-  it('finds blocked rules using the shared matching logic', () => {
+  it('finds blocked restriction rules using the shared matching logic', () => {
     const rules = [
       parseSingleRule('GET:/inventory/**'),
       parseSingleRule('/alarm/*'),
@@ -236,6 +260,17 @@ describe('restriction core helpers', () => {
     expect(findBlockingRestrictions(rules, 'GET', '/inventory/managedObjects/123').map((rule) => rule.source)).toEqual(['GET:/inventory/**'])
     expect(findBlockingRestrictions(rules, 'POST', '/alarm/alarms').map((rule) => rule.source)).toEqual(['/alarm/*'])
     expect(findBlockingRestrictions(rules, 'POST', '/event/events')).toEqual([])
+  })
+
+  it('finds matching allow rules using the shared matching logic', () => {
+    const rules = [
+      parseSingleAllowRule('GET:/inventory/**'),
+      parseSingleAllowRule('/alarm/*'),
+    ]
+
+    expect(findMatchingRules(rules, 'GET', '/inventory/managedObjects/123').map((rule) => rule.source)).toEqual(['GET:/inventory/**'])
+    expect(findMatchingRules(rules, 'POST', '/alarm/alarms').map((rule) => rule.source)).toEqual(['/alarm/*'])
+    expect(findMatchingRules(rules, 'POST', '/event/events')).toEqual([])
   })
 
   it.each(BLOCKED_RULE_CASES)('$description', ({ rules, method, path, expected }) => {

--- a/test/restrictions.test.ts
+++ b/test/restrictions.test.ts
@@ -2,8 +2,8 @@ import http from 'node:http'
 import { NodeRuntime, createNodeDriver, createNodeRuntimeDriverFactory } from 'secure-exec'
 import { describe, expect, it } from 'vitest'
 import { createNetworkPermissionDecision } from '../src/codemode/network-permissions'
-import { findBlockingRestrictions } from '../src/utils/restriction-matcher'
-import { parseRestrictionRule } from '../src/utils/restrictions'
+import { findBlockingRestrictions, findMatchingRules } from '../src/utils/restriction-matcher'
+import { parseAllowRule, parseRestrictionRule } from '../src/utils/restrictions'
 
 function parseSingleRule(input: string) {
   const result = parseRestrictionRule([input])
@@ -16,10 +16,22 @@ function parseSingleRule(input: string) {
   return rule
 }
 
+function parseSingleAllowRule(input: string) {
+  const result = parseAllowRule([input])
+  const rule = result.parsedRules[0]
+
+  if (!rule || result.failedRules.length > 0) {
+    throw new Error(`Expected a valid allow rule: ${input}`)
+  }
+
+  return rule
+}
+
 describe('restriction parsing', () => {
   it('parses methodless restrictions as all-method deny rules', () => {
     expect(parseRestrictionRule('/inventory/**')).toEqual({
       parsedRules: [{
+        type: 'deny',
         method: '*',
         pathPattern: '/inventory/**',
         source: '/inventory/**',
@@ -31,6 +43,7 @@ describe('restriction parsing', () => {
   it('parses method-scoped restrictions', () => {
     expect(parseRestrictionRule('get:/inventory/**')).toEqual({
       parsedRules: [{
+        type: 'deny',
         method: 'GET',
         pathPattern: '/inventory/**',
         source: 'get:/inventory/**',
@@ -47,12 +60,56 @@ describe('restriction parsing', () => {
       '',
     ])).toEqual({
       parsedRules: [
-        { method: '*', pathPattern: '/inventory/**', source: '/inventory/**' },
-        { method: 'POST', pathPattern: '/alarm/**', source: 'POST:/alarm/**' },
+        { type: 'deny', method: '*', pathPattern: '/inventory/**', source: '/inventory/**' },
+        { type: 'deny', method: 'POST', pathPattern: '/alarm/**', source: 'POST:/alarm/**' },
       ],
       failedRules: [
         { rule: 'BAD:/devicecontrol/**', reason: 'Unsupported restriction method "BAD".' },
         { rule: '', reason: 'Restriction value must not be empty.' },
+      ],
+    })
+  })
+})
+
+describe('allow parsing', () => {
+  it('parses methodless allow rules as all-method allow rules', () => {
+    expect(parseAllowRule('/inventory/**')).toEqual({
+      parsedRules: [{
+        type: 'allow',
+        method: '*',
+        pathPattern: '/inventory/**',
+        source: '/inventory/**',
+      }],
+      failedRules: [],
+    })
+  })
+
+  it('parses method-scoped allow rules', () => {
+    expect(parseAllowRule('get:/inventory/**')).toEqual({
+      parsedRules: [{
+        type: 'allow',
+        method: 'GET',
+        pathPattern: '/inventory/**',
+        source: 'get:/inventory/**',
+      }],
+      failedRules: [],
+    })
+  })
+
+  it('aggregates parsed and failed allow values', () => {
+    expect(parseAllowRule([
+      '/inventory/**',
+      'POST:/alarm/**',
+      'BAD:/devicecontrol/**',
+      '',
+    ])).toEqual({
+      parsedRules: [
+        { type: 'allow', method: '*', pathPattern: '/inventory/**', source: '/inventory/**' },
+        { type: 'allow', method: 'POST', pathPattern: '/alarm/**', source: 'POST:/alarm/**' },
+      ],
+      failedRules: [
+        { rule: 'BAD:/devicecontrol/**', reason: 'Unsupported allow method "BAD".' },
+        { rule: '', reason: 'Allow value must not be empty.' },
       ],
     })
   })
@@ -85,6 +142,32 @@ describe('restriction matching', () => {
   it('does not treat missing method metadata as GET for method-specific restrictions', () => {
     expect(findBlockingRestrictions(rules, undefined, '/alarm/alarms')).toEqual([])
     expect(findBlockingRestrictions(rules, '', '/alarm/alarms')).toEqual([])
+  })
+})
+
+describe('allow matching', () => {
+  const rules = [
+    parseSingleAllowRule('/inventory/**'),
+    parseSingleAllowRule('POST:/alarm/**'),
+  ]
+
+  it('matches every method when no method prefix is provided', () => {
+    expect(findMatchingRules(rules, 'GET', '/inventory/managedObjects').map((rule) => rule.source)).toEqual(['/inventory/**'])
+  })
+
+  it('keeps method-specific allow rules scoped to that method', () => {
+    expect(findMatchingRules(rules, 'GET', '/alarm/alarms')).toEqual([])
+    expect(findMatchingRules(rules, 'POST', '/alarm/alarms').map((rule) => rule.source)).toEqual(['POST:/alarm/**'])
+  })
+
+  it('still applies catch-all allow rules when method metadata is missing', () => {
+    expect(findMatchingRules(rules, undefined, '/inventory/managedObjects').map((rule) => rule.source)).toEqual(['/inventory/**'])
+    expect(findMatchingRules(rules, '', '/inventory/managedObjects').map((rule) => rule.source)).toEqual(['/inventory/**'])
+  })
+
+  it('does not treat missing method metadata as GET for method-specific allow rules', () => {
+    expect(findMatchingRules(rules, undefined, '/alarm/alarms')).toEqual([])
+    expect(findMatchingRules(rules, '', '/alarm/alarms')).toEqual([])
   })
 })
 
@@ -148,6 +231,52 @@ describe('network permission decisions', () => {
     ])).toEqual({
       allow: false,
       reason: 'Network connect blocked by MCP restrictions: /inventory/**, GET:/inventory/**',
+    })
+  })
+
+  it('allows requests that match the configured allow list', () => {
+    expect(createNetworkPermissionDecision(tenantUrl, {
+      op: 'connect',
+      hostname: 'tenant.example.com',
+      method: 'GET',
+      url: 'https://tenant.example.com/inventory/managedObjects?pageSize=5',
+    }, [], [parseSingleAllowRule('GET:/inventory/**')])).toEqual({
+      allow: true,
+    })
+  })
+
+  it('blocks requests outside the configured allow list when method and url are available', () => {
+    expect(createNetworkPermissionDecision(tenantUrl, {
+      op: 'connect',
+      hostname: 'tenant.example.com',
+      method: 'GET',
+      url: 'https://tenant.example.com/alarm/alarms?pageSize=5',
+    }, [], [parseSingleAllowRule('GET:/inventory/**')])).toEqual({
+      allow: false,
+      reason: 'Network connect blocked by MCP allow list: no allow rule matched GET /alarm/alarms. Configured allow rules: GET:/inventory/**',
+    })
+  })
+
+  it('lets restrictions take priority over matching allow rules', () => {
+    expect(createNetworkPermissionDecision(tenantUrl, {
+      op: 'connect',
+      hostname: 'tenant.example.com',
+      method: 'GET',
+      url: 'https://tenant.example.com/inventory/managedObjects?pageSize=5',
+    }, [parseSingleRule('/inventory/managedObjects')], [parseSingleAllowRule('/inventory/**')])).toEqual({
+      allow: false,
+      reason: 'Network connect blocked by MCP restrictions: /inventory/managedObjects',
+    })
+  })
+
+  it('does not enforce allow lists when secure-exec omits the request method', () => {
+    expect(createNetworkPermissionDecision(tenantUrl, {
+      op: 'connect',
+      hostname: 'tenant.example.com',
+      method: '',
+      url: 'https://tenant.example.com/alarm/alarms?pageSize=5',
+    }, [], [parseSingleAllowRule('GET:/inventory/**')])).toEqual({
+      allow: true,
     })
   })
 


### PR DESCRIPTION
## Summary
- add allow-list path matching for CLI and HTTP query parameters using `-a` / `--allow` / `--allowed` and `a` / `allow` / `allowed`
- enforce allow-list behavior in `query` and `execute` while keeping restriction precedence over allow rules
- add and update tests for parsing, matching, OpenAPI blocking metadata, and execute/network enforcement

## Validation
- pnpm test:run
- pnpm typecheck
- pnpm lint

## Notes
- updates `README.md` and `AGENTS.md` for the new access-policy behavior and agent guidance
