### PR TITLE
feat: add header-based access policy inputs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,7 @@ src/core-openapi.d.ts         Ambient type declarations for the `#core-openapi` 
 
 1. `src/index.ts` starts the HTTP server and exposes `/mcp` and `/health`.
 2. It sets `globalThis.executionEnvironment = 'server'`.
-3. It extracts auth from request headers, restrictions from `restriction`, `restrict`, and `r` query parameters, and allow rules from `allowed`, `allow`, and `a` query parameters.
+3. It extracts auth from request headers, restrictions from `restriction`, `restrict`, and `r` query parameters plus the `mc8yp-restriction` header, and allow rules from `allowed`, `allow`, and `a` query parameters plus the `mc8yp-allow` header.
 4. It stores auth in request-local context and forwards the request to the shared MCP server.
 5. It configures the HTTP transport in POST-only mode (`disableSse: true`) because the optional long-lived GET/SSE channel proved unstable behind Cumulocity microservice ingress.
 
@@ -132,6 +132,7 @@ Restrictions and allow rules both use the format `[METHOD:]<path-pattern>`.
 - Restrictions are deny rules.
 - Allow rules are allow-list entries. When any allow rule exists, requests must match at least one allow rule unless a restriction blocks them first.
 - Restrictions take priority over allow rules.
+- In microservice mode, prefer the project-scoped `mc8yp-restriction` and `mc8yp-allow` headers for HTTP policy transport; repeated headers and comma-separated values are both accepted.
 
 The restriction system is implemented in two places:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,7 +246,8 @@ When working on this project:
 8. Notify the user when `AGENTS.md` or `README.md` has changed so those docs can be reviewed explicitly.
 9. When the user asks for branch/commit/PR workflow, use the available MCP/devtools for branch creation, commits, pushes, and PRs. Only fall back to `gh` CLI when those tools are not available. Never assume Claude Code or any other external workflow helper.
 10. For branch/commit/PR workflow, branch names should use the same conventional type prefixes as commits and PR titles where appropriate. Prefer prefixes such as `feat/`, `test/`, `chore/`, `fix/`, `docs/`, `refactor/`, `build/`, `types/`, `examples/`, `style/`, `perf/`, and `ci/`. Commit subjects and PR titles must use conventional-commit style and should choose the most appropriate type from this set: `feat`, `perf`, `fix`, `refactor`, `docs`, `build`, `types`, `chore`, `examples`, `test`, `style`, `ci`. The project maps them as follows: `feat` → 🚀 Enhancements (minor), `perf` → 🔥 Performance (patch), `fix` → 🩹 Fixes (patch), `refactor` → 💅 Refactors (patch), `docs` → 📖 Documentation (patch), `build` → 📦 Build (patch), `types` → 🌊 Types (patch), `chore` → 🏡 Chore, `examples` → 🏀 Examples, `test` → ✅ Tests, `style` → 🎨 Styles, `ci` → 🤖 CI.
-11. PRs created for the user must include a body. If the work clearly addresses an existing issue and the issue identifier is known, include it in the PR body using the appropriate GitHub-style reference.
+11. When the user asks for a PR while the current branch already contains related work, assume the PR should be opened from the current branch to `main` unless the user explicitly asks to isolate only a subset of changes or use a different base branch. Do not create a fresh branch off an in-progress feature branch just to hold the latest agent-only changes unless the user asks for that.
+12. PRs created for the user must include a body. If the work clearly addresses an existing issue and the issue identifier is known, include it in the PR body using the appropriate GitHub-style reference.
 
 ## Project Context & Learnings
 
@@ -269,6 +270,7 @@ This section captures project-specific knowledge, tool quirks, and lessons learn
 - `scripts/package-microservices.mjs` intentionally targets `linux/amd64` by default to avoid Apple Silicon release images failing with `exec format error` in Cumulocity.
 - Restrictions and allow rules are both discoverability metadata and enforcement logic; both layers matter.
 - When creating branches for user-requested work, prefer conventional prefixes that match the intended change type, especially `feat/`, `test/`, and `chore/`.
+- If the user asks to open a PR from an already-active feature branch, treat that existing branch as the PR head by default and target `main` unless they say otherwise.
 - Server-mode auth must stay request-local.
 - For deployed microservice mode, prefer POST-only streamable HTTP over long-lived GET/SSE. The optional SSE channel can go inactive behind Cumulocity ingress and break later tool calls even when initialization and tool discovery succeeded.
 

--- a/README.md
+++ b/README.md
@@ -276,12 +276,26 @@ mc8yp -a "/inventory/**" -r "/inventory/managedObjects"
 
 Pass restrictions as `restriction`, `restrict`, or `r` query parameters on the MCP endpoint URL.
 Pass allow rules as `allowed`, `allow`, or `a` query parameters.
+You can also send project-scoped HTTP headers to avoid conflicts with well-known headers:
+
+- `mc8yp-restriction` for deny rules
+- `mc8yp-allow` for allow-list rules
+
+Both headers accept either repeated header instances or a comma-separated list of rules. Query parameters and headers can be combined on the same connection.
 
 ```
 /mcp?restriction=/inventory/**&restrict=DELETE:/alarm/**
 /mcp?r=/inventory/**&r=DELETE:/alarm/**
 /mcp?allow=/inventory/**&allowed=POST:/alarm/**
 /mcp?a=/inventory/**&r=/inventory/managedObjects
+```
+
+```http
+POST /mcp HTTP/1.1
+Authorization: Bearer <token>
+mc8yp-restriction: /inventory/**
+mc8yp-restriction: DELETE:/alarm/**
+mc8yp-allow: GET:/measurement/**
 ```
 
 ### How Access Policy Works

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,16 @@ import { createC8YMcpServer } from './server'
 import { getAuthContext } from './ctx/auth'
 import process from 'node:process'
 import { extractAuthFromHeaders } from './utils/auth'
-import { parseAllowRule, parseRestrictionRule } from './utils/restrictions'
+import {
+  ALLOW_HEADER,
+  ALLOW_QUERY_KEYS,
+  RESTRICTION_HEADER,
+  RESTRICTION_QUERY_KEYS,
+  collectServerAllowSources,
+  collectServerRestrictionSources,
+  parseAllowRule,
+  parseRestrictionRule,
+} from './utils/restrictions'
 
 globalThis.executionEnvironment = 'server'
 
@@ -20,32 +29,28 @@ const app = new H3().all('/mcp', async (event) => {
   // Extract authentication from request headers
   const credentials = extractAuthFromHeaders(event.req)
   const query = getQuery(event)
-  const restrictionSources = [query.restriction, query.restrict, query.r].flatMap((value) => Array.isArray(value) ? value : [value]).filter(
-    (value): value is string => typeof value === 'string' && value.length > 0,
-  )
+  const restrictionSources = collectServerRestrictionSources(query, event.req.headers)
   const { parsedRules: restrictions, failedRules: failedRestrictions } = parseRestrictionRule(restrictionSources)
 
   if (failedRestrictions.length > 0) {
     throw new HTTPError({
       status: 400,
-      statusText: 'Invalid restriction query',
-      message: 'One or more restriction query parameters (?restriction, ?restrict, ?r) could not be parsed.',
+      statusText: 'Invalid restriction policy',
+      message: `One or more restriction values from query params (${RESTRICTION_QUERY_KEYS.map((key) => `?${key}`).join(', ')}) or the ${RESTRICTION_HEADER} header could not be parsed.`,
       data: {
         failedRules: failedRestrictions,
       },
     })
   }
 
-  const allowSources = [query.allowed, query.allow, query.a].flatMap((value) => Array.isArray(value) ? value : [value]).filter(
-    (value): value is string => typeof value === 'string' && value.length > 0,
-  )
+  const allowSources = collectServerAllowSources(query, event.req.headers)
   const { parsedRules: allowRules, failedRules: failedAllowRules } = parseAllowRule(allowSources)
 
   if (failedAllowRules.length > 0) {
     throw new HTTPError({
       status: 400,
-      statusText: 'Invalid allow query',
-      message: 'One or more allow query parameters (?allowed, ?allow, ?a) could not be parsed.',
+      statusText: 'Invalid allow policy',
+      message: `One or more allow values from query params (${ALLOW_QUERY_KEYS.map((key) => `?${key}`).join(', ')}) or the ${ALLOW_HEADER} header could not be parsed.`,
       data: {
         failedRules: failedAllowRules,
       },

--- a/src/utils/restrictions.ts
+++ b/src/utils/restrictions.ts
@@ -1,10 +1,42 @@
 export const HTTP_METHODS = ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE'] as const
+export const RESTRICTION_QUERY_KEYS = ['restriction', 'restrict', 'r'] as const
+export const ALLOW_QUERY_KEYS = ['allowed', 'allow', 'a'] as const
+export const RESTRICTION_HEADER = 'mc8yp-restriction'
+export const ALLOW_HEADER = 'mc8yp-allow'
 
 export type HttpMethod = (typeof HTTP_METHODS)[number]
 export type RestrictionMethod = HttpMethod | '*'
 
 const HTTP_METHOD_SET: ReadonlySet<string> = new Set(HTTP_METHODS)
 const SEGMENT_PATTERN = /^[A-Za-z0-9._~*-]+$/
+
+function collectRuleSources(values: readonly unknown[]): string[] {
+  return values.flatMap((value) => Array.isArray(value) ? value : [value]).filter(
+    (value): value is string => typeof value === 'string' && value.length > 0,
+  )
+}
+
+function collectHeaderRuleSources(value: string | null): string[] {
+  if (!value) {
+    return []
+  }
+
+  return value.split(',').map((entry) => entry.trim()).filter((entry) => entry.length > 0)
+}
+
+export function collectServerRestrictionSources(query: Record<string, unknown>, headers: Headers): string[] {
+  return [
+    ...collectRuleSources(RESTRICTION_QUERY_KEYS.map((key) => query[key])),
+    ...collectHeaderRuleSources(headers.get(RESTRICTION_HEADER)),
+  ]
+}
+
+export function collectServerAllowSources(query: Record<string, unknown>, headers: Headers): string[] {
+  return [
+    ...collectRuleSources(ALLOW_QUERY_KEYS.map((key) => query[key])),
+    ...collectHeaderRuleSources(headers.get(ALLOW_HEADER)),
+  ]
+}
 
 interface BaseRule {
   method: RestrictionMethod

--- a/test/restrictions.test.ts
+++ b/test/restrictions.test.ts
@@ -140,6 +140,64 @@ describe('server access policy input collection', () => {
     ])
   })
 
+  it('ignores empty restriction header entries created by leading, trailing, or repeated commas', () => {
+    const headers = new Headers()
+    headers.append(RESTRICTION_HEADER, ' , DELETE:/alarm/** ,, /event/** , ')
+    headers.append(RESTRICTION_HEADER, ',, GET:/measurement/**,')
+
+    expect(collectServerRestrictionSources({}, headers)).toEqual([
+      'DELETE:/alarm/**',
+      '/event/**',
+      'GET:/measurement/**',
+    ])
+  })
+
+  it('treats commas inside a restriction rule as separators, so malformed fragments fail parsing independently', () => {
+    const sources = collectServerRestrictionSources({}, new Headers({
+      [RESTRICTION_HEADER]: 'GET, /inventory/**, POST:/alarm/**',
+    }))
+
+    expect(sources).toEqual([
+      'GET',
+      '/inventory/**',
+      'POST:/alarm/**',
+    ])
+
+    expect(parseRestrictionRule(sources)).toEqual({
+      parsedRules: [
+        { type: 'deny', method: '*', pathPattern: '/inventory/**', source: '/inventory/**' },
+        { type: 'deny', method: 'POST', pathPattern: '/alarm/**', source: 'POST:/alarm/**' },
+      ],
+      failedRules: [
+        { rule: 'GET', reason: 'Restriction path pattern must start with "/".' },
+      ],
+    })
+  })
+
+  it('surfaces very malformed restriction header fragments individually after comma splitting', () => {
+    const sources = collectServerRestrictionSources({}, new Headers({
+      [RESTRICTION_HEADER]: 'GET,:/i**, *:,/',
+    }))
+
+    expect(sources).toEqual([
+      'GET',
+      ':/i**',
+      '*:',
+      '/',
+    ])
+
+    expect(parseRestrictionRule(sources)).toEqual({
+      parsedRules: [
+        { type: 'deny', method: '*', pathPattern: '/', source: '/' },
+      ],
+      failedRules: [
+        { rule: 'GET', reason: 'Restriction path pattern must start with "/".' },
+        { rule: ':/i**', reason: 'Restriction path pattern must start with "/".' },
+        { rule: '*:', reason: 'Restriction path pattern must not be empty.' },
+      ],
+    })
+  })
+
   it('collects allow rules from query aliases and trims comma-separated header values', () => {
     const headers = new Headers()
     headers.append(ALLOW_HEADER, ' /inventory/** ')
@@ -155,6 +213,64 @@ describe('server access policy input collection', () => {
       '/inventory/**',
       'POST:/alarm/**',
     ])
+  })
+
+  it('ignores empty allow header entries created by leading, trailing, or repeated commas', () => {
+    const headers = new Headers()
+    headers.append(ALLOW_HEADER, ', /inventory/** ,, POST:/alarm/** ,')
+    headers.append(ALLOW_HEADER, ' , , GET:/measurement/**')
+
+    expect(collectServerAllowSources({}, headers)).toEqual([
+      '/inventory/**',
+      'POST:/alarm/**',
+      'GET:/measurement/**',
+    ])
+  })
+
+  it('treats commas inside an allow rule as separators, so malformed fragments fail parsing independently', () => {
+    const sources = collectServerAllowSources({}, new Headers({
+      [ALLOW_HEADER]: 'POST, /inventory/**, GET:/alarm/**',
+    }))
+
+    expect(sources).toEqual([
+      'POST',
+      '/inventory/**',
+      'GET:/alarm/**',
+    ])
+
+    expect(parseAllowRule(sources)).toEqual({
+      parsedRules: [
+        { type: 'allow', method: '*', pathPattern: '/inventory/**', source: '/inventory/**' },
+        { type: 'allow', method: 'GET', pathPattern: '/alarm/**', source: 'GET:/alarm/**' },
+      ],
+      failedRules: [
+        { rule: 'POST', reason: 'Allow path pattern must start with "/".' },
+      ],
+    })
+  })
+
+  it('surfaces very malformed allow header fragments individually after comma splitting', () => {
+    const sources = collectServerAllowSources({}, new Headers({
+      [ALLOW_HEADER]: 'GET,:/i**, *:,/',
+    }))
+
+    expect(sources).toEqual([
+      'GET',
+      ':/i**',
+      '*:',
+      '/',
+    ])
+
+    expect(parseAllowRule(sources)).toEqual({
+      parsedRules: [
+        { type: 'allow', method: '*', pathPattern: '/', source: '/' },
+      ],
+      failedRules: [
+        { rule: 'GET', reason: 'Allow path pattern must start with "/".' },
+        { rule: ':/i**', reason: 'Allow path pattern must start with "/".' },
+        { rule: '*:', reason: 'Allow path pattern must not be empty.' },
+      ],
+    })
   })
 })
 

--- a/test/restrictions.test.ts
+++ b/test/restrictions.test.ts
@@ -3,7 +3,14 @@ import { NodeRuntime, createNodeDriver, createNodeRuntimeDriverFactory } from 's
 import { describe, expect, it } from 'vitest'
 import { createNetworkPermissionDecision } from '../src/codemode/network-permissions'
 import { findBlockingRestrictions, findMatchingRules } from '../src/utils/restriction-matcher'
-import { parseAllowRule, parseRestrictionRule } from '../src/utils/restrictions'
+import {
+  ALLOW_HEADER,
+  RESTRICTION_HEADER,
+  collectServerAllowSources,
+  collectServerRestrictionSources,
+  parseAllowRule,
+  parseRestrictionRule,
+} from '../src/utils/restrictions'
 
 function parseSingleRule(input: string) {
   const result = parseRestrictionRule([input])
@@ -112,6 +119,42 @@ describe('allow parsing', () => {
         { rule: '', reason: 'Allow value must not be empty.' },
       ],
     })
+  })
+})
+
+describe('server access policy input collection', () => {
+  it('collects restriction rules from query aliases and the project-scoped header', () => {
+    const headers = new Headers({
+      [RESTRICTION_HEADER]: 'DELETE:/alarm/**, /event/**',
+    })
+
+    expect(collectServerRestrictionSources({
+      restriction: '/inventory/**',
+      restrict: ['GET:/measurement/**'],
+      r: '',
+    }, headers)).toEqual([
+      '/inventory/**',
+      'GET:/measurement/**',
+      'DELETE:/alarm/**',
+      '/event/**',
+    ])
+  })
+
+  it('collects allow rules from query aliases and trims comma-separated header values', () => {
+    const headers = new Headers()
+    headers.append(ALLOW_HEADER, ' /inventory/** ')
+    headers.append(ALLOW_HEADER, 'POST:/alarm/**,   ')
+
+    expect(collectServerAllowSources({
+      allowed: ['GET:/devicecontrol/**'],
+      allow: '/measurement/**',
+      a: undefined,
+    }, headers)).toEqual([
+      'GET:/devicecontrol/**',
+      '/measurement/**',
+      '/inventory/**',
+      'POST:/alarm/**',
+    ])
   })
 })
 


### PR DESCRIPTION
## Summary
- accept project-scoped `mc8yp-restriction` and `mc8yp-allow` headers in microservice mode alongside the existing query parameters
- document repeated and comma-separated header values for access-policy transport
- add edge-case tests covering malformed comma placement and malformed header fragments
- clarify `AGENTS.md` guidance so PR requests default to the current feature branch against `main` unless the user says otherwise

## Validation
- pnpm test:run
- pnpm lint:fix
- pnpm typecheck
