### PR TITLE
fix(cli): mask password entry in creds add

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ src/core-openapi.d.ts         Ambient type declarations for the `#core-openapi` 
 3. It sets `globalThis.executionEnvironment = 'cli'`.
 4. It exposes credential lookup helpers on `globalThis` for tools and subcommands.
 5. It starts the shared MCP server over stdio transport.
+6. `creds add` uses `@clack/prompts` so password entry is masked instead of echoed through the terminal prompt.
 
 #### Microservice mode
 
@@ -258,6 +259,7 @@ This section captures project-specific knowledge, tool quirks, and lessons learn
 - `secure-exec` is the execution boundary for both `query` and `execute`.
 - `tsdown` produces separate server and CLI bundles.
 - `@napi-rs/keyring` is used for local(cli) credential storage.
+- `@clack/prompts` is used for interactive CLI credential entry so password input is masked.
 - `secure-exec` must stay external in server builds. Bundling it into the microservice server output pulls in `node-stdlib-browser` resolution code and can crash at startup with `Cannot find module 'assert/'`.
 
 ### Patterns & Conventions

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ mc8yp
 ```
 
 **Credential Storage:**
-Credentials are stored using your operating system's secure credential manager:
+Credentials are stored using your operating system's secure credential manager. The interactive `mc8yp creds add` flow uses hidden password input so the secret is not echoed back in the terminal while you type it.
 
 - **macOS**: Keychain
 - **Windows**: Credential Vault
@@ -50,7 +50,7 @@ No additional credential configuration needed — the microservice uses Cumuloci
 ### Managing Credentials (CLI)
 
 ```sh
-# Add credentials (prompts for tenant URL, username, password)
+# Add credentials (prompts for tenant URL, username, and a masked password)
 pnpm dlx mc8yp creds add
 
 # List stored credentials

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@c8y/client": "catalog:",
+    "@clack/prompts": "catalog:",
     "@napi-rs/keyring": "catalog:",
     "@tmcp/adapter-valibot": "catalog:",
     "@tmcp/transport-http": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@c8y/client':
       specifier: ^1023.68.7
       version: 1023.70.0
+    '@clack/prompts':
+      specifier: ^1.3.0
+      version: 1.3.0
     '@napi-rs/keyring':
       specifier: ^1.2.0
       version: 1.2.0
@@ -80,6 +83,9 @@ importers:
       '@c8y/client':
         specifier: 'catalog:'
         version: 1023.70.0
+      '@clack/prompts':
+        specifier: 'catalog:'
+        version: 1.3.0
       '@napi-rs/keyring':
         specifier: 'catalog:'
         version: 1.2.0
@@ -340,6 +346,14 @@ packages:
     resolution: {integrity: sha512-dI+9P7cfWxkTQ+oE+7Aa6onEn92PHgfWXZivjNheCRmTBDBf2fx6RyTi0cmgpYLnD1KLZK9ZYrMxaPZ4oiXhGA==}
     cpu: [x64]
     os: [win32]
+
+  '@clack/core@1.3.0':
+    resolution: {integrity: sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.3.0':
+    resolution: {integrity: sha512-GgcWwRCs/xPtaqlMy8qRhPnZf9vlWcWZNHAitnVQ3yk7JmSralSiq5q07yaffYE8SogtDm7zFeKccx1QNVARpw==}
+    engines: {node: '>= 20.12.0'}
 
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
@@ -2205,8 +2219,17 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-wrap-ansi@0.2.0:
+    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
   fault@2.0.1:
     resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
@@ -3582,6 +3605,9 @@ packages:
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
@@ -4413,6 +4439,18 @@ snapshots:
 
   '@cbor-extract/cbor-extract-win32-x64@2.2.2':
     optional: true
+
+  '@clack/core@1.3.0':
+    dependencies:
+      fast-wrap-ansi: 0.2.0
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.3.0':
+    dependencies:
+      '@clack/core': 1.3.0
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.0
+      sisteransi: 1.0.5
 
   '@emnapi/core@1.9.2':
     dependencies:
@@ -6500,7 +6538,17 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.0: {}
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fault@2.0.1:
     dependencies:
@@ -8140,6 +8188,8 @@ snapshots:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
+
+  sisteransi@1.0.5: {}
 
   slice-ansi@7.1.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,7 @@ trustPolicyExclude:
 
 catalog:
   '@c8y/client': ^1023.68.7
+  '@clack/prompts': ^1.3.0
   '@napi-rs/keyring': ^1.2.0
   '@schplitt/eslint-config': ^1.4.0
   '@tmcp/adapter-valibot': ^0.1.5

--- a/src/cli/subcommands/subcommands/add.ts
+++ b/src/cli/subcommands/subcommands/add.ts
@@ -1,6 +1,7 @@
 import type { CommandDef } from 'citty'
 import type { UserC8yAuth } from '../../../utils/credentials'
 import { exit } from 'node:process'
+import { cancel, isCancel, password } from '@clack/prompts'
 import { defineCommand } from 'citty'
 import consola from 'consola'
 import * as v from 'valibot'
@@ -26,10 +27,22 @@ const command: CommandDef = defineCommand({
         cancel: 'reject',
       })
 
-      const password = await consola.prompt('Password:', {
-        type: 'text',
-        cancel: 'reject',
+      const passwordPrompt = await password({
+        message: 'Password:',
+        clearOnError: true,
+        validate: (value) => {
+          if (!value) {
+            return 'Password is required.'
+          }
+
+          return undefined
+        },
       })
+
+      if (isCancel(passwordPrompt)) {
+        cancel('Cancelled.')
+        exit()
+      }
 
       // Check if credentials with same tenant URL already exist
       const existingCreds = await getStoredC8yAuth()
@@ -51,7 +64,7 @@ const command: CommandDef = defineCommand({
       await setStoredC8yAuth({
         tenantUrl,
         user,
-        password,
+        password: passwordPrompt,
       })
 
       consola.success('Credentials saved successfully!')


### PR DESCRIPTION
## Summary
- switch only the `creds add` password prompt to `@clack/prompts.password`
- keep the existing `consola` prompts for tenant URL, username, and overwrite confirmation
- document the masked password behavior in `README.md` and `AGENTS.md`

## Testing
- pnpm test:run
- pnpm lint:fix
- pnpm typecheck