### PR TITLE
fix: clarify query tool bindings are scope-level constants, not function params

### DIFF
--- a/src/prompts/codemode.ts
+++ b/src/prompts/codemode.ts
@@ -40,8 +40,9 @@ You have exactly two MCP tools available.
 ## query
 Use \`query\` when you need to inspect the bundled OpenAPI specs.
 
-- Input: a JavaScript function expression
-- The top-level bindings \`coreSpec\`, \`dtmSpec\`, and \`specsEnabled\` are available automatically
+- Input: a **zero-parameter** JavaScript function expression
+- Do NOT declare \`coreSpec\`, \`dtmSpec\`, or \`specsEnabled\` as function parameters — they are already declared as top-level constants in the surrounding scope. Writing \`(dtmSpec) => ...\` would shadow the global with an undefined parameter and produce incorrect results
+- The top-level bindings \`coreSpec\`, \`dtmSpec\`, and \`specsEnabled\` are available automatically inside the function body
 - \`coreSpec\` is for the main Cumulocity REST surface such as inventory, alarms, events, measurements, identity, device control, users, tenants, audit, and the broader platform APIs
 - \`dtmSpec\` is for Digital Twin Manager work such as schema definitions, asset models, linked series, and DTM asset or definition APIs
 - Return the exact value you want back from that function
@@ -51,6 +52,9 @@ Use \`query\` when you need to inspect the bundled OpenAPI specs.
 - The current MCP connection may still block \`execute\` requests through deny rules and/or an allow list even when an operation exists in a visible spec
 
 ### Available Shape
+
+The function must accept **no parameters**. The bindings below are scope-level constants, not function arguments.
+
 \`\`\`ts
 type OperationInfo = {
   summary?: string
@@ -87,7 +91,7 @@ declare const dtmSpec: DtmSpec
 declare const specsEnabled: SpecsEnabled
 \`\`\`
 
-Examples:
+Examples (all zero-parameter — note no arguments in the arrow function signatures):
 \`\`\`js
 () => specsEnabled
 \`\`\`
@@ -98,6 +102,7 @@ Examples:
 
 \`\`\`js
 () => {
+  // dtmSpec is already in scope — do NOT write (dtmSpec) => { ... }
   const op = dtmSpec.paths['/assets']?.get
   return op?.parameters
 }

--- a/src/tools/codemode.ts
+++ b/src/tools/codemode.ts
@@ -78,7 +78,9 @@ declare const coreSpec: CoreSpec
 declare const dtmSpec: DtmSpec
 declare const specsEnabled: SpecsEnabled
 
-Your code must evaluate to a function. The top-level bindings \
+Your code must evaluate to a **zero-parameter** function — do NOT declare \`coreSpec\`, \`dtmSpec\`, or \`specsEnabled\` as function parameters. These are already declared as constants in the surrounding scope and are available inside the function body without any argument passing. Writing \`(dtmSpec) => ...\` would shadow the global binding with an undefined parameter and produce incorrect results.
+
+The top-level bindings \
 
 a) \`coreSpec\` — use this for the main Cumulocity REST APIs such as inventory, alarms, events, measurements, identity, device control, users, tenants, audit, and the broader platform REST surface
 \nb) \`dtmSpec\` — use this for Digital Twin Manager work such as schema definitions, asset models, linked series, and DTM asset or definition APIs
@@ -86,7 +88,7 @@ a) \`coreSpec\` — use this for the main Cumulocity REST APIs such as inventory
 
 are available automatically. The sandbox assigns your function to a local variable, invokes it, and returns its result.
 
-Recommended shapes:
+Recommended shapes (zero parameters — bindings come from scope, not arguments):
 \`(() => { ... })\`
 \`async () => { ... }\`
 
@@ -122,7 +124,7 @@ Examples:
 }
 `,
     schema: v.object({
-      code: createCodeSchema('A JavaScript function expression. The top-level bindings `coreSpec`, `dtmSpec`, and `specsEnabled` are available automatically. Return the final result from that function. Async functions are supported.'),
+      code: createCodeSchema('A zero-parameter JavaScript function expression. Do NOT declare `coreSpec`, `dtmSpec`, or `specsEnabled` as function parameters — they are already declared as top-level constants in the surrounding scope and are available in the function body automatically. Writing `(dtmSpec) => ...` would shadow the global binding with an undefined parameter and produce incorrect results. Return the final result from that function. Async functions are supported.'),
     }),
   }, async (input) => {
     try {


### PR DESCRIPTION
## Problem

When an agent wrote `(dtmSpec) => { ... }` as the `query` code, the function parameter shadowed the outer `const dtmSpec` declared by the sandbox, causing it to receive `undefined`. The tool and prompt descriptions never explicitly stated that the function must take **no parameters** and that `coreSpec`, `dtmSpec`, and `specsEnabled` are scope-level constants rather than injected arguments.

## Changes

**`src/tools/codemode.ts`**
- Tool description now opens with a "zero-parameter function" statement and explicitly names `(dtmSpec) => ...` as the wrong pattern, explaining the shadowing consequence.
- "Recommended shapes" label now says *(zero parameters — bindings come from scope, not arguments)*.
- The `code` schema description now starts with "A zero-parameter JavaScript function expression. Do NOT declare …" and repeats the shadowing warning.

**`src/prompts/codemode.ts`**
- Query bullet list now says "zero-parameter" and includes a dedicated don't-do-this bullet with the shadowing consequence.
- "Available Shape" section now has a prose note: *"The function must accept no parameters. The bindings below are scope-level constants, not function arguments."*
- Examples header says *(all zero-parameter — note no arguments in the arrow function signatures)* and the `dtmSpec` example has an inline comment: `// dtmSpec is already in scope — do NOT write (dtmSpec) => { ... }`.