### PR TITLE
fix: rewrite dtm spec paths to include /service/dtm prefix at build time

### DIFF
--- a/openapi-builds.json
+++ b/openapi-builds.json
@@ -28,6 +28,7 @@
         "version": "release",
         "label": "release (latest)",
         "url": "https://cumulocity.com/api/dtm/dist/c8y-dtm-oas.json",
+        "servicePrefix": "/service/dtm",
         "default": true
       }
     ]

--- a/test/excute.test.ts
+++ b/test/excute.test.ts
@@ -373,7 +373,7 @@ describe('buildExecuteScript', () => {
       'installFetchTrap();',
       'return await cumulocity.request({',
       '  method: "GET",',
-      '  path: "/assets?pageSize=5",',
+      '  path: "/service/dtm/assets?pageSize=5",',
       '});',
       '}',
     ].join('\n'), generatedRestrictions, [], { Authorization: 'Bearer test' }, ['dtm'])
@@ -395,9 +395,9 @@ describe('buildExecuteScript', () => {
       '',
       'Blocked operation:',
       'Method: GET',
-      'Path: /assets',
+      'Path: /service/dtm/assets',
       'Matching restrictions:',
-      '- GET:/assets',
+      '- GET:/service/dtm/assets',
     ].join('\n')))
   })
 
@@ -467,10 +467,10 @@ describe('buildExecuteScript', () => {
       'installFetchTrap();',
       'return await cumulocity.request({',
       '  method: "GET",',
-      '  path: "/assets?pageSize=5",',
+      '  path: "/service/dtm/assets?pageSize=5",',
       '});',
       '}',
-    ].join('\n'), generatedRestrictions, [parseSingleAllowRule('GET:/assets')], { Authorization: 'Bearer test' }, ['dtm'])
+    ].join('\n'), generatedRestrictions, [parseSingleAllowRule('GET:/service/dtm/assets')], { Authorization: 'Bearer test' }, ['dtm'])
 
     expect(result.called).toBe(false)
     expect(result.result).toEqual(expectedBlockedResult([
@@ -489,9 +489,9 @@ describe('buildExecuteScript', () => {
       '',
       'Blocked operation:',
       'Method: GET',
-      'Path: /assets',
+      'Path: /service/dtm/assets',
       'Matching restrictions:',
-      '- GET:/assets',
+      '- GET:/service/dtm/assets',
     ].join('\n')))
   })
 

--- a/test/restrictions.test.ts
+++ b/test/restrictions.test.ts
@@ -448,7 +448,7 @@ describe('network permission decisions', () => {
       op: 'connect',
       hostname: 'tenant.example.com',
       method: 'GET',
-      url: 'https://tenant.example.com/assets?pageSize=5',
+      url: 'https://tenant.example.com/service/dtm/assets?pageSize=5',
     }, createOpenApiPartRestrictionRules(['dtm']))).toEqual({
       allow: false,
       reason: expect.stringContaining('Network connect blocked by MCP restrictions:'),

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -36,6 +36,7 @@ interface OpenApiSourceEntry {
   version: string
   label: string
   url: string
+  servicePrefix?: string
   default?: boolean
 }
 
@@ -62,8 +63,31 @@ function getSourceConfig(api: OpenApiModuleName, version: string): OpenApiSource
   return entry
 }
 
+function rewriteSpecPaths(specJson: string, servicePrefix: string): string {
+  const spec = JSON.parse(specJson) as {
+    paths?: Record<string, unknown>
+    servers?: Array<{ url: string, description?: string }>
+  }
+  if (spec.paths) {
+    const rewritten: Record<string, unknown> = {}
+    for (const [p, item] of Object.entries(spec.paths)) {
+      rewritten[`${servicePrefix}${p}`] = item
+    }
+    spec.paths = rewritten
+  }
+  if (spec.servers) {
+    spec.servers = spec.servers.map((server) => ({
+      ...server,
+      url: server.url.replace('<TENANT_DOMAIN>', `<TENANT_DOMAIN>${servicePrefix}`),
+    }))
+  }
+  return JSON.stringify(spec)
+}
+
 function readSpecJson(api: OpenApiModuleName, version: string): string {
-  return readFileSync(path.join(rootDir, 'openapi', api, `${version}.json`), 'utf8').trim()
+  const raw = readFileSync(path.join(rootDir, 'openapi', api, `${version}.json`), 'utf8').trim()
+  const source = getSourceConfig(api, version)
+  return source.servicePrefix ? rewriteSpecPaths(raw, source.servicePrefix) : raw
 }
 
 function generateEntries(api: OpenApiModuleName, versions: readonly string[]): string {


### PR DESCRIPTION
DTM OpenAPI spec paths are relative to the service root (e.g. /assets, /definitions/properties) but the actual Cumulocity endpoints live at /service/dtm/.... Without the prefix the agent would attempt requests against non-existent tenant-root paths and always get 404s.

Add servicePrefix to openapi-builds.json DTM source entries. In tsdown.config.ts, rewriteSpecPaths() rewrites every spec path key and the servers[0].url placeholder at bundle time when a servicePrefix is configured. The core spec has no prefix and is unchanged.

BUNDLED_OPENAPI_OPERATIONS now generates /service/dtm/... patterns so createOpenApiPartRestrictionRules correctly blocks DTM endpoints when DTM is disabled. Update tests to match the new canonical paths.