### PR TITLE
feat: bundle DTM (and any future service spec) generically

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,14 +66,15 @@ openapi/
     2026.json                Bundled 2026 Cumulocity core OpenAPI snapshot
     2025.json                Bundled 2025 Cumulocity core OpenAPI snapshot
     2024.json                Bundled 2024 Cumulocity core OpenAPI snapshot
-  dtm/
-    release.json             Bundled latest Cumulocity DTM OpenAPI snapshot
-openapi-builds.json           Build matrix plus download URLs for bundled OpenAPI sources
+  services/
+    dtm.json                 Bundled Digital Twin Manager spec (one file per service)
+openapi-builds.json           Single source of truth: core versions, bundled services, build matrix
 scripts/
   cumulocity.mjs             Updates cumulocity.json metadata from package.json
+  update-openapi.mjs         Fetches all bundled OpenAPI specs from upstream
   package-microservices.mjs  Builds versioned Docker-based Cumulocity release zips
-tsdown.config.ts              CLI/server build configuration plus the `#core-openapi` and `#dtm-openapi` virtual module plugins
-src/openapi-modules.d.ts      Ambient type declarations for both the `#core-openapi` and `#dtm-openapi` virtual modules
+tsdown.config.ts              CLI/server build config + two virtual module plugins: `#core-openapi` (versioned, switchable) and `#bundled-services` (generic, derived from openapi-builds.json#services)
+src/openapi-modules.d.ts      Ambient type declarations for the virtual modules
 ```
 
 ### Runtime Flow
@@ -98,7 +99,7 @@ src/openapi-modules.d.ts      Ambient type declarations for both the `#core-open
 #### Shared MCP surface
 
 - `src/server.ts` creates the MCP server, registers tools and prompts, and conditionally enables `list-credentials` only in CLI mode.
-- `openapi/core/` and `openapi/dtm/` contain the bundled OpenAPI snapshots consumed by the build.
+- `openapi/core/` holds versioned core snapshots; `openapi/services/` holds one snapshot per bundled microservice (e.g. `dtm.json`).
 - `src/tools/codemode.ts` defines the `query` and `execute` tools.
 - `src/prompts/codemode.ts` defines the `code-mode-guide` prompt.
 
@@ -114,24 +115,24 @@ src/openapi-modules.d.ts      Ambient type declarations for both the `#core-open
 
 ### Bundled OpenAPI Selection
 
-- Consumers import from the virtual modules `#core-openapi` and `#dtm-openapi`.
+- Consumers import from two virtual modules: `#core-openapi` (versioned, switchable in CLI mode) and `#bundled-services` (generic, exports `BUNDLED_SERVICE_SPECS: DiscoveredApiSpec[]` synthesised from every entry under `openapi-builds.json#services`).
 - Both modules use the same module-local interface shape: `specs`, one active `get...Spec()`, one active `get...Version()`, one `set...Version()`, and one `get...Label()`.
 - The module bodies are synthesized by small tsdown plugins in `tsdown.config.ts`:
   - For the CLI build the core plugin inlines all `openapi/core/*.json` snapshots and `setCoreOpenApiVersion` switches between them at runtime.
-  - For the CLI build the DTM plugin currently inlines the bundled `openapi/dtm/release.json` snapshot.
-  - For each server build, the plugins inline exactly the configured core+DTM combination for that build.
+  - The `#bundled-services` plugin reads every `openapi/services/<key>.json` and emits them in the same `DiscoveredApiSpec` shape that live discovery produces (paths already prefixed with `servicePrefix` at build time). Identical content in CLI and server builds — bundled services have no version axis.
+  - For each server build, the core plugin inlines only the configured core version; bundled services are always inlined as-is.
 - Types for both virtual modules live together in `src/openapi-modules.d.ts`; no `tsconfig.paths` entry is needed.
 - `openapi-builds.json` is the source of truth for both the download URLs used by `scripts/update-openapi.mjs` and the server build/package matrix used by `tsdown.config.ts` and `scripts/package-microservices.mjs`.
 - `tsdown.config.ts` emits one server bundle per supported build version into `.output/<version>/`.
-- `scripts/package-microservices.mjs` turns those built server outputs into one Docker-based zip per build, for example `mc8yp-core-2026-dtm-v2.x.x.zip`.
+- `scripts/package-microservices.mjs` turns those built server outputs into one Docker-based zip per build. The artifact name is computed: `core-<coreVersion>` plus each bundled service key (sorted) appended, e.g. `mc8yp-core-2026-dtm-v2.x.x.zip`.
 - The packaging script writes a temporary generated Dockerfile under `.c8y/`, builds from the repository root, copies the selected `.output/<version>/` bundle into `/app/server/`, and installs production dependencies inside the Linux image with pnpm before copying them into the runtime stage.
 - The packaging script builds Docker images for `linux/amd64` by default so release zips created on Apple Silicon remain deployable in typical Cumulocity environments; override with `DOCKER_PLATFORM` only when you intentionally need a different target.
 
 ### Query vs Execute
 
 - `query` expects a JavaScript function expression and returns strings directly or other values as JSON text.
-- `query` injects three deterministic top-level bindings into the sandbox: `coreSpec`, `dtmSpec`, and `specsEnabled`.
-- `coreSpec` is the main Cumulocity REST surface, `dtmSpec` is the Digital Twin Manager surface, and `specsEnabled` reports which spec families are enabled for execute policy.
+- `query` injects three top-level bindings into the sandbox: `coreSpec`, `specsEnabled`, and `serviceSpecs`. `core` is the only spec with a named binding — everything else (bundled service specs like DTM and live-discovered services) lives in `serviceSpecs` keyed by contextPath.
+- `specsEnabled` reports per-bundled-service availability on the current tenant. `specsEnabled.dtm === false` means execute calls to `/service/dtm/**` will be blocked by auto-restriction (even when `--no-spec-removal` keeps the bundled spec visible for reference).
 - `execute` expects a JavaScript function expression and returns successful results in Toon format.
 - Visible operations remain raw OpenAPI data; blocked live requests fail before network access.
 
@@ -198,7 +199,7 @@ pnpm prerelease    # lint + typecheck + build
 - `tsdown.config.ts` builds the CLI bundle into `dist/`
 - Server bundles intentionally keep runtime dependencies external.
 - Release zip artifacts are created in the repository root by `pnpm package:microservices`
-- `pnpm package:microservices` names artifacts from the bundled API combination, for example `mc8yp-core-2026-dtm-v2.x.x.zip`.
+- `pnpm package:microservices` computes artifact names from each build's `core` version plus every entry in `openapi-builds.json#services` (sorted), e.g. `mc8yp-core-2026-dtm-v2.x.x.zip`.
 - `pnpm package:microservices` uses a temporary `.c8y/` staging directory, deletes old root `*.zip` artifacts before creating fresh ones, installs production dependencies inside a Linux Docker build so platform-specific optional native packages resolve correctly, and builds `linux/amd64` images unless `DOCKER_PLATFORM` is set explicitly.
 
 ## Code Style And Conventions
@@ -214,8 +215,8 @@ pnpm prerelease    # lint + typecheck + build
 ### Practical editing guidance
 
 - If a change affects tool behavior, inspect both the tool definition and the codemode runtime.
-- If a change affects bundled OpenAPI selection, update the `#core-openapi` / `#dtm-openapi` plugins in `tsdown.config.ts`, the ambient declarations in `src/openapi-modules.d.ts`, and the source/build matrix in `openapi-builds.json`.
-- If you add a new bundled OpenAPI spec in the future: add `openapi/<name>/...` files, add a virtual module in `tsdown.config.ts` + its declaration in `src/openapi-modules.d.ts`, add one entry to `BUNDLED_SPEC_REGISTRY` in `src/utils/openapi.ts` with `contextPath`/`servicePrefix` if it is service-backed. That is all — `resolveAvailableSpecs`, `resolveServiceSpecs`, `buildQueryScript`, and the auto-restriction logic all handle new entries generically without further changes.
+- If a change affects bundled OpenAPI selection or the core build matrix, update `openapi-builds.json` and the `#core-openapi` plugin in `tsdown.config.ts` only. Service-backed bundled specs do not need plugin or registry edits.
+- **Adding a new bundled service spec:** drop the JSON at `openapi/services/<key>.json` (or wait for the nightly action), then add **one** entry to `openapi-builds.json#services`: `{ key, label, url, servicePrefix }`. That is all. The `#bundled-services` plugin loops services generically, `resolveSpecs` handles the A/B/C resolution against discovery, and auto-restrictions fire automatically when the service is absent. **No code changes anywhere in `src/`.**
 - If a change affects restrictions or allow rules, verify both policy messaging and live request blocking.
 - If a change affects auth, verify the CLI and server paths separately.
 - If a change affects public MCP behavior, update `README.md` as well as this file.
@@ -253,7 +254,7 @@ When working on this project:
 1. Start from the actual controlling surface. For most feature work that is `src/tools/`, `src/prompts/`, `src/codemode/execute.ts`, or restriction/auth utilities.
 2. Treat CLI mode and microservice mode as separate execution environments with different auth and tool availability.
 3. Run focused tests first when changing a narrow subsystem, then run the full validation set if the change is broader. Use this exact validation order: `pnpm test:run`, then `pnpm lint:fix`, then `pnpm typecheck`.
-4. The `query` sandbox receives pre-resolved `availableSpecs` (from `resolveAvailableSpecs`) and `serviceSpecs` (from `resolveServiceSpecs`). In server mode these are computed per-request by the H3 handler. In CLI mode they are computed per tool call by `resolveQueryContext` in `src/tools/codemode.ts`. `buildQueryScript` is pure injection — no resolution logic belongs there.
+4. The `query` sandbox receives pre-resolved `specs` and `specsEnabled` from `resolveSpecs` in `src/utils/spec-resolution.ts`. Server mode computes these per-request in the H3 handler. CLI mode computes them in `setCliTenantContext` (CLI singleton) when the active tenant is set or switched. `buildQueryScript` is pure injection — no resolution logic belongs in `src/codemode/execute.ts`.
 5. Keep public MCP tool and prompt descriptions aligned with actual runtime behavior.
 6. Preserve the current sandbox limits and request boundary logic unless the task explicitly changes them.
 7. Record recurring project-specific lessons in the section below when they are likely to prevent future mistakes.
@@ -279,7 +280,7 @@ This section captures project-specific knowledge, tool quirks, and lessons learn
 
 - `execute` uses a generated ESM module entry and reads the default export from sandbox execution.
 - `query` and `execute` accept function-expression style code and normalize fenced code input before evaluation.
-- `#core-openapi` and `#dtm-openapi` are virtual modules synthesized by tsdown plugins; consumers must not import the JSON snapshots directly.
+- `#core-openapi` and `#bundled-services` are virtual modules synthesised by tsdown plugins; consumers must not import the JSON snapshots directly. `#core-openapi` is the only versioned/switchable spec module; every other bundled spec flows generically through `#bundled-services` in the same `DiscoveredApiSpec` shape as live discovery.
 - The CLI build inlines all bundled core snapshots plus the bundled DTM snapshot; each server build inlines exactly the configured combination for that build.
 - Server builds should not use `noExternal: [/^.*$/]`. The microservice bundle is allowed to depend on runtime `node_modules`, and the release image must install those dependencies inside the Linux image rather than copying host `node_modules` from macOS.
 - `scripts/package-microservices.mjs` intentionally targets `linux/amd64` by default to avoid Apple Silicon release images failing with `exec format error` in Cumulocity.

--- a/README.md
+++ b/README.md
@@ -223,11 +223,12 @@ This only changes the bundled OpenAPI data that `query` sees. The `execute` tool
 
 ### Tools
 
-| Tool               | Description                                                                                                                                                                                                                                        |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `query`            | Search and inspect the bundled OpenAPI specs by running a JavaScript function expression. The sandbox exposes `coreSpec`, `dtmSpec`, and `specsEnabled`, and it never hides bundled specs from the query surface.                                  |
-| `execute`          | Execute JavaScript against the live Cumulocity API. Provide an async JavaScript function expression. A top-level `cumulocity` binding provides `cumulocity.request({ method, path, body?, headers? })`. Return the final value from that function. |
-| `list-credentials` | _(CLI mode only)_ List stored credentials from your system keyring.                                                                                                                                                                                |
+| Tool                | Description                                                                                                                                                                                                                                                                                                                                    |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `query`             | Search and inspect bundled and live-discovered OpenAPI specs by running a JavaScript function expression. The sandbox exposes `coreSpec` (always), `specsEnabled` (per-service availability on the tenant), and `serviceSpecs` (bundled service specs like Digital Twin Manager plus any live-discovered microservices, keyed by contextPath). |
+| `execute`           | Execute JavaScript against the live Cumulocity API. Provide an async JavaScript function expression. A top-level `cumulocity` binding provides `cumulocity.request({ method, path, body?, headers? })`. Return the final value from that function.                                                                                             |
+| `list-credentials`  | _(CLI mode only)_ List stored credentials from your system keyring.                                                                                                                                                                                                                                                                            |
+| `set-active-tenant` | _(CLI mode only)_ Select which stored tenant `query` and `execute` operate against. Persists to `~/.config/mc8yp/active-tenant.json` so the selection survives restarts.                                                                                                                                                                       |
 
 Both code-mode tools run in a sandboxed runtime ([secure-exec](https://github.com/nicepkg/secure-exec)).
 
@@ -382,26 +383,16 @@ mc8yp --allow "GET:/inventory/**" --allowed "POST:/alarm/**"
 mc8yp -a "/inventory/**" -r "/inventory/managedObjects"
 ```
 
-To forbid one or more bundled OpenAPI parts for execute policy, repeat `--disable-openapi` (or `-d`) in CLI mode. `query` still sees all bundled specs and can inspect `specsEnabled` to understand which spec families remain enabled for execute policy:
-
-```sh
-# Disable bundled DTM APIs for execute policy on this CLI connection
-mc8yp -d dtm
-
-# Disable multiple bundled specs if more are added in the future
-mc8yp -d dtm -d core
-```
+By default, bundled service specs for services **not** installed on the current tenant are removed from the `query` sandbox and `execute` is automatically restricted from calling their routes. Pass `--no-spec-removal` in CLI mode to keep the bundled spec visible in `query` for reference (execute restrictions still apply). `specsEnabled` always reflects what's actually callable.
 
 ### Microservice Mode (HTTP)
 
 Pass restrictions as `restriction`, `restrict`, or `r` query parameters on the MCP endpoint URL.
 Pass allow rules as `allowed`, `allow`, or `a` query parameters.
-To forbid bundled OpenAPI parts for execute policy, pass the `openapi-disabled` query parameter.
 You can also send project-scoped HTTP headers to avoid conflicts with well-known headers:
 
 - `mc8yp-restriction` for deny rules
 - `mc8yp-allow` for allow-list rules
-- `mc8yp-openapi-disabled` for bundled OpenAPI part disablement
 
 Both headers accept either repeated header instances or a comma-separated list of values. Query parameters and headers can be combined on the same connection.
 
@@ -409,8 +400,6 @@ Both headers accept either repeated header instances or a comma-separated list o
 /mcp?restriction=/inventory/**&restrict=DELETE:/alarm/**
 /mcp?r=/inventory/**&r=DELETE:/alarm/**
 /mcp?allow=/inventory/**&allowed=POST:/alarm/**
-/mcp?openapi-disabled=dtm
-/mcp?openapi-disabled=dtm&openapi-disabled=core
 ```
 
 ```http
@@ -419,16 +408,15 @@ Authorization: Bearer <token>
 mc8yp-restriction: /inventory/**
 mc8yp-restriction: DELETE:/alarm/**
 mc8yp-allow: GET:/measurement/**
-mc8yp-openapi-disabled: dtm
 ```
 
 ### How Access Policy Works
 
-1. **Query visibility**: The `query` tool exposes the raw bundled OpenAPI specs for the current MCP connection. Bundled specs are not hidden or rewritten, and the query sandbox exposes `specsEnabled` so the model can see which spec families are enabled for execute policy.
+1. **Query visibility**: `query` exposes `coreSpec` (always), `serviceSpecs` keyed by contextPath (bundled service specs like DTM plus any live-discovered services), and `specsEnabled` (per-service installation flag on the current tenant). Live discovery overrides bundled specs per contextPath when both exist.
 
-2. **Sandbox request enforcement**: The `execute` tool checks restrictions and allow rules inside the generated sandbox request helper, where the actual HTTP method and normalized path are both available. Matching deny rules block first. If any allow rules are configured, requests must also match at least one allow rule.
+2. **Sandbox request enforcement**: `execute` checks restrictions and allow rules inside the generated sandbox request helper, where the HTTP method and normalised path are both known. Matching deny rules block first. If any allow rules are configured, requests must also match at least one.
 
-3. **Bundled spec disablement**: When the connection disables bundled OpenAPI parts such as `dtm`, `query` still shows all bundled specs, while the server expands that selection into additional restrictions so `execute` stays path-and-method based.
+3. **Auto-restriction for absent services**: When live discovery confirms a bundled service is not installed on the tenant, `*:/service/<contextPath>/**` deny rules are added to the effective restriction set. `execute` calls to those routes are blocked with a clear policy message rather than failing with a 404. `specsEnabled.<contextPath>` is `false` in this state.
 
 4. **Network boundary**: The secure-exec permission layer independently restricts network access to the configured tenant host. Other network operations are denied.
 
@@ -445,7 +433,7 @@ The repository bundles multiple OpenAPI specs for CLI use and builds one microse
 - CLI bundle in `dist/`
 - Versioned server bundles in `.output/release/`, `.output/2026/`, `.output/2025/`, and `.output/2024/`
 
-The build matrix is driven by [`openapi-builds.json`](openapi-builds.json). Core snapshots live under `openapi/core/`, DTM snapshots live under `openapi/dtm/`, and each server bundle contains the configured combination for that build.
+The build matrix is driven by [`openapi-builds.json`](openapi-builds.json). Versioned core snapshots live under `openapi/core/`; bundled service specs (one per file) live under `openapi/services/`. Each server bundle contains the configured core version plus every bundled service.
 
 ### Release Packaging
 

--- a/openapi-builds.json
+++ b/openapi-builds.json
@@ -1,6 +1,6 @@
 {
-  "sources": {
-    "core": [
+  "core": {
+    "versions": [
       {
         "version": "release",
         "label": "release (latest)",
@@ -24,39 +24,35 @@
       }
     ]
   },
+  "services": [
+    {
+      "key": "dtm",
+      "label": "Digital Twin Manager",
+      "url": "https://cumulocity.com/api/dtm/dist/c8y-dtm-oas.json",
+      "servicePrefix": "/service/dtm"
+    }
+  ],
   "builds": [
     {
       "version": "release",
       "label": "release (latest)",
-      "artifact": "core-release",
-      "default": true,
-      "apis": {
-        "core": "release"
-      }
+      "core": "release",
+      "default": true
     },
     {
       "version": "2026",
       "label": "2026",
-      "artifact": "core-2026",
-      "apis": {
-        "core": "2026"
-      }
+      "core": "2026"
     },
     {
       "version": "2025",
       "label": "2025",
-      "artifact": "core-2025",
-      "apis": {
-        "core": "2025"
-      }
+      "core": "2025"
     },
     {
       "version": "2024",
       "label": "2024",
-      "artifact": "core-2024",
-      "apis": {
-        "core": "2024"
-      }
+      "core": "2024"
     }
   ]
 }

--- a/openapi/services/dtm.json
+++ b/openapi/services/dtm.json
@@ -1,0 +1,13134 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "DTM Asset and Definition API",
+    "description": "The Digital Twin Manager (DTM) enables schema-based modeling in Cumulocity.\nIt allows creating and managing data model schemas, which serve as blueprints for all Cumulocity domain model entities such as assets and their properties, but also, for example, events, alarms, and measurements.\nThese blueprints act as reusable templates within the platform and are used to describe the logical structure, hierarchies and constraints of\ncomplex [business assets](https://cumulocity.com/docs/glossary/#assets) also known as [digital twins](https://cumulocity.com/docs/glossary/#digital-twin).\n\nThe DTM API is the interface to manage the schema definitions as well as the (asset) instances based on these definitions. The API is structured to separate schema governance (Definition API) from instance management (Asset API):\n\nThe **Definition API** provides the governance layer of the DTM to manage the reusable schema elements that define the structure used to describe, create or validate schema for domain model entities, called _definitions_. \n\nThe **Asset API** allows managing asset instances based on predefined Asset Definitions (also known as [Asset Models](https://cumulocity.com/docs/glossary/#asset-models)). Asset instances created from an Asset Model inherit the structure and constraints defined in the model.\n\n# Cumulocity REST API\n\nThe DTM Definition API and Asset API are an extension of the Cumulocity REST API and follow the same design principles and aspects common to all REST-based interfaces of Cumulocity. For general information about the Cumulocity REST API, see the [Cumulocity REST API documentation](https://cumulocity.com/api/core/).\n\n# Authorization\n\nAll requests issued to DTM Definition API and Asset API are subject to authentication and authorization. For detailed information about authentication, refer to the Cumulocity Core OpenAPI specification details on [Authentication](https://cumulocity.com/api/core/#section/Authentication). To determine the required permissions, see the \"Required user role\" entries for the individual requests.\n\nFor general information about permissions and the concept of ownership in Cumulocity, see [Getting started > Technical concepts > Security aspects > Access control > Managing roles and assigning permissions](https://www.cumulocity.com/docs/concepts/security/#managing-roles-and-assigning-permissions) in the [Cumulocity user documentation](https://cumulocity.com/docs/).\n<br>",
+    "version": "Latest",
+    "x-logo": {
+      "href": "https://cumulocity.com/api",
+      "backgroundColor": "#F8F8F8",
+      "altText": "Cumulocity – Digital Twin Manager",
+      "url": "https://cumulocity.com/docs/images/logo-platform.svg"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://<TENANT_DOMAIN>",
+      "description": "The Digital Twin Manager service."
+    }
+  ],
+  "tags": [
+    {
+      "name": "Assets",
+      "description": "The Asset API extends the Cumulocity core capabilities and domain model to manage assets with schema-based governance by linking asset instances to predefined Asset Definitions (also known as Asset Models). The Asset Definition serves as a blueprint\nfor the asset instances, defining\ntheir structure and constraints and relationships within an asset hierarchy.\n\nAsset instances without a linked Asset Definition are treated as generic assets without schema governance or constraints of the logical structure defined in an Asset Definition.\n\nThe Asset API extends the Cumulocity core capabilities with\n* Schema Governance: Enforcing and managing the underlying data schemas.\n* Integration: Synchronizing external sources of assets and digital twins.\n* Bulk Operations: Facilitating large-scale asset management.\n* Linked Series: Linking of time-series context to assets.\n* Permissions: Elevated permissions for synchronization and linked series management.\n\n### Asset Synchronization\n\nThe Asset API provides optimized operations specifically designed to efficiently create or update assets within synchronization workflows from external systems.\n\nFor referencing an asset from an external system, a unique identifier is required to map the asset between Cumulocity and the external system. This unique identifier is used in addition to the Cumulocity asset id and can be used to query the asset via the Asset API. This has a significant performance benefit over using any custom fragment property or even properties to identify the asset. Internally the Asset API creates an external id in the Identity API of type `c8y_Asset` for each asset that has an external identifier set via the `c8y_ExternalId` fragment.\n\nUsing the external identifier, the Asset API can perform idempotent create or update operations. This means that if an asset with the specified external identifier already exists, it will be updated; otherwise, a new asset will be created. This is particularly useful in synchronization scenarios where the same asset data may be processed multiple times, ensuring that duplicate assets are not created.\n\nIf the asset has the `c8y_ExternalAsset` fragment, it is considered to be externally managed applying additional restrictions on update and delete operations to avoid unintended modifications of externally managed assets. See the Permissions section below for more details.\n\nThe `c8y_ExternalAsset` fragment allows defining a `source` to indicate the origin of the external asset.\n\n```json\n{\n  \"c8y_ExternalAsset\": {\n    \"source\": \"string\"\n  }\n}\n```\n\n### Permissions\n\nBy default, for all Asset API operations, users require the corresponding *ROLE_INVENTORY_\\** permission to create, update or delete assets. The *ROLE_DIGITAL_TWIN_ASSETS_\\** permissions are elevated permissions that are specifically designed to control modifications of externally managed assets in addition to the *ROLE_INVENTORY_\\** roles and permissions.\n\nThe *ROLE_DIGITAL_TWIN_ASSETS_\\** permissions are only required for updating or deleting externally managed assets (assets having the `c8y_ExternalAsset` fragment).\nThis is especially useful for using the Asset API for synchronization of assets from an external source and to control modifications of these externally managed assets within Cumulocity while still allowing regular\n(not external) assets to be managed without additional permissions.\n\nTo enforce always requiring the *ROLE_DIGITAL_TWIN_ASSETS_\\** permissions, no matter if the asset is external or not, the tenant option `assets.permission.mode` can be configured to `all`. In this case, the *ROLE_DIGITAL_TWIN_ASSETS_CREATE* permission is required to create assets. To disable the requirement of *ROLE_DIGITAL_TWIN_ASSETS_\\** permissions completely, the tenant option can be set to `none`.\n\nThe following elevated permissions are available for the Asset API:\n\n- *ROLE_DIGITAL_TWIN_ASSETS_CREATE*: Users can create new assets including LinkedSeries and their Source.\n- *ROLE_DIGITAL_TWIN_ASSETS_UPDATE*: Users can update existing assets including LinkedSeries and their Source.\n- *ROLE_DIGITAL_TWIN_ASSETS_ADMIN*: Users can manage all assets, including creating, updating, and deleting them.\n"
+    },
+    {
+      "name": "Linked Series",
+      "description": "Linked data points enable assets to reference measurement series originating from other managed objects (typically devices). This enables contextualization of raw IoT measurements at the asset level.\n\nAn asset may contain multiple linked data points — referred to as Linked Series within the Asset API.  \nEach Linked Series must be uniquely identified by its combination of `fragment` and `series`. No two linked data points on the same asset may share the same `fragment.series`.\n\nA Linked Series consists of the following elements:\n\n- fragment – the measurement fragment (mandatory, for example, `c8y_Temperature`)\n- series – the series name within that fragment (mandatory, for example, `T`)\n- label – an optional human-readable identifier for this linked data point\n- source – optional reference to the origin of the measurement (typically a device)\n- custom fragments – optional additional properties used to enrich the linked data point with custom metadata\n\n> **Note:** The DTM application can be configured to control which fragments appear in the user interface via the tenant option `assets.linkedseries.fragments.show`. Example: `assets.linkedseries.fragments.show: label,type,description` (where `description` is a\n> custom fragment).\n\nTo create a Linked Series, fragment and series are the minimum required fields.\nHowever, specifying only these fields does not link the asset to any actual measurement stream.\n\nA source describes the origin of the measurement series and consists of the following properties:\n\n- fragment – the fragment name of the originating measurement, if omitted the fragment of the Linked Series is used (for example, `c8y_Temperature`)\n- series – the series name of the originating measurement, if omitted the series of the Linked Series is used (for example, `T`)\n- id – the ID of the managed object (typically a device) that produces the measurement\n- type – the type of the originating measurement (for example, `c8y_TemperatureMeasurement`)\n- name – a human-readable name of the source object (for example, `Temperature Sensor`)\n\n> **Note:** The fragment and series on the Linked Series may differ from those on the source. This allows decoupling of asset and device models — for example, if a device is replaced, upgraded, or renamed.\n\n### Example: Defining a Linked Series\n\nThis example demonstrates how to create a Linked Series on an asset, linking it to an existing measurement series produced by a device.\n\n```json\n{\n  \"fragment\": \"c8y_Temperature\",\n  \"series\": \"T_Ambient\",\n  \"label\": \"Ambient Room Temperature\",\n  \"source\": {\n    \"id\": \"512123\",\n    \"type\": \"c8y_TemperatureMeasurement\",\n    \"fragment\": \"c8y_Temperature\",\n    \"series\": \"T\",\n    \"name\": \"Temperature Sensor\"\n  },\n  \"description\": \"Linked series representing the primary ambient temperature sensor\"\n}\n```\n\nThe Linked Series allows the asset to expose a stable measurement stream (c8y_Temperature.T_Ambient) while the underlying source may change or come from different devices.\n\nThe asset API supports creating Linked Series either by creating/updating an asset by specifying the `c8y_LinkedSeries` fragment or by using dedicated endpoints to manage Linked Series individually.\n\n### Permissions\n\nManaging Linked Series in the asset API requires the following elevated permissions:\n\n- *ROLE_DIGITAL_TWIN_ASSETS_CREATE* – allows creating Linked Series and their sources.\n- *ROLE_DIGITAL_TWIN_ASSETS_UPDATE* – allows updating existing Linked Series and their sources.\n- *ROLE_DIGITAL_TWIN_ASSETS_ADMIN* – allows full management, including creating, updating, and deleting Linked Series.\n\nThese permissions ensure that only authorized users can modify asset-level links to measurement streams.\n\nFor maintaining the source of a Linked Series, DTM provides the *ROLE_DIGITAL_TWIN_LINKING_\\** permissions. These can be used without *ROLE_DIGITAL_TWIN_ASSETS_\\** permissions to enable use cases where users are only allowed to update the source, but\nnot the asset itself.\nThe following permissions are available for updating the source of Linked Series:\n\n- *ROLE_DIGITAL_TWIN_LINKING_UPDATE* – allows updating the source of a Linked Series.\n- *ROLE_DIGITAL_TWIN_LINKING_ADMIN* – allows full management of sources, including updating, and deleting a source."
+    },
+    {
+      "name": "Asset Definitions",
+      "description": "An Asset Definition represents a composable type definition for inventory assets in Cumulocity.  \nIt describes the structure, composition, and allowed relationships of assets.\n\nWhile Property Definitions describe individual data structures, an Asset Definition combines multiple Property Definitions into a higher-level composite model — forming the blueprint for complex digital twins such as machines, vehicles, or buildings.\n\nAn Asset Definition is both:\n\n- Composable — it aggregates multiple Property Definitions and their schemas into a single JSON object schema, and\n- Hierarchical — it can define parent-child relationships between assets.\n\nEach Asset Definition acts as a meta-model describing:\n\n- Which properties an asset may have,\n- Which sub-assets (children) it may contain, and\n- Whether additional (unlisted) properties or sub-assets are allowed.\n\n### Structure of an Asset Definition\n\nAn Asset Definition typically contains:\n\n- A unique identifier (`identifier`)\n- A composition object specifying allowed properties and sub-assets\n- Optional metadata\n\n```JSON\n{\n  \"identifier\": \"c8y_Windfarm\",\n  \"composition\": {\n    \"allowedProperties\": [],\n    \"allowedSubAssets\": [],\n    \"additionalProperties\": false,\n    \"additionalSubAssets\": false\n  }\n}\n```\n\nThe composition defines how an asset is built from Property Definitions and sub-assets:\n\n- `allowedProperties` — a set of entries referencing the identifiers of Property Definitions that compose this asset.\n- `allowedSubAssets` — a set of entries referencing other Asset Definitions that can appear as children.\n- `additionalProperties` — a boolean flag allowing additional (unspecified) properties to be added dynamically.\n- `additionalSubAssets` — a boolean flag allowing additional sub-assets beyond those explicitly defined.\n\nBelow is an example of an Asset Definition for a Windfarm that consists of multiple properties and sub-assets:\n\n```JSON\n{\n  \"identifier\": \"c8y_Windfarm\",\n  \"composition\": {\n    \"allowedProperties\": [\n      {\n        \"identifier\": \"c8y_Position\",\n        \"minOccurs\": \"1\"\n      },\n      {\n        \"identifier\": \"c8y_Status\",\n        \"minOccurs\": \"0\"\n      }\n    ],\n    \"allowedSubAssets\": [\n      {\n        \"identifier\": \"c8y_Windturbine\",\n        \"minOccurs\": \"1\",\n        \"maxOccurs\": \"10\"\n      }\n    ],\n    \"additionalProperties\": false,\n    \"additionalSubAssets\": false\n  }\n}\n```\n\nExplanation of the example:\n\n- The Asset Definition `c8y_Windfarm` composes several Property Definitions (`c8y_Position`, `c8y_Status`).\n- It allows up to 10 sub-assets of type `c8y_Windturbine`.\n- Additional properties and sub-assets are not allowed to enforce a fixed structure.\n- You can control whether a property or sub-asset is required by setting `minOccurs: 1` (required) or `minOccurs: 0` (optional).\n\n### JSON Schema Composition in Asset Definitions\n\nWhen an Asset Definition is created (or updated), its JSON Schema is automatically generated.\nThe JSON Schema is generated by composing the schemas of all allowed Property Definitions specified in the Asset Definition.\nEach allowed Property Definition contributes its individual schema, which is composed into a single, higher-level JSON object schema representing the complete asset.\n\nConsider an Asset Definition for a Windfarm that includes `c8y_Position` as an allowed Property Definition. The final, composed JSON Schema is:\n\n```JSON\n{\n  \"jsonSchema\": {\n    \"additionalProperties\": false,\n    \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n    \"type\": \"object\",\n    \"definitions\": {\n      \"c8y_Position\": {\n        \"title\": \"Location\",\n        \"type\": \"object\",\n        \"additionalProperties\": false,\n        \"properties\": {\n          \"lng\": {\n            \"type\": \"number\"\n          },\n          \"lat\": {\n            \"type\": \"number\"\n          },\n          \"alt\": {\n            \"type\": \"number\"\n          }\n        },\n        \"required\": [\n          \"lat\",\n          \"lng\"\n        ]\n      }\n    },\n    \"properties\": {\n      \"c8y_Position\": {\n        \"$ref\": \"#/definitions/c8y_Position\"\n      }\n    },\n    \"required\": [\n      \"c8y_Position\"\n    ]\n  }\n}\n```"
+    },
+    {
+      "name": "Alarm Definitions",
+      "description": "An Alarm Definition represents a composable type definition for an alarm in Cumulocity.\nIt acts as a meta-model describing the structure and composition of an alarm, specifying which properties an alarm may have.\n\nWhile Property Definitions describe individual data elements, an Alarm Definition composes multiple Property Definitions into a single, reusable model.\n\nAn Alarm Definition is:\n\n- Composable – it aggregates multiple Property Definitions into one JSON object schema.\n- Flat – it does not define relationships."
+    },
+    {
+      "name": "Event Definitions",
+      "description": "An Event Definition represents a composable type definition for events in Cumulocity.\nIt acts as a meta-model describing the structure and composition of events, specifying which properties an event may have.\n\nWhile Property Definitions describe individual data elements, an Event Definition composes multiple Property Definitions into a single, reusable model.\n\nAn Event Definition is:\n\n- Composable – it aggregates multiple Property Definitions into one JSON object schema.\n- Flat – it does not define relationships."
+    },
+    {
+      "name": "Measurement Definitions",
+      "description": "A Measurement Definition represents a composable type definition for measurements in Cumulocity.\nIt acts as a meta-model describing the structure and composition of measurements, specifying which properties a measurement may have.\n\nWhile Property Definitions describe individual data elements, a Measurement Definition composes multiple Property Definitions into a single, reusable model.\n\nMeasurement Definition is:\n\n- Composable – it aggregates multiple Property Definitions into one JSON object schema.\n- Flat – it does not define relationships."
+    },
+    {
+      "name": "Property Definitions",
+      "description": "Cumulocity domain entities - such as managed objects, alarms, events, and measurements - share a flexible data model that can be extended through properties and fragments.\n\nA Property Definition specifies the abstract syntax and semantics of such a property or fragment. It defines the type of data a property can contain, how it should be represented and validated, which domain entities it applies to, and who owns it.\n\nEach Property Definition consists of:\n\n- a **unique identifier**,\n- a **JSON Schema** that defines its structure and constraints,\n- a set of applicable **contexts** indicating which domain entities the property applies to, and\n- an **origin** specifying the owner of the property.\n\n### Example: Defining the c8y_Position Property Definition\n\nThe `c8y_Position` fragment represents a device’s geographical position. It typically contains three properties:\n\n- `lat` — latitude\n- `lng` — longitude\n- `alt` — altitude\n\nThese values are numeric and describe where a device is located in the real world.\n\nHere’s how a `c8y_Position` Property Definition would look when modeled as a Property Definition:\n\n```json\n{\n  \"identifier\": \"c8y_Position\",\n  \"jsonSchema\": {\n    \"$schema\": \"http://json-schema.org/draft-07/schema#\",\n    \"type\": \"object\",\n    \"title\": \"Location\",\n    \"properties\": {\n      \"lat\": {\n        \"type\": \"number\"\n      },\n      \"lng\": {\n        \"type\": \"number\"\n      },\n      \"alt\": {\n        \"type\": \"number\"\n      }\n    },\n    \"required\": [\n      \"lat\",\n      \"lng\"\n    ],\n    \"additionalProperties\": false\n  }\n}\n```\n\nYou can use JSON Schema to define additional constraints and metadata for a property.\nThese constraints allow you to precisely describe valid data ranges, default values, formatting rules, or enumerations.\n\n### Defining the Context of a Property Definition\n\nEvery Property Definition can specify contexts — that is, the domain entities to which the property or fragment applies. The context determines where in the platform the property can be used or validated.\n\nA context represents a Cumulocity domain entity type such as:\n\n- `MEASUREMENT` - used for sensor readings or time-series data collected from devices.\n- `EVENT` - represents occurrences or state changes triggered by devices or applications.\n- `ALARM` - defines alerts or threshold violations that require attention.\n- `AUDIT` - refers to audit records for tracking configuration changes or user actions.\n- `OPERATION` - applies to executable operations that can be performed on a device.\n- `ASSET` - used for assets in the inventory hierarchy.\n- `TENANT_OPTION` - represents tenant-level configuration options or metadata.\n\nYou can define one or more contexts inside the Property Definition to indicate where the property applies. Use the `contexts` field as an array of values from the supported context list:\n\n```JSON\n{\n  \"contexts\": [\n    \"MEASUREMENT\",\n    \"EVENT\"\n  ]\n}\n```"
+    }
+  ],
+  "paths": {
+    "/definitions/properties/{identifier}": {
+      "get": {
+        "tags": [
+          "Property Definitions"
+        ],
+        "summary": "Retrieve a Property Definition by identifier",
+        "description": "Finds a `Property Definition` by its `identifier`.\n\n The `identifier` needs to point to an existing `Property Definition`. The `applicableTo` parameter is used to find the `Property Definition` that is applicable to the specified domain entity. Otherwise, this operation responds in `HTTP 404`. If no `applicableTo` is specified, the operation will return the `Property Definition` that is not applicable to any domain entity, if it exists.",
+        "operationId": "getPropertyDefinition",
+        "parameters": [
+          {
+            "name": "identifier",
+            "in": "path",
+            "description": "The `identifier` used to uniquely identify the `Property Definition`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "applicableTo",
+            "in": "query",
+            "description": "Limits the response to Property Definitions applicable to the specified domain entity.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "measurement",
+                "event",
+                "alarm",
+                "audit",
+                "operation",
+                "asset",
+                "tenant_option"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PropertyDefinition"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "identifier is invalid": {
+                    "description": "identifier is invalid",
+                    "value": {
+                      "messages": [
+                        "identifier {identifier} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark or periods. Whitespace is not allowed."
+                      ]
+                    }
+                  },
+                  "title is invalid": {
+                    "description": "title is invalid",
+                    "value": {
+                      "messages": [
+                        "title {title} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark, whitespace or periods."
+                      ]
+                    }
+                  },
+                  "Limit exceeded": {
+                    "description": "This error occurs when a predefined limit for a specific entity (e.g. 'Property Definition') has been reached. The limits can be adjusted by setting a tenant option.",
+                    "value": {
+                      "messages": [
+                        "{Entity} limit of {maxCount} reached. Further creation is not allowed."
+                      ]
+                    }
+                  },
+                  "Json Schema exceeds allowed properties": {
+                    "description": "The Json schema defined for the Definition exceeds the maximum number of allowed properties. Either reduce the number of properties to meet the limit or change the limit by adjusting the tenant option.",
+                    "value": {
+                      "messages": [
+                        "Json Schema has {x} properties but only up to {maxCount} are allowed."
+                      ]
+                    }
+                  },
+                  "Inapplicable context": {
+                    "description": "The given Property Definition is not applicable to the required context and can therefore not be used in the composition of the Asset or MEA Definition.",
+                    "value": {
+                      "messages": [
+                        "Property Definition {identifier} is not applicable to context {context} and cannot be used in composition."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "detail"
+      },
+      "put": {
+        "tags": [
+          "Property Definitions"
+        ],
+        "summary": "Update an existing Property Definition",
+        "description": "Updates an existing `Property Definition`.\n\n Updates the `Property Definition` that is exactly identified by the `identifier` and `contexts` in the path. The `Property Definition` must be applicable to all the specified domain entities (and no others). If no contexts is specified, the `Property Definition` that is not applicable to any domain entity will be updated. The `requestBody` is used to update the `Property Definition` with the new values. This operation is restricted to updating the existing JSON Schema (including `title` and `description`), `contexts`, `tags`, and other custom fragments. Updating the `identifier` is not permitted.",
+        "operationId": "updatePropertyDefinition",
+        "parameters": [
+          {
+            "name": "identifier",
+            "in": "path",
+            "description": "The `identifier` used to uniquely identify the `Property Definition`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "contexts",
+            "in": "query",
+            "description": "Limits the response to Property Definitions matching exactly the specified domain entities.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "measurement",
+                  "event",
+                  "alarm",
+                  "audit",
+                  "operation",
+                  "asset",
+                  "tenant_option"
+                ]
+              }
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "The data payload the `Property Definition` should be updated with.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PropertyDefinition"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PropertyDefinition"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "identifier is invalid": {
+                    "description": "identifier is invalid",
+                    "value": {
+                      "messages": [
+                        "identifier {identifier} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark or periods. Whitespace is not allowed."
+                      ]
+                    }
+                  },
+                  "title is invalid": {
+                    "description": "title is invalid",
+                    "value": {
+                      "messages": [
+                        "title {title} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark, whitespace or periods."
+                      ]
+                    }
+                  },
+                  "Limit exceeded": {
+                    "description": "This error occurs when a predefined limit for a specific entity (e.g. 'Property Definition') has been reached. The limits can be adjusted by setting a tenant option.",
+                    "value": {
+                      "messages": [
+                        "{Entity} limit of {maxCount} reached. Further creation is not allowed."
+                      ]
+                    }
+                  },
+                  "Json Schema exceeds allowed properties": {
+                    "description": "The Json schema defined for the Definition exceeds the maximum number of allowed properties. Either reduce the number of properties to meet the limit or change the limit by adjusting the tenant option.",
+                    "value": {
+                      "messages": [
+                        "Json Schema has {x} properties but only up to {maxCount} are allowed."
+                      ]
+                    }
+                  },
+                  "Inapplicable context": {
+                    "description": "The given Property Definition is not applicable to the required context and can therefore not be used in the composition of the Asset or MEA Definition.",
+                    "value": {
+                      "messages": [
+                        "Property Definition {identifier} is not applicable to context {context} and cannot be used in composition."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "update"
+      },
+      "delete": {
+        "tags": [
+          "Property Definitions"
+        ],
+        "summary": "Delete an existing Property Definition",
+        "description": "Deletes an existing `Property Definition` by its `identifier` and `contexts`.\n\n Deletes only the Property Definition that is exactly applicable to all the specified domain entities (and no others). If no contexts is specified, the operation will delete the Property Definition that is not applicable to any domain entity.",
+        "operationId": "deletePropertyDefinition",
+        "parameters": [
+          {
+            "name": "identifier",
+            "in": "path",
+            "description": "The key used to uniquely identify the `Property Definition`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "contexts",
+            "in": "query",
+            "description": "Limits the response to Property Definitions matching exactly the specified domain entities.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "measurement",
+                  "event",
+                  "alarm",
+                  "audit",
+                  "operation",
+                  "asset",
+                  "tenant_option"
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "identifier is invalid": {
+                    "description": "identifier is invalid",
+                    "value": {
+                      "messages": [
+                        "identifier {identifier} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark or periods. Whitespace is not allowed."
+                      ]
+                    }
+                  },
+                  "title is invalid": {
+                    "description": "title is invalid",
+                    "value": {
+                      "messages": [
+                        "title {title} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark, whitespace or periods."
+                      ]
+                    }
+                  },
+                  "Limit exceeded": {
+                    "description": "This error occurs when a predefined limit for a specific entity (e.g. 'Property Definition') has been reached. The limits can be adjusted by setting a tenant option.",
+                    "value": {
+                      "messages": [
+                        "{Entity} limit of {maxCount} reached. Further creation is not allowed."
+                      ]
+                    }
+                  },
+                  "Json Schema exceeds allowed properties": {
+                    "description": "The Json schema defined for the Definition exceeds the maximum number of allowed properties. Either reduce the number of properties to meet the limit or change the limit by adjusting the tenant option.",
+                    "value": {
+                      "messages": [
+                        "Json Schema has {x} properties but only up to {maxCount} are allowed."
+                      ]
+                    }
+                  },
+                  "Inapplicable context": {
+                    "description": "The given Property Definition is not applicable to the required context and can therefore not be used in the composition of the Asset or MEA Definition.",
+                    "value": {
+                      "messages": [
+                        "Property Definition {identifier} is not applicable to context {context} and cannot be used in composition."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "External ID conflict": {
+                    "description": "The c8y_ExternalId of an Asset must be unique.",
+                    "value": {
+                      "messages": [
+                        "The externalId {externalId} is already used by ManagedObject {id}."
+                      ]
+                    }
+                  },
+                  "Definition conflict": {
+                    "description": "A Property Definition must be unique based on its identifier and context.",
+                    "value": {
+                      "messages": [
+                        "Asset Definition with identifier {identifier} already exists in the given context."
+                      ]
+                    }
+                  },
+                  "Linked Series conflict": {
+                    "description": "A Linked Series must be unique within an Asset based on its fragment and series.",
+                    "value": {
+                      "messages": [
+                        "Source for Linked Series with fragment {fragment} and series {series} already exists."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "delete"
+      }
+    },
+    "/definitions/measurements": {
+      "get": {
+        "tags": [
+          "Measurement Definitions"
+        ],
+        "summary": "Retrieve Measurement Definitions",
+        "description": "Finds a collection of `Measurement Definition`s.\n\n This resource offers diverse filtering capabilities, yet it's essential to consider data consistency rules: \n\n * Passing only one `identifier` results in `0...1` `Measurement Definition`s.\n\n * Passing only one `title` results in `0...1` `Measurement Definition`s.\n\n\n\n\n\n The following rules will be applied when searching for the `Measurement Definition`s: \n\n * `identifiers`, `titles`, `tags` will be concatenated using logical AND operators\n\n * Values within a filter will be concatenated using a logical OR operator\n\n  For instance, the query filter `?identifiers=id_a,id_b&title=position` results in the following query filter:` (identifier equals id_a OR identifier equals id_b) AND title equals position `\n\n *Will be executed in context of an `Storage` tenant.*",
+        "operationId": "getMeasurementDefinitions",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "description": "Use the `$filter` keyword to specify filtering criteria. Filtering can be applied to properties of the asset. Detailed information can be found within the Cumulocity core OpenAPI [here](https://cumulocity.com/api/core/#tag/Query-language).",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "Filter by name": {
+                "description": "Filter by name",
+                "value": "$filter=name eq 'Windfarm'"
+              },
+              "Filter by type": {
+                "description": "Filter by type",
+                "value": "$filter=type eq 'c8y_*'"
+              },
+              "Using orderby": {
+                "description": "Using orderby",
+                "value": "$orderby=id asc"
+              }
+            }
+          },
+          {
+            "name": "identifiers",
+            "in": "query",
+            "description": "List of `identifiers`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "titles",
+            "in": "query",
+            "description": "List of `titles`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "List of `tags`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "currentPage",
+            "in": "query",
+            "description": "The current page number to be retrieved.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "The number of items to be displayed on each page.",
+            "required": false,
+            "schema": {
+              "maximum": 2000,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedDefinitionList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "list"
+      },
+      "put": {
+        "tags": [
+          "Measurement Definitions"
+        ],
+        "summary": "Update an existing Measurement Definition",
+        "description": "Updates an existing `Measurement Definition`.\n\n The Measurement Definition's `identifier` is taken from the `requestBody`. This operation is restricted to updating the existing JSON Schema (including `title` and `description`). No other modifications are permitted.",
+        "operationId": "updateMeasurementDefinition",
+        "requestBody": {
+          "description": "The data payload representing the `Measurement Definition` to be updated.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MeasurementDefinition"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeasurementDefinition"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "update"
+      },
+      "post": {
+        "tags": [
+          "Measurement Definitions"
+        ],
+        "summary": "Create a new Measurement Definition",
+        "description": "Creates a new `Measurement Definition`.\n\n This operation ensures consistency by enforcing the following rules: \n\n * The `identifier` of the `Measurement Definition` must be unique.\n\n * If a `title` is provided, it must also be unique.\n\n\n\n\n\n The supplied JSON Schema must conform to the [JSON Schema Draft-7 specification](http://json-schema.org/draft-07/schema).",
+        "operationId": "createMeasurementDefinition",
+        "requestBody": {
+          "description": "The data payload representing the `Measurement Definition` to be created.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MeasurementDefinition"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeasurementDefinition"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "identifier is invalid": {
+                    "description": "identifier is invalid",
+                    "value": {
+                      "messages": [
+                        "identifier {identifier} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark or periods. Whitespace is not allowed."
+                      ]
+                    }
+                  },
+                  "title is invalid": {
+                    "description": "title is invalid",
+                    "value": {
+                      "messages": [
+                        "title {title} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark, whitespace or periods."
+                      ]
+                    }
+                  },
+                  "Limit exceeded": {
+                    "description": "This error occurs when a predefined limit for a specific entity (e.g. 'Property Definition') has been reached. The limits can be adjusted by setting a tenant option.",
+                    "value": {
+                      "messages": [
+                        "{Entity} limit of {maxCount} reached. Further creation is not allowed."
+                      ]
+                    }
+                  },
+                  "Json Schema exceeds allowed properties": {
+                    "description": "The Json schema defined for the Definition exceeds the maximum number of allowed properties. Either reduce the number of properties to meet the limit or change the limit by adjusting the tenant option.",
+                    "value": {
+                      "messages": [
+                        "Json Schema has {x} properties but only up to {maxCount} are allowed."
+                      ]
+                    }
+                  },
+                  "Inapplicable context": {
+                    "description": "The given Property Definition is not applicable to the required context and can therefore not be used in the composition of the Asset or MEA Definition.",
+                    "value": {
+                      "messages": [
+                        "Property Definition {identifier} is not applicable to context {context} and cannot be used in composition."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "create"
+      }
+    },
+    "/definitions/events": {
+      "get": {
+        "tags": [
+          "Event Definitions"
+        ],
+        "summary": "Retrieve Event Definitions",
+        "description": "Finds a collection of `Event Definition`s.\n\n This resource offers diverse filtering capabilities, yet it's essential to consider data consistency rules: \n\n * Passing only one `identifier` results in `0...1` `Event Definition`s.\n\n * Passing only one `title` results in `0...1` `Event Definition`s.\n\n\n\n\n\n The following rules will be applied when searching for the `Event Definition`s: \n\n * `identifiers`, `titles`, `tags` will be concatenated using logical AND operators\n\n * Values within a filter will be concatenated using a logical OR operator\n\n  For instance, the query filter `?identifiers=id_a,id_b&title=position` results in the following query filter:` (identifier equals id_a OR identifier equals id_b) AND title equals position `\n\n *Will be executed in context of an `Storage` tenant.*",
+        "operationId": "getEventDefinitions",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "description": "Use the `$filter` keyword to specify filtering criteria. Filtering can be applied to properties of the asset. Detailed information can be found within the Cumulocity core OpenAPI [here](https://cumulocity.com/api/core/#tag/Query-language).",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "Filter by name": {
+                "description": "Filter by name",
+                "value": "$filter=name eq 'Windfarm'"
+              },
+              "Filter by type": {
+                "description": "Filter by type",
+                "value": "$filter=type eq 'c8y_*'"
+              },
+              "Using orderby": {
+                "description": "Using orderby",
+                "value": "$orderby=id asc"
+              }
+            }
+          },
+          {
+            "name": "identifiers",
+            "in": "query",
+            "description": "List of `identifiers`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "titles",
+            "in": "query",
+            "description": "List of `titles`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "List of `tags`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "currentPage",
+            "in": "query",
+            "description": "The current page number to be retrieved.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "The number of items to be displayed on each page.",
+            "required": false,
+            "schema": {
+              "maximum": 2000,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedDefinitionList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "list"
+      },
+      "put": {
+        "tags": [
+          "Event Definitions"
+        ],
+        "summary": "Update an existing Event Definition",
+        "description": "Updates an existing `Event Definition`.\n\n The Event Definition's `identifier` is taken from the `requestBody`. This operation is restricted to updating the existing JSON Schema (including `title` and `description`). No other modifications are permitted.",
+        "operationId": "updateEventDefinition",
+        "requestBody": {
+          "description": "The data payload representing the `Event Definition` to be updated.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventDefinition"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventDefinition"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "update"
+      },
+      "post": {
+        "tags": [
+          "Event Definitions"
+        ],
+        "summary": "Create a new Event Definition",
+        "description": "Creates a new `Event Definition`.\n\n This operation ensures consistency by enforcing the following rules: \n\n * The `identifier` of the `Event Definition` must be unique.\n\n * If a `title` is provided, it must also be unique.\n\n\n\n\n\n The supplied JSON Schema must conform to the [JSON Schema Draft-7 specification](http://json-schema.org/draft-07/schema).",
+        "operationId": "createEventDefinition",
+        "requestBody": {
+          "description": "The data payload representing the `Event Definition` to be created.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventDefinition"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventDefinition"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "identifier is invalid": {
+                    "description": "identifier is invalid",
+                    "value": {
+                      "messages": [
+                        "identifier {identifier} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark or periods. Whitespace is not allowed."
+                      ]
+                    }
+                  },
+                  "title is invalid": {
+                    "description": "title is invalid",
+                    "value": {
+                      "messages": [
+                        "title {title} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark, whitespace or periods."
+                      ]
+                    }
+                  },
+                  "Limit exceeded": {
+                    "description": "This error occurs when a predefined limit for a specific entity (e.g. 'Property Definition') has been reached. The limits can be adjusted by setting a tenant option.",
+                    "value": {
+                      "messages": [
+                        "{Entity} limit of {maxCount} reached. Further creation is not allowed."
+                      ]
+                    }
+                  },
+                  "Json Schema exceeds allowed properties": {
+                    "description": "The Json schema defined for the Definition exceeds the maximum number of allowed properties. Either reduce the number of properties to meet the limit or change the limit by adjusting the tenant option.",
+                    "value": {
+                      "messages": [
+                        "Json Schema has {x} properties but only up to {maxCount} are allowed."
+                      ]
+                    }
+                  },
+                  "Inapplicable context": {
+                    "description": "The given Property Definition is not applicable to the required context and can therefore not be used in the composition of the Asset or MEA Definition.",
+                    "value": {
+                      "messages": [
+                        "Property Definition {identifier} is not applicable to context {context} and cannot be used in composition."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "create"
+      }
+    },
+    "/definitions/assets": {
+      "get": {
+        "tags": [
+          "Asset Definitions"
+        ],
+        "summary": "Retrieve Asset Definitions",
+        "description": "Finds a collection of `Asset Definition`s.\n\n This resource offers diverse filtering capabilities, yet it's essential to consider data consistency rules: \n\n * Passing only one `identifier` results in `0...1` `Asset Definition`s.\n\n * Passing only one `title` results in `0...1` `Asset Definition`s.\n\n\n\n\n\n The following rules will be applied when searching for the `Asset Definition`s: \n\n * `identifiers`, `titles`, `onlyRoots` will be concatenated using logical AND operators\n\n * Values within a filter will be concatenated using a logical OR operator\n\n  For instance, the query filter `?identifiers=id_a,id_b&title=position` results in the following query filter:` (identifier equals id_a OR identifier equals id_b) AND title equals position `\n\n *Will be executed in context of an `Storage` tenant.*",
+        "operationId": "getAssetDefinitions",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "description": "Use the `$filter` keyword to specify filtering criteria. Filtering can be applied to properties of the asset. Detailed information can be found within the Cumulocity core OpenAPI [here](https://cumulocity.com/api/core/#tag/Query-language).",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "Filter by name": {
+                "description": "Filter by name",
+                "value": "$filter=name eq 'Windfarm'"
+              },
+              "Filter by type": {
+                "description": "Filter by type",
+                "value": "$filter=type eq 'c8y_*'"
+              },
+              "Using orderby": {
+                "description": "Using orderby",
+                "value": "$orderby=id asc"
+              }
+            }
+          },
+          {
+            "name": "identifiers",
+            "in": "query",
+            "description": "List of `identifiers`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "titles",
+            "in": "query",
+            "description": "List of `titles`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "List of `tags`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "onlyRoots",
+            "in": "query",
+            "description": "Only consider `Asset Definition`s not used within the hierarchy of another `Asset Definition`.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "currentPage",
+            "in": "query",
+            "description": "The current page number to be retrieved.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "The number of items to be displayed on each page.",
+            "required": false,
+            "schema": {
+              "maximum": 2000,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedDefinitionList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "list"
+      },
+      "put": {
+        "tags": [
+          "Asset Definitions"
+        ],
+        "summary": "Update an existing Asset Definition",
+        "description": "Updates the `Asset Definition`.\n\n Throws a `ConflictException` if validation fails due to conflicts in the specified properties or sub-assets. Such conflicts occur when one or more of the provided allowed properties or sub-assets either do not exist or are not applicable within the current `asset` context.  \n\n *Required user role: `ROLE_DIGITAL_TWIN_ASSETS_ADMIN` **AND** `ROLE_INVENTORY_ADMIN`*",
+        "operationId": "updateAssetDefinition",
+        "requestBody": {
+          "description": "The data payload containing only the fields that need to be updated or added to the existing `Asset Definition`. Fields\nnot included in the payload will remain unchanged.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssetDefinition"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "The newly updated <code>Asset Definition</code>, or an empty <code>Optional</code> if the definition is not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetDefinition"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "The newly updated <code>Asset Definition</code>, or an empty <code>Optional</code> if the definition is not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "The newly updated <code>Asset Definition</code>, or an empty <code>Optional</code> if the definition is not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "The newly updated <code>Asset Definition</code>, or an empty <code>Optional</code> if the definition is not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The newly updated <code>Asset Definition</code>, or an empty <code>Optional</code> if the definition is not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "External ID conflict": {
+                    "description": "The c8y_ExternalId of an Asset must be unique.",
+                    "value": {
+                      "messages": [
+                        "The externalId {externalId} is already used by ManagedObject {id}."
+                      ]
+                    }
+                  },
+                  "Definition conflict": {
+                    "description": "A Property Definition must be unique based on its identifier and context.",
+                    "value": {
+                      "messages": [
+                        "Asset Definition with identifier {identifier} already exists in the given context."
+                      ]
+                    }
+                  },
+                  "Linked Series conflict": {
+                    "description": "A Linked Series must be unique within an Asset based on its fragment and series.",
+                    "value": {
+                      "messages": [
+                        "Source for Linked Series with fragment {fragment} and series {series} already exists."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "The newly updated <code>Asset Definition</code>, or an empty <code>Optional</code> if the definition is not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "update"
+      },
+      "post": {
+        "tags": [
+          "Asset Definitions"
+        ],
+        "summary": "Create a new Asset Definition",
+        "description": "Creates a new `Asset Definition`.\n\n The schema of this `Asset Definition` can't be changed after creation. If you need to change the schema, you need to create a new `Asset Definition`. By doing this, a new version of the `Asset Definition` will be created.  *Required user role: `ROLE_DIGITAL_TWIN_DEFINITIONS_CREATE` **AND** `ROLE_INVENTORY_CREATE`*",
+        "operationId": "createAssetDefinition",
+        "requestBody": {
+          "description": "The data payload representing the `Asset Definition` to be created.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssetDefinition"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetDefinition"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "identifier is invalid": {
+                    "description": "identifier is invalid",
+                    "value": {
+                      "messages": [
+                        "identifier {identifier} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark or periods. Whitespace is not allowed."
+                      ]
+                    }
+                  },
+                  "title is invalid": {
+                    "description": "title is invalid",
+                    "value": {
+                      "messages": [
+                        "title {title} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark, whitespace or periods."
+                      ]
+                    }
+                  },
+                  "Limit exceeded": {
+                    "description": "This error occurs when a predefined limit for a specific entity (e.g. 'Property Definition') has been reached. The limits can be adjusted by setting a tenant option.",
+                    "value": {
+                      "messages": [
+                        "{Entity} limit of {maxCount} reached. Further creation is not allowed."
+                      ]
+                    }
+                  },
+                  "Json Schema exceeds allowed properties": {
+                    "description": "The Json schema defined for the Definition exceeds the maximum number of allowed properties. Either reduce the number of properties to meet the limit or change the limit by adjusting the tenant option.",
+                    "value": {
+                      "messages": [
+                        "Json Schema has {x} properties but only up to {maxCount} are allowed."
+                      ]
+                    }
+                  },
+                  "Inapplicable context": {
+                    "description": "The given Property Definition is not applicable to the required context and can therefore not be used in the composition of the Asset or MEA Definition.",
+                    "value": {
+                      "messages": [
+                        "Property Definition {identifier} is not applicable to context {context} and cannot be used in composition."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "create"
+      }
+    },
+    "/definitions/alarms": {
+      "get": {
+        "tags": [
+          "Alarm Definitions"
+        ],
+        "summary": "Retrieve a collection of Alarm Definitions",
+        "description": "Finds a collection of `Alarm Definition`s.\n\n This resource offers diverse filtering capabilities, yet it's essential to consider data consistency rules: \n\n * Passing only one `identifier` results in `0...1` `Alarm Definition`s.\n\n * Passing only one `title` results in `0...1` `Alarm Definition`s.\n\n\n\n\n\n The following rules will be applied when searching for the `Alarm Definition`s: \n\n * `identifiers`, `titles` will be concatenated using logical AND operators\n\n * Values within a filter will be concatenated using a logical OR operator\n\n  For instance, the query filter `?identifiers=id_a,id_b&title=position` results in the following query filter:` (identifier equals id_a OR identifier equals id_b) AND title equals position `\n\n *Will be executed in context of an `Storage` tenant.*",
+        "operationId": "getAlarmDefinitions",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "description": "Use the `$filter` keyword to specify filtering criteria. Filtering can be applied to properties of the asset. Detailed information can be found within the Cumulocity core OpenAPI [here](https://cumulocity.com/api/core/#tag/Query-language).",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "Filter by name": {
+                "description": "Filter by name",
+                "value": "$filter=name eq 'Windfarm'"
+              },
+              "Filter by type": {
+                "description": "Filter by type",
+                "value": "$filter=type eq 'c8y_*'"
+              },
+              "Using orderby": {
+                "description": "Using orderby",
+                "value": "$orderby=id asc"
+              }
+            }
+          },
+          {
+            "name": "identifiers",
+            "in": "query",
+            "description": "List of `identifiers`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "titles",
+            "in": "query",
+            "description": "List of `titles`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "List of `tags`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "currentPage",
+            "in": "query",
+            "description": "The current page number to be retrieved.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "The number of items to be displayed on each page.",
+            "required": false,
+            "schema": {
+              "maximum": 2000,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedDefinitionList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "list"
+      },
+      "put": {
+        "tags": [
+          "Alarm Definitions"
+        ],
+        "summary": "Update an existing Alarm Definition",
+        "description": "Updates an existing `Alarm Definition`.\n\n The Alarm Definition's `identifier` is taken from the `requestBody`. This operation is restricted to updating the existing JSON Schema (including `title` and `description`). No other modifications are permitted.",
+        "operationId": "updateAlarmDefinition",
+        "requestBody": {
+          "description": "The data payload representing the `Alarm Definition` to be updated.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AlarmDefinition"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlarmDefinition"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "update"
+      },
+      "post": {
+        "tags": [
+          "Alarm Definitions"
+        ],
+        "summary": "Create a new Alarm Definition",
+        "description": "Creates a new `Alarm Definition`.\n\n This operation ensures consistency by enforcing the following rules: \n\n * The `identifier` of the `Alarm Definition` must be unique.\n\n * If a `title` is provided, it must also be unique.\n\n\n\n\n\n The supplied JSON Schema must conform to the [JSON Schema Draft-7 specification](http://json-schema.org/draft-07/schema).",
+        "operationId": "createAlarmDefinition",
+        "requestBody": {
+          "description": "The data payload representing the `Alarm Definition` to be created.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AlarmDefinition"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlarmDefinition"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "identifier is invalid": {
+                    "description": "identifier is invalid",
+                    "value": {
+                      "messages": [
+                        "identifier {identifier} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark or periods. Whitespace is not allowed."
+                      ]
+                    }
+                  },
+                  "title is invalid": {
+                    "description": "title is invalid",
+                    "value": {
+                      "messages": [
+                        "title {title} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark, whitespace or periods."
+                      ]
+                    }
+                  },
+                  "Limit exceeded": {
+                    "description": "This error occurs when a predefined limit for a specific entity (e.g. 'Property Definition') has been reached. The limits can be adjusted by setting a tenant option.",
+                    "value": {
+                      "messages": [
+                        "{Entity} limit of {maxCount} reached. Further creation is not allowed."
+                      ]
+                    }
+                  },
+                  "Json Schema exceeds allowed properties": {
+                    "description": "The Json schema defined for the Definition exceeds the maximum number of allowed properties. Either reduce the number of properties to meet the limit or change the limit by adjusting the tenant option.",
+                    "value": {
+                      "messages": [
+                        "Json Schema has {x} properties but only up to {maxCount} are allowed."
+                      ]
+                    }
+                  },
+                  "Inapplicable context": {
+                    "description": "The given Property Definition is not applicable to the required context and can therefore not be used in the composition of the Asset or MEA Definition.",
+                    "value": {
+                      "messages": [
+                        "Property Definition {identifier} is not applicable to context {context} and cannot be used in composition."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "create"
+      }
+    },
+    "/assets/{assetId}": {
+      "get": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Retrieve an existing asset",
+        "description": "Retrieves an existing asset.",
+        "operationId": "getAsset",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "withLinkedSeries",
+            "in": "query",
+            "description": "Indicates the resource to add the `c8y_LinkedSeries` fragment in the response.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "withSubAssets",
+            "in": "query",
+            "description": "Indicates the resource to add the sub-assets in the response.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "withLatestValues",
+            "in": "query",
+            "description": "Indicates the resource to fetch the latest values for this Asset and the name of the Source Devices.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Asset"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "detail"
+      },
+      "put": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Update an existing asset",
+        "description": "Updates an existing asset. All properties of the asset can be updated, including `name`, `type`,\n`c8y_ExternalId`, and fragments - except the `id`. Missing properties in the request body will not be removed but stay\nunchanged. Fragments, however, will be replaced completely, so missing properties in a fragment will be removed. If you want to remove a\nfragment, you have to explicitly set it to `null`. If the `c8y_ExternalId` is different to the existing Asset, it will be\nupdated accordingly. If the new `c8y_ExternalId` already exists, a conflict error will be returned.\n\n *Required user role: `ROLE_DIGITAL_TWIN_ASSETS_UPDATE` **AND** `ROLE_INVENTORY_ADMIN`*",
+        "operationId": "updateAsset",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fetchTypeFromSource",
+            "in": "query",
+            "description": "Indicates the resource to fetch the Measurement type associated with the linked device, derived from recorded Measurements. This parameter can be overruled by setting the Tenant Option `assets.linkedSeries.source.measurementType.mode`. If set to `required`, the Measurement type is mandatory and always fetched. An error is thrown if no Measurement Type is found. If set to `disabled`, the Measurement type is not fetched at all.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Asset"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Asset"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "identifier is invalid": {
+                    "description": "identifier is invalid",
+                    "value": {
+                      "messages": [
+                        "identifier {identifier} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark or periods. Whitespace is not allowed."
+                      ]
+                    }
+                  },
+                  "title is invalid": {
+                    "description": "title is invalid",
+                    "value": {
+                      "messages": [
+                        "title {title} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark, whitespace or periods."
+                      ]
+                    }
+                  },
+                  "Limit exceeded": {
+                    "description": "This error occurs when a predefined limit for a specific entity (e.g. 'Property Definition') has been reached. The limits can be adjusted by setting a tenant option.",
+                    "value": {
+                      "messages": [
+                        "{Entity} limit of {maxCount} reached. Further creation is not allowed."
+                      ]
+                    }
+                  },
+                  "Json Schema exceeds allowed properties": {
+                    "description": "The Json schema defined for the Definition exceeds the maximum number of allowed properties. Either reduce the number of properties to meet the limit or change the limit by adjusting the tenant option.",
+                    "value": {
+                      "messages": [
+                        "Json Schema has {x} properties but only up to {maxCount} are allowed."
+                      ]
+                    }
+                  },
+                  "Inapplicable context": {
+                    "description": "The given Property Definition is not applicable to the required context and can therefore not be used in the composition of the Asset or MEA Definition.",
+                    "value": {
+                      "messages": [
+                        "Property Definition {identifier} is not applicable to context {context} and cannot be used in composition."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "External ID conflict": {
+                    "description": "The c8y_ExternalId of an Asset must be unique.",
+                    "value": {
+                      "messages": [
+                        "The externalId {externalId} is already used by ManagedObject {id}."
+                      ]
+                    }
+                  },
+                  "Definition conflict": {
+                    "description": "A Property Definition must be unique based on its identifier and context.",
+                    "value": {
+                      "messages": [
+                        "Asset Definition with identifier {identifier} already exists in the given context."
+                      ]
+                    }
+                  },
+                  "Linked Series conflict": {
+                    "description": "A Linked Series must be unique within an Asset based on its fragment and series.",
+                    "value": {
+                      "messages": [
+                        "Source for Linked Series with fragment {fragment} and series {series} already exists."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Delete an existing asset",
+        "description": "Deletes an existing asset.\n\n *Required user role: `ROLE_DIGITAL_TWIN_ASSETS_ADMIN` **AND** `ROLE_INVENTORY_ADMIN`*",
+        "operationId": "deleteAsset",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "External ID conflict": {
+                    "description": "The c8y_ExternalId of an Asset must be unique.",
+                    "value": {
+                      "messages": [
+                        "The externalId {externalId} is already used by ManagedObject {id}."
+                      ]
+                    }
+                  },
+                  "Definition conflict": {
+                    "description": "A Property Definition must be unique based on its identifier and context.",
+                    "value": {
+                      "messages": [
+                        "Asset Definition with identifier {identifier} already exists in the given context."
+                      ]
+                    }
+                  },
+                  "Linked Series conflict": {
+                    "description": "A Linked Series must be unique within an Asset based on its fragment and series.",
+                    "value": {
+                      "messages": [
+                        "Source for Linked Series with fragment {fragment} and series {series} already exists."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "delete"
+      }
+    },
+    "/assets/{assetId}/linkedSeries/{fragment}/{series}/source": {
+      "get": {
+        "tags": [
+          "Linked Series"
+        ],
+        "summary": "Retrieve the source for a given linked series",
+        "description": "Retrieves the source for a given linked series of an asset.\n\n Linked series are identified by their `fragment` **and** `series`.",
+        "operationId": "getLinkedSeriesSource",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fragment",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "series",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Source"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ]
+      },
+      "put": {
+        "tags": [
+          "Linked Series"
+        ],
+        "summary": "Update the source for a given linked series",
+        "description": "Updates an existing source for a given linked series of an asset.\n\n Linked series are identified by their `fragment` **and** `series`.  \n\n *Required user role: `ROLE_DIGITAL_TWIN_ASSETS_UPDATE` or `ROLE_DIGITAL_TWIN_ASSETS_ADMIN` or `ROLE_DIGITAL_TWIN_LINKING_UPDATE` or `ROLE_DIGITAL_TWIN_LINKING_ADMIN`*.",
+        "operationId": "updateLinkedSeriesSource",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fragment",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "series",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fetchTypeFromSource",
+            "in": "query",
+            "description": "Indicates the resource to fetch the Measurement type associated with the linked device, derived from recorded Measurements. This parameter can be overruled by setting the Tenant Option `assets.linkedSeries.source.measurementType.mode`. If set to `required`, the Measurement type is mandatory and always fetched. An error is thrown if no Measurement Type is found. If set to `disabled`, the Measurement type is not fetched at all.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Source"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Source"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Linked Series"
+        ],
+        "summary": "Set the source for a given linked series",
+        "description": "Adds a new source for a given linked series of an asset.\n\n Linked series are identified by their `fragment` **and** `series`.  \n\n *Required user role: `ROLE_DIGITAL_TWIN_ASSETS_CREATE` or `ROLE_DIGITAL_TWIN_ASSETS_ADMIN` or `ROLE_DIGITAL_TWIN_LINKING_CREATE` or `ROLE_DIGITAL_TWIN_LINKING_ADMIN`*.",
+        "operationId": "createLinkedSeriesSource",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fragment",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "series",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fetchTypeFromSource",
+            "in": "query",
+            "description": "Indicates the resource to fetch the Measurement type associated with the linked device, derived from recorded Measurements. This parameter can be overruled by setting the Tenant Option `assets.linkedSeries.source.measurementType.mode`. If set to `required`, the Measurement type is mandatory and always fetched. An error is thrown if no Measurement Type is found. If set to `disabled`, the Measurement type is not fetched at all.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Source"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Source"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "External ID conflict": {
+                    "description": "The c8y_ExternalId of an Asset must be unique.",
+                    "value": {
+                      "messages": [
+                        "The externalId {externalId} is already used by ManagedObject {id}."
+                      ]
+                    }
+                  },
+                  "Definition conflict": {
+                    "description": "A Property Definition must be unique based on its identifier and context.",
+                    "value": {
+                      "messages": [
+                        "Asset Definition with identifier {identifier} already exists in the given context."
+                      ]
+                    }
+                  },
+                  "Linked Series conflict": {
+                    "description": "A Linked Series must be unique within an Asset based on its fragment and series.",
+                    "value": {
+                      "messages": [
+                        "Source for Linked Series with fragment {fragment} and series {series} already exists."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Linked Series"
+        ],
+        "summary": "Delete the source for a given linked series",
+        "description": "Deletes an existing source for a given linked series of an asset.\n\n Linked series are identified by their `fragment` **and** `series`.  \n\n *Required user role: `ROLE_DIGITAL_TWIN_ASSETS_ADMIN` or `ROLE_DIGITAL_TWIN_LINKING_ADMIN`*.",
+        "operationId": "deleteLinkedSeriesSource",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fragment",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "series",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ]
+      }
+    },
+    "/assets/{assetId}/linkedSeries/{fragment}/{series}/source/type": {
+      "put": {
+        "tags": [
+          "Linked Series"
+        ],
+        "summary": "Update the measurement type of a linked series source",
+        "description": "Modifies the `type` of a source of a linked series for a given asset. If the `fetchTypeFromSource` is set to\n`true`, the type specified in the body of the request will be ignored. Instead, the value is fetched from the last measurement of\nthe device defined by the which `source.id`.",
+        "operationId": "updateMeasurementType",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fragment",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "series",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fetchTypeFromSource",
+            "in": "query",
+            "description": "Indicates the resource to fetch the Measurement type associated with the linked device, derived from recorded Measurements. This parameter can be overruled by setting the Tenant Option `assets.linkedSeries.source.measurementType.mode`. If set to `required`, the Measurement type is mandatory and always fetched. An error is thrown if no Measurement Type is found. If set to `disabled`, the Measurement type is not fetched at all.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Source"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "identifier is invalid": {
+                    "description": "identifier is invalid",
+                    "value": {
+                      "messages": [
+                        "identifier {identifier} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark or periods. Whitespace is not allowed."
+                      ]
+                    }
+                  },
+                  "title is invalid": {
+                    "description": "title is invalid",
+                    "value": {
+                      "messages": [
+                        "title {title} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark, whitespace or periods."
+                      ]
+                    }
+                  },
+                  "Limit exceeded": {
+                    "description": "This error occurs when a predefined limit for a specific entity (e.g. 'Property Definition') has been reached. The limits can be adjusted by setting a tenant option.",
+                    "value": {
+                      "messages": [
+                        "{Entity} limit of {maxCount} reached. Further creation is not allowed."
+                      ]
+                    }
+                  },
+                  "Json Schema exceeds allowed properties": {
+                    "description": "The Json schema defined for the Definition exceeds the maximum number of allowed properties. Either reduce the number of properties to meet the limit or change the limit by adjusting the tenant option.",
+                    "value": {
+                      "messages": [
+                        "Json Schema has {x} properties but only up to {maxCount} are allowed."
+                      ]
+                    }
+                  },
+                  "Inapplicable context": {
+                    "description": "The given Property Definition is not applicable to the required context and can therefore not be used in the composition of the Asset or MEA Definition.",
+                    "value": {
+                      "messages": [
+                        "Property Definition {identifier} is not applicable to context {context} and cannot be used in composition."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ]
+      }
+    },
+    "/assets/{assetId}/linkedSeries/{fragment}/{series}/label": {
+      "put": {
+        "tags": [
+          "Linked Series"
+        ],
+        "summary": "Update the label of a linked series",
+        "description": "Modifies the `label` of a linked series for a given asset.",
+        "operationId": "updateLabel",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fragment",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "series",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LinkedSeries"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ]
+      }
+    },
+    "/definitions/properties": {
+      "get": {
+        "tags": [
+          "Property Definitions"
+        ],
+        "summary": "Retrieve all Property Definitions",
+        "description": "Finds a collection of `Property Definition`s.\n\n This resource offers diverse filtering capabilities, yet it's essential to consider data consistency rules: \n\n * Passing only one `identifier` results in `0...1` `Property Definition`s.\n\n * Passing only one `title` results in `0...1` `Property Definition`s.\n\n\n\n\n\n The following rules will be applied when searching for the `Property Definition`s: \n\n * `identifiers`, `titles`, `tags` will be concatenated using logical AND operators\n\n * Values within a filter will be concatenated using a logical OR operator\n\n  For instance, the query filter `?identifiers=id_a,id_b&title=position` results in the following query filter:` (identifier equals id_a OR identifier equals id_b) AND title equals position `<i>Will be executed in context of an `Storage` tenant.</i>",
+        "operationId": "getPropertyDefinitions",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "description": "Use the `$filter` keyword to specify filtering criteria. Filtering can be applied to properties of the asset. Detailed information can be found within the Cumulocity core OpenAPI [here](https://cumulocity.com/api/core/#tag/Query-language).",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "Filter by name": {
+                "description": "Filter by name",
+                "value": "$filter=name eq 'Windfarm'"
+              },
+              "Filter by type": {
+                "description": "Filter by type",
+                "value": "$filter=type eq 'c8y_*'"
+              },
+              "Using orderby": {
+                "description": "Using orderby",
+                "value": "$orderby=id asc"
+              }
+            }
+          },
+          {
+            "name": "identifiers",
+            "in": "query",
+            "description": "List of `identifiers`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "titles",
+            "in": "query",
+            "description": "List of `titles`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "List of `tags`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "origin",
+            "in": "query",
+            "description": "Indicates the resource to filter for the specified origin of the Property Definitions.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "applicableTo",
+            "in": "query",
+            "description": "Limits the response to Property Definitions applicable to the specified domain entity.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "measurement",
+                "event",
+                "alarm",
+                "audit",
+                "operation",
+                "asset",
+                "tenant_option"
+              ]
+            }
+          },
+          {
+            "name": "currentPage",
+            "in": "query",
+            "description": "The current page number to be retrieved.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "The number of items to be displayed on each page.",
+            "required": false,
+            "schema": {
+              "maximum": 2000,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedDefinitionList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "list"
+      },
+      "post": {
+        "tags": [
+          "Property Definitions"
+        ],
+        "summary": "Create a new Property Definition",
+        "description": "Creates a new `Property Definition`.\n\n This operation ensures consistency by enforcing the following rules: \n\n * The `identifier` of the `Property Definition` must be unique for the given `context`s.\n\n * If a `title` is provided, it must also be unique.\n\n * None of the `context`s must not be used by another `Property Definition` with the same `identifier`.\n\n\n\n\n\n The supplied JSON Schema must conform to the [JSON Schema Draft-7 specification](http://json-schema.org/draft-07/schema).",
+        "operationId": "createPropertyDefinition",
+        "requestBody": {
+          "description": "The data payload representing the `Property Definition` to be created.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PropertyDefinition"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PropertyDefinition"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "identifier is invalid": {
+                    "description": "identifier is invalid",
+                    "value": {
+                      "messages": [
+                        "identifier {identifier} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark or periods. Whitespace is not allowed."
+                      ]
+                    }
+                  },
+                  "title is invalid": {
+                    "description": "title is invalid",
+                    "value": {
+                      "messages": [
+                        "title {title} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark, whitespace or periods."
+                      ]
+                    }
+                  },
+                  "Limit exceeded": {
+                    "description": "This error occurs when a predefined limit for a specific entity (e.g. 'Property Definition') has been reached. The limits can be adjusted by setting a tenant option.",
+                    "value": {
+                      "messages": [
+                        "{Entity} limit of {maxCount} reached. Further creation is not allowed."
+                      ]
+                    }
+                  },
+                  "Json Schema exceeds allowed properties": {
+                    "description": "The Json schema defined for the Definition exceeds the maximum number of allowed properties. Either reduce the number of properties to meet the limit or change the limit by adjusting the tenant option.",
+                    "value": {
+                      "messages": [
+                        "Json Schema has {x} properties but only up to {maxCount} are allowed."
+                      ]
+                    }
+                  },
+                  "Inapplicable context": {
+                    "description": "The given Property Definition is not applicable to the required context and can therefore not be used in the composition of the Asset or MEA Definition.",
+                    "value": {
+                      "messages": [
+                        "Property Definition {identifier} is not applicable to context {context} and cannot be used in composition."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "create"
+      }
+    },
+    "/definitions/properties/compose": {
+      "post": {
+        "tags": [
+          "Property Definitions"
+        ],
+        "summary": "Create JSON schema from Property Definitions",
+        "description": "Creates a JSON schema object type.\n\n This operation constructs a JSON Schema object type that encapsulates one or more `Property Definition`s as its properties. The resulting schema will include all provided `Property Definition`s. \n\n The `Property Definition`s to be included are supplied in the request body. At least one `Property Definition` must be provided and identified by its `identifier`. If a `Property Definition` applies to a specific domain entity, a corresponding `context` must also be supplied.",
+        "operationId": "composePropertyDefinitions",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/PropertyDefinition"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonSchema"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ]
+      }
+    },
+    "/assets": {
+      "get": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Retrieve assets",
+        "description": "Retrieves all assets registered in your tenant.\n\n The `query` parameter supports a flexible syntax for filtering and ordering results.",
+        "operationId": "getAssets",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "description": "Use the `$filter` keyword to specify filtering criteria. Filtering can be applied to properties of the asset. Detailed information can be found within the Cumulocity core OpenAPI [here](https://cumulocity.com/api/core/#tag/Query-language).",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "Filter by name": {
+                "description": "Filter by name",
+                "value": "$filter=name eq 'Windfarm'"
+              },
+              "Filter by type": {
+                "description": "Filter by type",
+                "value": "$filter=type eq 'c8y_*'"
+              },
+              "Using orderby": {
+                "description": "Using orderby",
+                "value": "$orderby=id asc"
+              }
+            }
+          },
+          {
+            "name": "withLinkedSeries",
+            "in": "query",
+            "description": "Indicates the resource to add the `c8y_LinkedSeries` fragment in the response.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "withSubAssets",
+            "in": "query",
+            "description": "Indicates the resource to add the sub-assets in the response.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "onlyRoots",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "currentPage",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "maximum": 2000,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedAssetList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "list"
+      },
+      "post": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Create or update an asset",
+        "description": "Creates or updates an Asset, for example, a room within a building.\n\n In general, each asset may consist of: \n\n * The name of the asset.\n\n * The most specific type of the asset.\n\n * Fragments with specific meanings, for example, c8y_Position, c8y_SupportedOperations.\n\n * Fragment `c8y_ExternalId` which uniquely identifies the asset in an external system.\n\n * If a value for the property `id` is provided, it will be ignored.\n\n\n\n If an asset with the given external ID exists and `X-Upsert-Mode` is true, the asset will be updated and the response code will be 200. If an asset with the given external ID exists and `X-Upsert-Mode` is false, a conflict error will be returned. If no asset with the given external ID exists, a new asset will be created (independent of the `X-Upsert-Mode`) and the response code will be 201.",
+        "operationId": "createAsset",
+        "parameters": [
+          {
+            "name": "fetchTypeFromSource",
+            "in": "query",
+            "description": "Indicates the resource to fetch the Measurement type associated with the linked device, derived from recorded Measurements. This parameter can be overruled by setting the Tenant Option `assets.linkedSeries.source.measurementType.mode`. If set to `required`, the Measurement type is mandatory and always fetched. An error is thrown if no Measurement Type is found. If set to `disabled`, the Measurement type is not fetched at all.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "X-Upsert-Mode",
+            "in": "header",
+            "description": "Determines if an existing Asset should be updated or not. If the Asset is found (identified by the provided `c8y_ExternalId`), and the `upsertMode` is set to `true`, the Asset will be updated. If the `upsertMode` is set to `false` (default), a `409 Conflict` error will be returned.",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Asset"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "If an existing asset is updated, the response code is 200.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Asset"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "If a new asset is created, the response code is 201.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Asset"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "identifier is invalid": {
+                    "description": "identifier is invalid",
+                    "value": {
+                      "messages": [
+                        "identifier {identifier} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark or periods. Whitespace is not allowed."
+                      ]
+                    }
+                  },
+                  "title is invalid": {
+                    "description": "title is invalid",
+                    "value": {
+                      "messages": [
+                        "title {title} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark, whitespace or periods."
+                      ]
+                    }
+                  },
+                  "Limit exceeded": {
+                    "description": "This error occurs when a predefined limit for a specific entity (e.g. 'Property Definition') has been reached. The limits can be adjusted by setting a tenant option.",
+                    "value": {
+                      "messages": [
+                        "{Entity} limit of {maxCount} reached. Further creation is not allowed."
+                      ]
+                    }
+                  },
+                  "Json Schema exceeds allowed properties": {
+                    "description": "The Json schema defined for the Definition exceeds the maximum number of allowed properties. Either reduce the number of properties to meet the limit or change the limit by adjusting the tenant option.",
+                    "value": {
+                      "messages": [
+                        "Json Schema has {x} properties but only up to {maxCount} are allowed."
+                      ]
+                    }
+                  },
+                  "Inapplicable context": {
+                    "description": "The given Property Definition is not applicable to the required context and can therefore not be used in the composition of the Asset or MEA Definition.",
+                    "value": {
+                      "messages": [
+                        "Property Definition {identifier} is not applicable to context {context} and cannot be used in composition."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "External ID conflict": {
+                    "description": "The c8y_ExternalId of an Asset must be unique.",
+                    "value": {
+                      "messages": [
+                        "The externalId {externalId} is already used by ManagedObject {id}."
+                      ]
+                    }
+                  },
+                  "Definition conflict": {
+                    "description": "A Property Definition must be unique based on its identifier and context.",
+                    "value": {
+                      "messages": [
+                        "Asset Definition with identifier {identifier} already exists in the given context."
+                      ]
+                    }
+                  },
+                  "Linked Series conflict": {
+                    "description": "A Linked Series must be unique within an Asset based on its fragment and series.",
+                    "value": {
+                      "messages": [
+                        "Source for Linked Series with fragment {fragment} and series {series} already exists."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "create"
+      }
+    },
+    "/assets/{assetId}/subAssets/{subAssetId}": {
+      "post": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Assign an asset as a sub-asset",
+        "description": "Assigns an asset as a sub-asset.\n\n Associates the specified asset, identified by its ID, with a parent asset. The sub-asset must already exist. If one of the IDs does not exist, the operation responds with `HTTP 404`. If one of the IDs is not an Asset, the operation responds with `HTTP 422`.  \n\n *Required user role: `ROLE_DIGITAL_TWIN_ASSETS_ADMIN` **AND** `ROLE_INVENTORY_ADMIN`*",
+        "operationId": "assignSubAsset",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "subAssetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Asset"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unprocessable Entity": {
+                    "description": "The provided id does exist but the corresponding ManagedObject is not an Asset and can therefore not be used in the requested operation.",
+                    "value": {
+                      "messages": [
+                        "ManagedObject with id {id} is not an Asset."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Remove a sub-asset from its parent asset",
+        "description": "Removes a sub-asset from its parent asset.\n\n Removes the association of the specified asset, identified by its ID, with a parent asset. If one of the IDs does not exist, the operation responds with `HTTP 404`. If one of the IDs is not an Asset, the operation responds with `HTTP 422`.  \n\n *Required user role: `ROLE_DIGITAL_TWIN_ASSETS_ADMIN` **AND** `ROLE_INVENTORY_ADMIN`*",
+        "operationId": "unassignSubAsset",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "subAssetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unprocessable Entity": {
+                    "description": "The provided id does exist but the corresponding ManagedObject is not an Asset and can therefore not be used in the requested operation.",
+                    "value": {
+                      "messages": [
+                        "ManagedObject with id {id} is not an Asset."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ]
+      }
+    },
+    "/assets/{assetId}/linkedSeries": {
+      "get": {
+        "tags": [
+          "Linked Series"
+        ],
+        "summary": "Retrieve linked series for an asset",
+        "description": "Retrieves linked series for a given asset.\n\n Supports optionally searching for a specific `fragment` and/or `series`.  \n\n The `withMeasurementType` query parameter is used to explicitly query the `type` of the measurements which are linked via the `source.id`. This parameter is only relevant if only one `LinkedSeries` is to be returned.",
+        "operationId": "getLinkedSeries",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "series",
+            "in": "query",
+            "description": "The specific series to search for.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fragment",
+            "in": "query",
+            "description": "A characteristic which identifies the measurement.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "withMeasurementType",
+            "in": "query",
+            "description": "Indicates the resource to fetch the Measurement type for this Asset.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "withJsonSchema",
+            "in": "query",
+            "description": "If true, the response includes the inferred JSON schema describing all linked series of this Asset.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "currentPage",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "maximum": 2000,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/vnd.com.nsn.cumulocity.linkedseriescollection+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedLinkedSeriesList"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LinkedSeries"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "Linked Series"
+        ],
+        "summary": "Add new and update existing linked series",
+        "description": "Adds new and updates existing linked series for a given asset.\n\n Linked series are identified by their `fragment` **and** `series`.  \n\n For each LinkedSeries provided in the body: \n\n * Adds the new linked series when it does not exist.\n\n * Updates the linked series when it already exists.\n\n\n\n\n\n *Required user role for adding a linked series: `ROLE_DIGITAL_TWIN_ASSETS_CREATE` or `ROLE_DIGITAL_TWIN_ASSETS_ADMIN`*.\n\n *Required user role for updating a linked series: `ROLE_DIGITAL_TWIN_ASSETS_UPDATE` or `ROLE_DIGITAL_TWIN_ASSETS_ADMIN`*.",
+        "operationId": "addAndUpdateLinkedSeries",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fetchTypeFromSource",
+            "in": "query",
+            "description": "Indicates the resource to fetch the Measurement type associated with the linked device, derived from recorded Measurements. This parameter can be overruled by setting the Tenant Option `assets.linkedSeries.source.measurementType.mode`. If set to `required`, the Measurement type is mandatory and always fetched. An error is thrown if no Measurement Type is found. If set to `disabled`, the Measurement type is not fetched at all.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/LinkedSeries"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Asset"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "identifier is invalid": {
+                    "description": "identifier is invalid",
+                    "value": {
+                      "messages": [
+                        "identifier {identifier} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark or periods. Whitespace is not allowed."
+                      ]
+                    }
+                  },
+                  "title is invalid": {
+                    "description": "title is invalid",
+                    "value": {
+                      "messages": [
+                        "title {title} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark, whitespace or periods."
+                      ]
+                    }
+                  },
+                  "Limit exceeded": {
+                    "description": "This error occurs when a predefined limit for a specific entity (e.g. 'Property Definition') has been reached. The limits can be adjusted by setting a tenant option.",
+                    "value": {
+                      "messages": [
+                        "{Entity} limit of {maxCount} reached. Further creation is not allowed."
+                      ]
+                    }
+                  },
+                  "Json Schema exceeds allowed properties": {
+                    "description": "The Json schema defined for the Definition exceeds the maximum number of allowed properties. Either reduce the number of properties to meet the limit or change the limit by adjusting the tenant option.",
+                    "value": {
+                      "messages": [
+                        "Json Schema has {x} properties but only up to {maxCount} are allowed."
+                      ]
+                    }
+                  },
+                  "Inapplicable context": {
+                    "description": "The given Property Definition is not applicable to the required context and can therefore not be used in the composition of the Asset or MEA Definition.",
+                    "value": {
+                      "messages": [
+                        "Property Definition {identifier} is not applicable to context {context} and cannot be used in composition."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Linked Series"
+        ],
+        "summary": "Delete a specific linked series",
+        "description": "Deletes a linked series for a given asset.\n\n Deletes all linked series. Specify `fragment` and/or `series` as query parameters to be more specific about the linked series to be deleted.  \n\n *Required user role: `ROLE_DIGITAL_TWIN_ASSETS_ADMIN`*.",
+        "operationId": "deleteLinkedSeries",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fragment",
+            "in": "query",
+            "description": "A characteristic which identifies the measurement.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "series",
+            "in": "query",
+            "description": "The specific series to search for.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ]
+      }
+    },
+    "/assets/{assetId}/devices/{deviceId}": {
+      "post": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Assign a device to an asset",
+        "description": "Assigns a device to an asset.\n\n Associates the specified device, identified by its ID, with an asset. The device must already exist. If one of the IDs does not exist, the operation responds with `HTTP 404`. If the managed object for the assetId is not an asset or of the managed object for the deviceId is not a Device, the operation responds with `HTTP 422`.  \n\n *Required user role: `ROLE_DIGITAL_TWIN_ASSETS_ADMIN` **AND** `ROLE_INVENTORY_ADMIN`*",
+        "operationId": "assignDevice",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "deviceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Asset"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unprocessable Entity": {
+                    "description": "The provided id does exist but the corresponding ManagedObject is not an Asset and can therefore not be used in the requested operation.",
+                    "value": {
+                      "messages": [
+                        "ManagedObject with id {id} is not an Asset."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Remove a device from an asset",
+        "description": "Removes a device from an asset.\n\n Removes the association of the specified device, identified by its ID, with an asset. If one of the IDs does not exist, the operation responds with `HTTP 404`. If the managed object for the assetId is not an asset or of the managed object for the deviceId is not a Device, the operation responds with `HTTP 422`. \n\n\n\n *Required user role: `ROLE_DIGITAL_TWIN_ASSETS_ADMIN` **AND** `ROLE_INVENTORY_ADMIN`*",
+        "operationId": "unassignDevice",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "deviceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unprocessable Entity": {
+                    "description": "The provided id does exist but the corresponding ManagedObject is not an Asset and can therefore not be used in the requested operation.",
+                    "value": {
+                      "messages": [
+                        "ManagedObject with id {id} is not an Asset."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ]
+      }
+    },
+    "/definitions/properties/tags": {
+      "get": {
+        "tags": [
+          "Property Definitions"
+        ],
+        "summary": "Retrieve tags of given Property Definitions",
+        "description": "Finds a collection of `Property Definition`s but returns only their associated `tag`s.",
+        "operationId": "getPropertyDefinitionTags",
+        "parameters": [
+          {
+            "name": "identifiers",
+            "in": "query",
+            "description": "List of `identifiers`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "titles",
+            "in": "query",
+            "description": "List of `titles`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-codegen-resource-name": "listTags"
+      }
+    },
+    "/definitions/properties/count": {
+      "get": {
+        "tags": [
+          "Property Definitions"
+        ],
+        "summary": "Get the count of all Property Definitions",
+        "description": "Counts the collection of `Property Definition`s.\n\n The following rules will be applied when searching for the `Property Definition`s: \n\n * `identifiers`, `titles`, `tags` will be concatenated using logical AND operators\n\n * Values within a filter will be concatenated using a logical OR operator\n\n  For instance, the query filter `?identifiers=id_a,id_b&title=position` results in the following query filter:` (identifier equals id_a OR identifier equals id_b) AND title equals position `\n\n *Will be executed in context of an `Storage` tenant.*",
+        "operationId": "countPropertyDefinitions",
+        "parameters": [
+          {
+            "name": "identifiers",
+            "in": "query",
+            "description": "List of `identifiers`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "titles",
+            "in": "query",
+            "description": "List of `titles`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "List of `tags`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "applicableTo",
+            "in": "query",
+            "description": "Limits the response to Property Definitions applicable to the specified domain entity.",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "measurement",
+                "event",
+                "alarm",
+                "audit",
+                "operation",
+                "asset",
+                "tenant_option"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "identifier is invalid": {
+                    "description": "identifier is invalid",
+                    "value": {
+                      "messages": [
+                        "identifier {identifier} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark or periods. Whitespace is not allowed."
+                      ]
+                    }
+                  },
+                  "title is invalid": {
+                    "description": "title is invalid",
+                    "value": {
+                      "messages": [
+                        "title {title} is invalid! It must start with a letter or digit, followed by any number of letters, digits, hyphens, underscores, colons, exclamation mark, whitespace or periods."
+                      ]
+                    }
+                  },
+                  "Limit exceeded": {
+                    "description": "This error occurs when a predefined limit for a specific entity (e.g. 'Property Definition') has been reached. The limits can be adjusted by setting a tenant option.",
+                    "value": {
+                      "messages": [
+                        "{Entity} limit of {maxCount} reached. Further creation is not allowed."
+                      ]
+                    }
+                  },
+                  "Json Schema exceeds allowed properties": {
+                    "description": "The Json schema defined for the Definition exceeds the maximum number of allowed properties. Either reduce the number of properties to meet the limit or change the limit by adjusting the tenant option.",
+                    "value": {
+                      "messages": [
+                        "Json Schema has {x} properties but only up to {maxCount} are allowed."
+                      ]
+                    }
+                  },
+                  "Inapplicable context": {
+                    "description": "The given Property Definition is not applicable to the required context and can therefore not be used in the composition of the Asset or MEA Definition.",
+                    "value": {
+                      "messages": [
+                        "Property Definition {identifier} is not applicable to context {context} and cannot be used in composition."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-codegen-resource-name": "count"
+      }
+    },
+    "/definitions/measurements/{identifier}": {
+      "get": {
+        "tags": [
+          "Measurement Definitions"
+        ],
+        "summary": "Retrieve a Measurement Definition by identifier",
+        "description": "Finds a `Measurement Definition` by its `identifier`.\n\n The `identifier` needs to point to an existing `Measurement Definition`, otherwise this operation responds in `HTTP 404`.",
+        "operationId": "getMeasurementDefinition",
+        "parameters": [
+          {
+            "name": "identifier",
+            "in": "path",
+            "description": "The key used to uniquely identify the `Measurement Definition`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeasurementDefinition"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "detail"
+      },
+      "delete": {
+        "tags": [
+          "Measurement Definitions"
+        ],
+        "summary": "Delete an existing Measurement Definition",
+        "description": "Deletes an existing `Measurement Definition` by its `identifier`.",
+        "operationId": "deleteMeasurementDefinition",
+        "parameters": [
+          {
+            "name": "identifier",
+            "in": "path",
+            "description": "The key used to uniquely identify the `Measurement Definition`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "External ID conflict": {
+                    "description": "The c8y_ExternalId of an Asset must be unique.",
+                    "value": {
+                      "messages": [
+                        "The externalId {externalId} is already used by ManagedObject {id}."
+                      ]
+                    }
+                  },
+                  "Definition conflict": {
+                    "description": "A Property Definition must be unique based on its identifier and context.",
+                    "value": {
+                      "messages": [
+                        "Asset Definition with identifier {identifier} already exists in the given context."
+                      ]
+                    }
+                  },
+                  "Linked Series conflict": {
+                    "description": "A Linked Series must be unique within an Asset based on its fragment and series.",
+                    "value": {
+                      "messages": [
+                        "Source for Linked Series with fragment {fragment} and series {series} already exists."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "delete"
+      }
+    },
+    "/definitions/measurements/tags": {
+      "get": {
+        "tags": [
+          "Measurement Definitions"
+        ],
+        "summary": "Retrieve tags of given Measurement Definitions",
+        "description": "Finds a collection of `Measurement Definition`s but returns only their associated `tag`s.",
+        "operationId": "getMeasurementDefinitionTags",
+        "parameters": [
+          {
+            "name": "identifiers",
+            "in": "query",
+            "description": "List of `identifiers`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "titles",
+            "in": "query",
+            "description": "List of `titles`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-codegen-resource-name": "listTags"
+      }
+    },
+    "/definitions/measurements/count": {
+      "get": {
+        "tags": [
+          "Measurement Definitions"
+        ],
+        "summary": "Get the count of all Measurement Definitions",
+        "description": "Counts the collection of `Measurement Definition`s.\n\n The following rules will be applied when searching for the `Measurement Definition`s: \n\n * `identifiers`, `titles`, `tags` will be concatenated using logical AND operators\n\n * Values within a filter will be concatenated using a logical OR operator\n\n  For instance, the query filter `?identifiers=id_a,id_b&title=position` results in the following query filter:` (identifier equals id_a OR identifier equals id_b) AND title equals position `\n\n *Will be executed in context of an `Storage` tenant.*",
+        "operationId": "countMeasurementDefinitions",
+        "parameters": [
+          {
+            "name": "identifiers",
+            "in": "query",
+            "description": "List of `identifiers`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "titles",
+            "in": "query",
+            "description": "List of `titles`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "List of `tags`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-codegen-resource-name": "count"
+      }
+    },
+    "/definitions/events/{identifier}": {
+      "get": {
+        "tags": [
+          "Event Definitions"
+        ],
+        "summary": "Retrieve an Event Definition by identifier",
+        "description": "Finds a `Event Definition` by its `identifier`.\n\n The `identifier` needs to point to an existing `Event Definition`, otherwise this operation responds in `HTTP 404`.",
+        "operationId": "getEventDefinition",
+        "parameters": [
+          {
+            "name": "identifier",
+            "in": "path",
+            "description": "The key used to uniquely identify the `Event Definition`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventDefinition"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "detail"
+      },
+      "delete": {
+        "tags": [
+          "Event Definitions"
+        ],
+        "summary": "Delete an existing Event Definition",
+        "description": "Deletes an existing `Event Definition` by its `identifier`.",
+        "operationId": "deleteEventDefinition",
+        "parameters": [
+          {
+            "name": "identifier",
+            "in": "path",
+            "description": "The key used to uniquely identify the `Event Definition`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "External ID conflict": {
+                    "description": "The c8y_ExternalId of an Asset must be unique.",
+                    "value": {
+                      "messages": [
+                        "The externalId {externalId} is already used by ManagedObject {id}."
+                      ]
+                    }
+                  },
+                  "Definition conflict": {
+                    "description": "A Property Definition must be unique based on its identifier and context.",
+                    "value": {
+                      "messages": [
+                        "Asset Definition with identifier {identifier} already exists in the given context."
+                      ]
+                    }
+                  },
+                  "Linked Series conflict": {
+                    "description": "A Linked Series must be unique within an Asset based on its fragment and series.",
+                    "value": {
+                      "messages": [
+                        "Source for Linked Series with fragment {fragment} and series {series} already exists."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "delete"
+      }
+    },
+    "/definitions/events/tags": {
+      "get": {
+        "tags": [
+          "Event Definitions"
+        ],
+        "summary": "Retrieve tags of given Event Definitions",
+        "description": "Finds a collection of `Event Definition`s but returns only their associated `tag`s.",
+        "operationId": "getEventDefinitionTags",
+        "parameters": [
+          {
+            "name": "identifiers",
+            "in": "query",
+            "description": "List of `identifiers`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "titles",
+            "in": "query",
+            "description": "List of `titles`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-codegen-resource-name": "listTags"
+      }
+    },
+    "/definitions/events/count": {
+      "get": {
+        "tags": [
+          "Event Definitions"
+        ],
+        "summary": "Get the count of all Event Definitions",
+        "description": "Counts the collection of `Event Definition`s.\n\n The following rules will be applied when searching for the `Event Definition`s: \n\n * `identifiers`, `titles`, `tags` will be concatenated using logical AND operators\n\n * Values within a filter will be concatenated using a logical OR operator\n\n  For instance, the query filter `?identifiers=id_a,id_b&title=position` results in the following query filter:` (identifier equals id_a OR identifier equals id_b) AND title equals position `\n\n *Will be executed in context of an `Storage` tenant.*",
+        "operationId": "countEventDefinitions",
+        "parameters": [
+          {
+            "name": "identifiers",
+            "in": "query",
+            "description": "List of `identifiers`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "titles",
+            "in": "query",
+            "description": "List of `titles`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "List of `tags`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-codegen-resource-name": "count"
+      }
+    },
+    "/definitions/assets/{identifier}": {
+      "get": {
+        "tags": [
+          "Asset Definitions"
+        ],
+        "summary": "Retrieve an Asset Definition by identifier",
+        "description": "Finds a `Asset Definition` by its `identifier`.\n\n The `identifier` needs to point to an existing `Asset Definition`, otherwise this operation responds in `HTTP 404`.",
+        "operationId": "getAssetDefinition",
+        "parameters": [
+          {
+            "name": "identifier",
+            "in": "path",
+            "description": "The key used to uniquely identify the `Asset Definition`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetDefinition"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "detail"
+      },
+      "delete": {
+        "tags": [
+          "Asset Definitions"
+        ],
+        "summary": "Delete an existing Asset Definition",
+        "description": "Deletes an existing `Asset Definition` by its `identifier`.",
+        "operationId": "deleteAssetDefinition",
+        "parameters": [
+          {
+            "name": "identifier",
+            "in": "path",
+            "description": "The key used to uniquely identify the `Asset Definition`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "External ID conflict": {
+                    "description": "The c8y_ExternalId of an Asset must be unique.",
+                    "value": {
+                      "messages": [
+                        "The externalId {externalId} is already used by ManagedObject {id}."
+                      ]
+                    }
+                  },
+                  "Definition conflict": {
+                    "description": "A Property Definition must be unique based on its identifier and context.",
+                    "value": {
+                      "messages": [
+                        "Asset Definition with identifier {identifier} already exists in the given context."
+                      ]
+                    }
+                  },
+                  "Linked Series conflict": {
+                    "description": "A Linked Series must be unique within an Asset based on its fragment and series.",
+                    "value": {
+                      "messages": [
+                        "Source for Linked Series with fragment {fragment} and series {series} already exists."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "delete"
+      }
+    },
+    "/definitions/assets/count": {
+      "get": {
+        "tags": [
+          "Asset Definitions"
+        ],
+        "summary": "Get count of Asset Definitions",
+        "description": "Counts the collection of `Asset Definition`s.\n\n The following rules will be applied when searching for the `Asset Definition`s: \n\n * `identifiers`, `titles`, `onlyRoots` will be concatenated using logical AND operators\n\n * Values within a filter will be concatenated using a logical OR operator\n\n  For instance, the query filter `?identifiers=id_a,id_b&title=position` results in the following query filter:` (identifier equals id_a OR identifier equals id_b) AND title equals position `\n\n *Will be executed in context of an `Storage` tenant.*",
+        "operationId": "countAssetDefinitions",
+        "parameters": [
+          {
+            "name": "identifiers",
+            "in": "query",
+            "description": "List of `identifiers`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "titles",
+            "in": "query",
+            "description": "List of `titles`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "List of `tags`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "onlyRoots",
+            "in": "query",
+            "description": "Only consider `Asset Definition`s not used within the hierarchy of another `Asset Definition`.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-codegen-resource-name": "count"
+      }
+    },
+    "/definitions/alarms/{identifier}": {
+      "get": {
+        "tags": [
+          "Alarm Definitions"
+        ],
+        "summary": "Retrieve an Alarm Definition by identifier",
+        "description": "Retrieves an `Alarm Definition` by its `identifier`.\n\n The `identifier` needs to point to an existing `Alarm Definition`, otherwise this operation respond in `HTTP 404`.",
+        "operationId": "getAlarmDefinition",
+        "parameters": [
+          {
+            "name": "identifier",
+            "in": "path",
+            "description": "The key used to uniquely identify the `Alarm Definition`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlarmDefinition"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "detail"
+      },
+      "delete": {
+        "tags": [
+          "Alarm Definitions"
+        ],
+        "summary": "Delete an existing Alarm Definition",
+        "description": "Deletes an existing `Alarm Definition` by its `identifier`.",
+        "operationId": "deleteAlarmDefinition",
+        "parameters": [
+          {
+            "name": "identifier",
+            "in": "path",
+            "description": "The key used to uniquely identify the `Alarm Definition`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "External ID conflict": {
+                    "description": "The c8y_ExternalId of an Asset must be unique.",
+                    "value": {
+                      "messages": [
+                        "The externalId {externalId} is already used by ManagedObject {id}."
+                      ]
+                    }
+                  },
+                  "Definition conflict": {
+                    "description": "A Property Definition must be unique based on its identifier and context.",
+                    "value": {
+                      "messages": [
+                        "Asset Definition with identifier {identifier} already exists in the given context."
+                      ]
+                    }
+                  },
+                  "Linked Series conflict": {
+                    "description": "A Linked Series must be unique within an Asset based on its fragment and series.",
+                    "value": {
+                      "messages": [
+                        "Source for Linked Series with fragment {fragment} and series {series} already exists."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "delete"
+      }
+    },
+    "/definitions/alarms/tags": {
+      "get": {
+        "tags": [
+          "Alarm Definitions"
+        ],
+        "summary": "Retrieve tags of Alarm Definitions",
+        "description": "Finds a collection of `Alarm Definition`s but returns only their associated `tag`s.",
+        "operationId": "getAlarmDefinitionTags",
+        "parameters": [
+          {
+            "name": "identifiers",
+            "in": "query",
+            "description": "List of `identifiers`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "titles",
+            "in": "query",
+            "description": "List of `titles`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-codegen-resource-name": "listTags"
+      }
+    },
+    "/definitions/alarms/count": {
+      "get": {
+        "tags": [
+          "Alarm Definitions"
+        ],
+        "summary": "Get count of Alarm Definitions",
+        "description": "Counts the collection of `Alarm Definition`s.\n\n The following rules will be applied when searching for the `Alarm Definition`s: \n\n * `identifiers`, `titles`, `tags` will be concatenated using logical AND operators\n\n * Values within a filter will be concatenated using a logical OR operator\n\n  For instance, the query filter `?identifiers=id_a,id_b&title=position` results in the following query filter:` (identifier equals id_a OR identifier equals id_b) AND title equals position `\n\n *Will be executed in context of an `Storage` tenant.*",
+        "operationId": "countAlarmDefinitions",
+        "parameters": [
+          {
+            "name": "identifiers",
+            "in": "query",
+            "description": "List of `identifiers`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "titles",
+            "in": "query",
+            "description": "List of `titles`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "List of `tags`, comma-separated.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-codegen-resource-name": "count"
+      }
+    },
+    "/assets/{assetId}/subAssets": {
+      "get": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Retrieve sub-assets of an asset",
+        "description": "Retrieves sub-assets of an asset.\n\n Fetches all sub-assets of the parent asset specified by `assetId`. You can optionally apply the filter `query`.",
+        "operationId": "getSubAssets",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "description": "Use the `$filter` keyword to specify filtering criteria. Filtering can be applied to properties of the asset. Detailed information can be found within the Cumulocity core OpenAPI [here](https://cumulocity.com/api/core/#tag/Query-language).",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "Filter by name": {
+                "description": "Filter by name",
+                "value": "$filter=name eq 'Windfarm'"
+              },
+              "Filter by type": {
+                "description": "Filter by type",
+                "value": "$filter=type eq 'c8y_*'"
+              },
+              "Using orderby": {
+                "description": "Using orderby",
+                "value": "$orderby=id asc"
+              }
+            }
+          },
+          {
+            "name": "withLinkedSeries",
+            "in": "query",
+            "description": "Indicates the resource to add the `c8y_LinkedSeries` fragment in the response.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "currentPage",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "maximum": 2000,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedAssetList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ]
+      }
+    },
+    "/assets/{assetId}/linkedSeries/count": {
+      "get": {
+        "tags": [
+          "Linked Series"
+        ],
+        "summary": "Get count of linked series for an asset",
+        "description": "Counts linked series for a given asset.\n\n Provides a count of linked series, with optional `fragment` and `series` query parameters to filter and count specific linked series.",
+        "operationId": "countLinkedSeries",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fragment",
+            "in": "query",
+            "description": "A characteristic which identifies the measurement.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "series",
+            "in": "query",
+            "description": "The specific series to search for.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-codegen-resource-name": "count"
+      }
+    },
+    "/assets/{assetId}/devices": {
+      "get": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Retrieve child devices of an asset",
+        "description": "Retrieves child devices of an asset.\n\n Fetches all child devices of the parent asset specified by `assetId`.",
+        "operationId": "getChildDevices",
+        "parameters": [
+          {
+            "name": "assetId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "description": "Use the `$filter` keyword to specify filtering criteria. Filtering can be applied to properties of the asset. Detailed information can be found within the Cumulocity core OpenAPI [here](https://cumulocity.com/api/core/#tag/Query-language).",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "Filter by name": {
+                "description": "Filter by name",
+                "value": "$filter=name eq 'Windfarm'"
+              },
+              "Filter by type": {
+                "description": "Filter by type",
+                "value": "$filter=type eq 'c8y_*'"
+              },
+              "Using orderby": {
+                "description": "Using orderby",
+                "value": "$orderby=id asc"
+              }
+            }
+          },
+          {
+            "name": "currentPage",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "maximum": 2000,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ]
+      }
+    },
+    "/assets/linkedSeries": {
+      "get": {
+        "tags": [
+          "Linked Series"
+        ],
+        "summary": "Retrieve linked series for all assets",
+        "description": "Retrieves linked series for all assets on your tenant.\n\n Provides a list of linked series, with a set of optional query parameters to filter for specific linked series, asset types or asset ids.",
+        "operationId": "getLinkedSeriesByQuery",
+        "parameters": [
+          {
+            "name": "assetIds",
+            "in": "query",
+            "description": "The asset IDs to search for.",
+            "required": false,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "The asset type to search for.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fragment",
+            "in": "query",
+            "description": "A characteristic which identifies the measurement.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "series",
+            "in": "query",
+            "description": "The specific series to search for.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "currentPage",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "maximum": 2000,
+              "minimum": 1,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedAssetList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-c8y-client-semantic": "list"
+      }
+    },
+    "/assets/externalIds/{externalId}": {
+      "get": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Retrieve an asset by its external ID",
+        "description": "Retrieves an Asset by its external ID of type `c8y_ExternalId`.\n\n This endpoint allows clients to look up assets using identifiers from external systems. It resolves the external ID to a ManagedObject and returns the corresponding Asset if found.",
+        "operationId": "getAssetByExternalId",
+        "parameters": [
+          {
+            "name": "externalId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "withLinkedSeries",
+            "in": "query",
+            "description": "Indicates the resource to add the `c8y_LinkedSeries` fragment in the response.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "withSubAssets",
+            "in": "query",
+            "description": "Indicates the resource to add the sub-assets in the response.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Asset"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Asset not found": {
+                    "description": "The Asset with the given ID does not exist.",
+                    "value": {
+                      "messages": [
+                        "Asset with id {assetId} not found."
+                      ]
+                    }
+                  },
+                  "Definition not found": {
+                    "description": "The Property Definition with the given parameters does not exist.",
+                    "value": {
+                      "messages": [
+                        "Property Definition with identifier {identifier} applicable to context {context} not found."
+                      ]
+                    }
+                  },
+                  "Setting not found": {
+                    "description": "The Setting with the given key is not defined for the DTM microservice.",
+                    "value": {
+                      "messages": [
+                        "Setting with key {key} not found."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ]
+      }
+    },
+    "/assets/count": {
+      "get": {
+        "tags": [
+          "Assets"
+        ],
+        "summary": "Get count of assets",
+        "description": "Counts all assets on your tenant.\n\n You can optionally apply the filters `query` and `onlyRoots`.",
+        "operationId": "countAssets",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "description": "Use the `$filter` keyword to specify filtering criteria. Filtering can be applied to properties of the asset. Detailed information can be found within the Cumulocity core OpenAPI [here](https://cumulocity.com/api/core/#tag/Query-language).",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "examples": {
+              "Filter by name": {
+                "description": "Filter by name",
+                "value": "$filter=name eq 'Windfarm'"
+              },
+              "Filter by type": {
+                "description": "Filter by type",
+                "value": "$filter=type eq 'c8y_*'"
+              },
+              "Using orderby": {
+                "description": "Using orderby",
+                "value": "$orderby=id asc"
+              }
+            }
+          },
+          {
+            "name": "onlyRoots",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Unauthorized": {
+                    "description": "The user is not authenticated against the tenant.",
+                    "value": {
+                      "messages": [
+                        "Insufficient permissions."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "tenant not subscribed": {
+                    "description": "You need to subscribe the DTM microservice on the tenant to be able to use the REST API.",
+                    "value": {
+                      "messages": [
+                        "Microservice dtm is not subscribed by tenant {tenantId}."
+                      ]
+                    }
+                  },
+                  "access from management tenant": {
+                    "description": "You can not access the REST API from the management, only subtenants of the management tenants are allowed.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Management tenant is not permitted."
+                      ]
+                    }
+                  },
+                  "no read access": {
+                    "description": "You can not read Definitions from this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no read access."
+                      ]
+                    }
+                  },
+                  "no write access": {
+                    "description": "You can not create or update Definitions on this tenant.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. Tenant {tenantId} has no write access."
+                      ]
+                    }
+                  },
+                  "missing permission": {
+                    "description": "The user needs the permission 'ROLE_DIGITAL_TWIN_?' for the invoked endpoint, e.g. the 'ROLE_DIGITAL_TWIN_ASSETS_CREATE' to create Assets.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. User does not have permission {ROLE_DIGITAL_TWIN_?}."
+                      ]
+                    }
+                  },
+                  "feature toggle disabled": {
+                    "description": "The Asset Instance API is disabled for this tenant. Please contact support or your administrator to enable it.",
+                    "value": {
+                      "messages": [
+                        "Access Denied. The FeatureToggle for the Asset Instance API is disabled for tenant {tenantId}."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiError"
+                },
+                "examples": {
+                  "Internal Server Error": {
+                    "description": "This error indicates an unexpected internal problem that could not be handled properly. The error message of this problem is just forwarded in the response.",
+                    "value": {
+                      "messages": [
+                        "Failed to fetch Inventory API Managed Objects."
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "SSO": []
+          },
+          {
+            "JWT-IAM": []
+          },
+          {
+            "OAI-Secure": []
+          },
+          {
+            "Basic": []
+          }
+        ],
+        "x-codegen-resource-name": "count"
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AvailableActions": {
+        "type": "object",
+        "properties": {
+          "editAllowed": {
+            "type": "boolean"
+          },
+          "editMetadataAllowed": {
+            "type": "boolean"
+          },
+          "deleteAllowed": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false,
+        "readOnly": true
+      },
+      "JsonSchema": {
+        "required": [
+          "title"
+        ],
+        "type": "object",
+        "properties": {
+          "title": {
+            "pattern": "^(?:[A-Za-z0-9](?:\\s*[-\\w:.!])*\\s*)?$",
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true,
+        "example": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "title": "Position",
+          "description": "A JSON schema for representing geographic position data.",
+          "type": "object",
+          "properties": {
+            "lat": {
+              "type": "number"
+            },
+            "lng": {
+              "type": "number"
+            },
+            "alt": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "PropertyDefinition": {
+        "title": "PropertyDefinition",
+        "required": [
+          "identifier",
+          "jsonSchema"
+        ],
+        "type": "object",
+        "properties": {
+          "identifier": {
+            "type": "string",
+            "example": "c8y_Position"
+          },
+          "jsonSchema": {
+            "$ref": "#/components/schemas/JsonSchema"
+          },
+          "creationTime": {
+            "type": "string",
+            "readOnly": true,
+            "example": "2017-12-12T22:09:06.881+01:00"
+          },
+          "lastUpdated": {
+            "type": "string",
+            "readOnly": true,
+            "example": "2018-07-19T12:01:50.731Z"
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "example": [
+              "Location"
+            ],
+            "items": {
+              "type": "string",
+              "example": "[\"Location\"]"
+            }
+          },
+          "contexts": {
+            "uniqueItems": true,
+            "type": "array",
+            "description": "Specifies the optional domain entities to which this Property Definition applies.",
+            "items": {
+              "type": "string",
+              "description": "Specifies the optional domain entities to which this Property Definition applies.",
+              "enum": [
+                "measurement",
+                "event",
+                "alarm",
+                "audit",
+                "operation",
+                "asset",
+                "tenant_option"
+              ]
+            }
+          },
+          "c8y_AvailableActions": {
+            "$ref": "#/components/schemas/AvailableActions"
+          },
+          "c8y_Origin": {
+            "type": "string",
+            "description": "Specifies the origin of this Property Definition and identifies the owning component. If the value is <code>library</code>, the Property Definition is system-defined and read-only."
+          }
+        },
+        "additionalProperties": true
+      },
+      "ApiError": {
+        "required": [
+          "messages"
+        ],
+        "type": "object",
+        "properties": {
+          "messages": {
+            "maxItems": 2147483647,
+            "minItems": 1,
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "AllowedPropertyDefinition": {
+        "required": [
+          "identifier"
+        ],
+        "type": "object",
+        "properties": {
+          "identifier": {
+            "pattern": "^[A-Za-z0-9][-\\w:.!]*$",
+            "type": "string",
+            "example": "c8y_Position"
+          },
+          "minOccurs": {
+            "pattern": "^([01])$",
+            "type": "string",
+            "example": "1",
+            "default": "0"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MeasurementDefinition": {
+        "title": "MeasurementDefinition",
+        "required": [
+          "identifier"
+        ],
+        "type": "object",
+        "properties": {
+          "identifier": {
+            "type": "string",
+            "example": "c8y_TemperateMeasurement"
+          },
+          "jsonSchema": {
+            "$ref": "#/components/schemas/JsonSchema"
+          },
+          "creationTime": {
+            "type": "string",
+            "readOnly": true,
+            "example": "2017-12-12T22:09:06.881+01:00"
+          },
+          "lastUpdated": {
+            "type": "string",
+            "readOnly": true,
+            "example": "2018-07-19T12:01:50.731Z"
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "example": [
+              "Location"
+            ],
+            "items": {
+              "type": "string",
+              "example": "[\"Location\"]"
+            }
+          },
+          "composition": {
+            "type": "object",
+            "properties": {
+              "allowedProperties": {
+                "uniqueItems": true,
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedPropertyDefinition"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "c8y_AvailableActions": {
+            "$ref": "#/components/schemas/AvailableActions"
+          }
+        },
+        "additionalProperties": true
+      },
+      "EventDefinition": {
+        "title": "EventDefinition",
+        "required": [
+          "identifier"
+        ],
+        "type": "object",
+        "properties": {
+          "identifier": {
+            "type": "string",
+            "example": "c8y_LocationUdpdate"
+          },
+          "jsonSchema": {
+            "$ref": "#/components/schemas/JsonSchema"
+          },
+          "creationTime": {
+            "type": "string",
+            "readOnly": true,
+            "example": "2017-12-12T22:09:06.881+01:00"
+          },
+          "lastUpdated": {
+            "type": "string",
+            "readOnly": true,
+            "example": "2018-07-19T12:01:50.731Z"
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "example": [
+              "Location"
+            ],
+            "items": {
+              "type": "string",
+              "example": "[\"Location\"]"
+            }
+          },
+          "c8y_AvailableActions": {
+            "$ref": "#/components/schemas/AvailableActions"
+          },
+          "composition": {
+            "type": "object",
+            "properties": {
+              "allowedProperties": {
+                "uniqueItems": true,
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedPropertyDefinition"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": true
+      },
+      "AssetDefinition": {
+        "title": "AssetDefinition",
+        "required": [
+          "identifier"
+        ],
+        "type": "object",
+        "properties": {
+          "identifier": {
+            "type": "string",
+            "example": "c8y_Windfarm"
+          },
+          "jsonSchema": {
+            "$ref": "#/components/schemas/JsonSchema"
+          },
+          "creationTime": {
+            "type": "string",
+            "readOnly": true,
+            "example": "2017-12-12T22:09:06.881+01:00"
+          },
+          "lastUpdated": {
+            "type": "string",
+            "readOnly": true,
+            "example": "2018-07-19T12:01:50.731Z"
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "example": [
+              "Location"
+            ],
+            "items": {
+              "type": "string",
+              "example": "[\"Location\"]"
+            }
+          },
+          "c8y_AvailableActions": {
+            "$ref": "#/components/schemas/AvailableActions"
+          },
+          "composition": {
+            "type": "object",
+            "properties": {
+              "allowedSubAssets": {
+                "uniqueItems": true,
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedSubAssetDefinition"
+                }
+              },
+              "allowedProperties": {
+                "uniqueItems": true,
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedPropertyDefinition"
+                }
+              },
+              "additionalProperties": {
+                "type": "boolean",
+                "default": false
+              },
+              "additionalSubAssets": {
+                "type": "boolean",
+                "default": false
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": true
+      },
+      "AlarmDefinition": {
+        "title": "AlarmDefinition",
+        "required": [
+          "identifier"
+        ],
+        "type": "object",
+        "properties": {
+          "identifier": {
+            "type": "string",
+            "example": "c8y_UnavailableAlarm"
+          },
+          "jsonSchema": {
+            "$ref": "#/components/schemas/JsonSchema"
+          },
+          "creationTime": {
+            "type": "string",
+            "readOnly": true,
+            "example": "2017-12-12T22:09:06.881+01:00"
+          },
+          "lastUpdated": {
+            "type": "string",
+            "readOnly": true,
+            "example": "2018-07-19T12:01:50.731Z"
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "example": [
+              "Location"
+            ],
+            "items": {
+              "type": "string",
+              "example": "[\"Location\"]"
+            }
+          },
+          "c8y_AvailableActions": {
+            "$ref": "#/components/schemas/AvailableActions"
+          },
+          "composition": {
+            "type": "object",
+            "properties": {
+              "allowedProperties": {
+                "uniqueItems": true,
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/AllowedPropertyDefinition"
+                }
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": true
+      },
+      "Asset": {
+        "title": "Asset",
+        "type": "object",
+        "properties": {
+          "creationTime": {
+            "type": "string",
+            "readOnly": true,
+            "example": "2017-12-12T22:09:06.881+01:00"
+          },
+          "lastUpdated": {
+            "type": "string",
+            "readOnly": true,
+            "example": "2018-07-19T12:01:50.731Z"
+          },
+          "id": {
+            "type": "string",
+            "readOnly": true,
+            "example": "989682"
+          },
+          "type": {
+            "type": "string",
+            "example": "c8y_Windturbine"
+          },
+          "name": {
+            "type": "string",
+            "example": "Windturbine"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "subAssets": {
+            "type": "array",
+            "readOnly": true,
+            "items": {
+              "$ref": "#/components/schemas/Asset"
+            }
+          },
+          "c8y_LinkedSeries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LinkedSeries"
+            }
+          },
+          "c8y_Notes": {
+            "type": "string",
+            "description": "The description of this Asset."
+          },
+          "c8y_LatestMeasurements": {
+            "$ref": "#/components/schemas/LatestMeasurements"
+          },
+          "c8y_ExternalId": {
+            "maxLength": 2147483647,
+            "minLength": 1,
+            "type": "string",
+            "description": "Represents an external identifier used to reference this asset in external systems. When set, an identity of type 'c8y_Asset' is created for this asset with the value of this property."
+          },
+          "c8y_ExternalAsset": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Represents Assets synchronized from external systems into Cumulocity IoT. The fragment allows storing free-form metadata relevant to external systems."
+          }
+        },
+        "additionalProperties": true
+      },
+      "FragmentSeries": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/Measurement"
+        }
+      },
+      "LatestMeasurements": {
+        "type": "object",
+        "additionalProperties": {
+          "$ref": "#/components/schemas/FragmentSeries"
+        },
+        "readOnly": true,
+        "example": {
+          "c8y_Temperature": {
+            "T": {
+              "time": "2025-03-18T11:44:49.855Z",
+              "value": -9.7814760073,
+              "unit": "ºC",
+              "source": {
+                "id": "881204"
+              }
+            }
+          }
+        }
+      },
+      "LinkedSeries": {
+        "required": [
+          "fragment",
+          "series"
+        ],
+        "type": "object",
+        "properties": {
+          "fragment": {
+            "minLength": 1,
+            "type": "string",
+            "example": "c8y_Temperature"
+          },
+          "series": {
+            "minLength": 1,
+            "type": "string",
+            "example": "T"
+          },
+          "label": {
+            "type": "string",
+            "example": "Room temperature"
+          },
+          "source": {
+            "$ref": "#/components/schemas/Source"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Measurement": {
+        "type": "object",
+        "properties": {
+          "time": {
+            "type": "string",
+            "example": "2025-03-18T11:44:49.855Z"
+          },
+          "value": {
+            "type": "number",
+            "example": -9.7814760073
+          },
+          "unit": {
+            "type": "string",
+            "example": "ºC"
+          },
+          "source": {
+            "$ref": "#/components/schemas/MeasurementSource"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MeasurementSource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "881204"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Source": {
+        "type": "object",
+        "properties": {
+          "fragment": {
+            "type": "string",
+            "example": "c8y_Temperature"
+          },
+          "series": {
+            "type": "string",
+            "example": "T"
+          },
+          "id": {
+            "type": "string",
+            "example": "9688123"
+          },
+          "type": {
+            "type": "string",
+            "example": "c8y_TemperatureMeasurement"
+          },
+          "name": {
+            "type": "string",
+            "example": "Temperature Sensor"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PageStatistics": {
+        "required": [
+          "currentPage",
+          "pageSize",
+          "totalElements",
+          "totalPages"
+        ],
+        "type": "object",
+        "properties": {
+          "currentPage": {
+            "type": "integer",
+            "format": "int32",
+            "example": 1,
+            "default": 1
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32",
+            "example": 50,
+            "default": 100
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32",
+            "example": 2
+          },
+          "totalElements": {
+            "type": "integer",
+            "format": "int32",
+            "example": 43
+          }
+        },
+        "additionalProperties": false
+      },
+      "PaginatedDefinitionList": {
+        "required": [
+          "definitions",
+          "statistics"
+        ],
+        "type": "object",
+        "properties": {
+          "self": {
+            "title": "SelfURL",
+            "type": "string",
+            "description": "A URL linking to this resource.",
+            "format": "uri",
+            "readOnly": true
+          },
+          "next": {
+            "title": "NextPageURL",
+            "type": "string",
+            "description": "A URI reference [[RFC3986](https://tools.ietf.org/html/rfc3986)] to a potential next page.",
+            "format": "uri",
+            "readOnly": true
+          },
+          "prev": {
+            "title": "PreviousPageURL",
+            "type": "string",
+            "description": "A URI reference [[RFC3986](https://tools.ietf.org/html/rfc3986)] to a potential previous page.",
+            "format": "uri",
+            "readOnly": true
+          },
+          "definitions": {
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/PropertyDefinition"
+                },
+                {
+                  "$ref": "#/components/schemas/AssetDefinition"
+                },
+                {
+                  "$ref": "#/components/schemas/AlarmDefinition"
+                },
+                {
+                  "$ref": "#/components/schemas/EventDefinition"
+                },
+                {
+                  "$ref": "#/components/schemas/MeasurementDefinition"
+                }
+              ]
+            }
+          },
+          "statistics": {
+            "$ref": "#/components/schemas/PageStatistics"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PaginatedAssetList": {
+        "required": [
+          "assets",
+          "statistics"
+        ],
+        "type": "object",
+        "properties": {
+          "self": {
+            "title": "SelfURL",
+            "type": "string",
+            "description": "A URL linking to this resource.",
+            "format": "uri",
+            "readOnly": true
+          },
+          "next": {
+            "title": "NextPageURL",
+            "type": "string",
+            "description": "A URI reference [[RFC3986](https://tools.ietf.org/html/rfc3986)] to a potential next page.",
+            "format": "uri",
+            "readOnly": true
+          },
+          "prev": {
+            "title": "PreviousPageURL",
+            "type": "string",
+            "description": "A URI reference [[RFC3986](https://tools.ietf.org/html/rfc3986)] to a potential previous page.",
+            "format": "uri",
+            "readOnly": true
+          },
+          "assets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Asset"
+            }
+          },
+          "statistics": {
+            "$ref": "#/components/schemas/PageStatistics"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PaginatedLinkedSeriesList": {
+        "required": [
+          "linkedSeries",
+          "statistics"
+        ],
+        "type": "object",
+        "properties": {
+          "self": {
+            "title": "SelfURL",
+            "type": "string",
+            "description": "A URL linking to this resource.",
+            "format": "uri",
+            "readOnly": true
+          },
+          "next": {
+            "title": "NextPageURL",
+            "type": "string",
+            "description": "A URI reference [[RFC3986](https://tools.ietf.org/html/rfc3986)] to a potential next page.",
+            "format": "uri",
+            "readOnly": true
+          },
+          "prev": {
+            "title": "PreviousPageURL",
+            "type": "string",
+            "description": "A URI reference [[RFC3986](https://tools.ietf.org/html/rfc3986)] to a potential previous page.",
+            "format": "uri",
+            "readOnly": true
+          },
+          "linkedSeries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LinkedSeries"
+            }
+          },
+          "jsonSchema": {
+            "$ref": "#/components/schemas/JsonSchema"
+          },
+          "statistics": {
+            "$ref": "#/components/schemas/PageStatistics"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AllowedSubAssetDefinition": {
+        "required": [
+          "identifier"
+        ],
+        "type": "object",
+        "properties": {
+          "minOccurs": {
+            "pattern": "^(0|[1-9]\\d*)$",
+            "type": "string",
+            "example": "0",
+            "default": "0"
+          },
+          "maxOccurs": {
+            "pattern": "^([1-9]\\d*|infinite)$",
+            "type": "string",
+            "example": "3",
+            "default": "infinite"
+          },
+          "identifier": {
+            "pattern": "^[A-Za-z0-9][-\\w:.!]*$",
+            "type": "string",
+            "example": "c8y_Windturbine"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "securitySchemes": {
+      "Basic": {
+        "type": "http",
+        "description": "The authorization header is formed as `Authorization: Basic <Base64(<tenantID>/<c8yuser>:<password>)>`.\n\nFor more details, see the [Cumulocity Basic Authentication documentation](https://cumulocity.com/api/core/#section/Authentication/Basic).",
+        "scheme": "basic"
+      },
+      "OAI-Secure": {
+        "type": "http",
+        "description": "This is the recommended authorization method because it provides high security using authorization tokens to prove the identity of the user, and it is the default login mode on creating new tenants.\n\nFor more details about OAI-Secure authentication, see [Platform administration > Authentication > Basic settings > Login settings](https://www.cumulocity.com/docs/authentication/basic-settings/#login-settings) in the Cumulocity user documentation.",
+        "scheme": "bearer"
+      },
+      "JWT-IAM": {
+        "type": "http",
+        "description": "OAuth2-based authentication allows clients to replace JWT authentication with access tokens issued by their Identity and Access Management (IAM) system. This is enabled through the SSO configuration in Cumulocity.\n\nFor more details, see the [Cumulocity JWT-IAM Authentication documentation](https://cumulocity.com/api/core/#section/Authentication/JWT-IAM).",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      },
+      "SSO": {
+        "type": "oauth2",
+        "description": "Single sign-on (SSO) login in Cumulocity requires appropriate configuration on the platform. When enabled, users see an additional login button that redirects them to the configured authorization server for authentication. After successful login,\nthey return to Cumulocity.\n\nFor more details, see the [Cumulocity SSO Authentication documentation](https://cumulocity.com/api/core/#section/Authentication/SSO).",
+        "flows": {
+          "clientCredentials": {
+            "tokenUrl": "/tenant/oauth?grant_type=authorization_code&code=<CODE>",
+            "scopes": {}
+          }
+        }
+      }
+    }
+  },
+  "x-tagGroups": [
+    {
+      "tags": [
+        "Assets",
+        "Linked Series"
+      ],
+      "name": "Asset API"
+    },
+    {
+      "tags": [
+        "Property Definitions",
+        "Asset Definitions",
+        "Alarm Definitions",
+        "Event Definitions",
+        "Measurement Definitions"
+      ],
+      "name": "Definition API"
+    }
+  ]
+}

--- a/scripts/package-microservices.mjs
+++ b/scripts/package-microservices.mjs
@@ -32,6 +32,17 @@ const dockerReleaseTag = sanitizeDockerNamePart(releaseTag, `v${packageJson.vers
 
 const openApiBuildConfig = JSON.parse(fs.readFileSync(path.join(rootDir, 'openapi-builds.json'), 'utf8'))
 const openApiBuilds = openApiBuildConfig.builds
+const bundledServices = openApiBuildConfig.services ?? []
+
+/**
+ * Artifact name for a given build: `core-<coreVersion>` plus each bundled
+ * service key appended (sorted for determinism). E.g. `core-release-dtm`.
+ * @param {{ core: string }} build
+ */
+function artifactName(build) {
+  const serviceSuffix = bundledServices.map((s) => s.key).sort().join('-')
+  return serviceSuffix ? `core-${build.core}-${serviceSuffix}` : `core-${build.core}`
+}
 
 function run(command, args, cwd = rootDir) {
   execFileSync(command, args, {
@@ -93,9 +104,10 @@ try {
     }
 
     prepareStagingDir(build.version)
-    const zipFileName = `${assetBaseName}-${build.artifact}-${releaseTag}.zip`
+    const artifact = artifactName(build)
+    const zipFileName = `${assetBaseName}-${artifact}-${releaseTag}.zip`
     const zipFilePath = path.join(rootDir, zipFileName)
-    const imageRef = `${dockerRepositoryName}:${sanitizeDockerNamePart(build.artifact, build.version)}-${dockerReleaseTag}`
+    const imageRef = `${dockerRepositoryName}:${sanitizeDockerNamePart(artifact, build.version)}-${dockerReleaseTag}`
 
     try {
       run('docker', ['build', '--platform', targetPlatform, '-f', stagedDockerfilePath, '-t', imageRef, '.'], rootDir)

--- a/scripts/update-openapi.mjs
+++ b/scripts/update-openapi.mjs
@@ -1,5 +1,8 @@
 /* eslint-disable no-console */
-// Script to fetch and update all bundled OpenAPI specs defined in openapi-builds.json
+// Fetch and update all bundled OpenAPI specs defined in openapi-builds.json.
+// Two generic loops: core versions (under openapi/core/<version>.json) and
+// services (under openapi/services/<key>.json). No per-spec code paths.
+
 import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
@@ -11,72 +14,94 @@ const outputDir = path.join(rootDir, 'openapi')
 
 const config = JSON.parse(fs.readFileSync(openApiConfigPath, 'utf8'))
 
-/** @type {Array<{ api: string, version: string, status: 'unchanged' | 'updated' | 'created' | 'error', detail?: string }>} */
+/**
+ * @typedef {{ id: string, status: 'unchanged' | 'updated' | 'created' | 'error', detail?: string }} Result
+ */
+
+/** @type {Result[]} */
 const results = []
 let hasErrors = false
 
-for (const [api, entries] of Object.entries(config.sources)) {
-  for (const entry of entries) {
-    const { version, label, url } = entry
-    const apiOutputDir = path.join(outputDir, api)
-    const outputPath = path.join(apiOutputDir, `${version}.json`)
+/**
+ * Fetch one spec, write it to disk, append a result entry.
+ * @param {string} id              Human-readable id for logs (e.g. "core@release", "services/dtm")
+ * @param {string} url             Upstream URL to fetch
+ * @param {string} outputPath      Destination file
+ */
+async function fetchAndWrite(id, url, outputPath) {
+  process.stdout.write(`Fetching ${id} ... `)
 
-    process.stdout.write(`Fetching ${api} ${label} (${version}) ... `)
-
-    let response
-    try {
-      // eslint-disable-next-line antfu/no-top-level-await
-      response = await fetch(url)
-    } catch (err) {
-      const detail = /** @type {Error} */ (err).message
-      console.error(`network error: ${detail}`)
-      results.push({ api, version, status: 'error', detail })
-      hasErrors = true
-      continue
-    }
-
-    if (!response.ok) {
-      const detail = `HTTP ${response.status} ${response.statusText}`
-      console.error(detail)
-      results.push({ api, version, status: 'error', detail })
-      hasErrors = true
-      continue
-    }
-
-    let text
-    try {
-      // eslint-disable-next-line antfu/no-top-level-await
-      text = await response.text()
-      JSON.parse(text)
-    } catch (err) {
-      const detail = `invalid JSON: ${/** @type {Error} */ (err).message}`
-      console.error(detail)
-      results.push({ api, version, status: 'error', detail })
-      hasErrors = true
-      continue
-    }
-
-    fs.mkdirSync(apiOutputDir, { recursive: true })
-    const newContent = text.trim()
-    const existing = fs.existsSync(outputPath) ? fs.readFileSync(outputPath, 'utf8').trim() : null
-
-    if (existing === newContent) {
-      console.log('unchanged')
-      results.push({ api, version, status: 'unchanged' })
-    } else {
-      fs.writeFileSync(outputPath, newContent, 'utf8')
-      const status = existing === null ? 'created' : 'updated'
-      console.log(status)
-      results.push({ api, version, status })
-    }
+  let response
+  try {
+    response = await fetch(url)
+  } catch (err) {
+    const detail = /** @type {Error} */ (err).message
+    console.error(`network error: ${detail}`)
+    results.push({ id, status: 'error', detail })
+    hasErrors = true
+    return
   }
+
+  if (!response.ok) {
+    const detail = `HTTP ${response.status} ${response.statusText}`
+    console.error(detail)
+    results.push({ id, status: 'error', detail })
+    hasErrors = true
+    return
+  }
+
+  let text
+  try {
+    text = await response.text()
+    JSON.parse(text)
+  } catch (err) {
+    const detail = `invalid JSON: ${/** @type {Error} */ (err).message}`
+    console.error(detail)
+    results.push({ id, status: 'error', detail })
+    hasErrors = true
+    return
+  }
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true })
+  const newContent = text.trim()
+  const existing = fs.existsSync(outputPath) ? fs.readFileSync(outputPath, 'utf8').trim() : null
+
+  if (existing === newContent) {
+    console.log('unchanged')
+    results.push({ id, status: 'unchanged' })
+  } else {
+    fs.writeFileSync(outputPath, newContent, 'utf8')
+    const status = existing === null ? 'created' : 'updated'
+    console.log(status)
+    results.push({ id, status })
+  }
+}
+
+// Core versions
+for (const entry of config.core.versions) {
+  // eslint-disable-next-line antfu/no-top-level-await
+  await fetchAndWrite(
+    `core@${entry.version}`,
+    entry.url,
+    path.join(outputDir, 'core', `${entry.version}.json`),
+  )
+}
+
+// Bundled services (single version per service — the upstream live spec)
+for (const entry of config.services ?? []) {
+  // eslint-disable-next-line antfu/no-top-level-await
+  await fetchAndWrite(
+    `services/${entry.key}`,
+    entry.url,
+    path.join(outputDir, 'services', `${entry.key}.json`),
+  )
 }
 
 console.log('\nSummary:')
 for (const result of results) {
   const icon = result.status === 'error' ? '✗' : result.status === 'unchanged' ? '·' : '✓'
   const detail = result.detail ? ` — ${result.detail}` : ''
-  console.log(`  ${icon} ${result.api}@${result.version}: ${result.status}${detail}`)
+  console.log(`  ${icon} ${result.id}: ${result.status}${detail}`)
 }
 
 if (process.env.GITHUB_OUTPUT) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -7,6 +7,7 @@ import { getCoreOpenApiLabel, getCoreOpenApiVersion, setCoreOpenApiVersion, spec
 import { c8yMcpServer, setupMcpServer } from '../server'
 import { getCredentialsByTenantUrl, getStoredC8yAuth } from '../utils/credentials'
 import { parseAllowRule, parseRestrictionRule } from '../utils/restrictions'
+import { resolveSpecs } from '../utils/spec-resolution'
 import { readActiveTenantUrl } from './active-tenant'
 import { configureSpecRemoval, getCliTenantContext, setCliTenantContext } from './tenant-context'
 
@@ -107,12 +108,17 @@ const main = defineCommand({
 
     const transport = new StdioTransport(c8yMcpServer)
     const active = getCliTenantContext()
+    // No active tenant yet — seed the sandbox with the bundled-only resolution so
+    // coreSpec is always present. Live tenant data is pushed into the context by
+    // set-active-tenant on first invocation.
+    const fallback = active ? null : resolveSpecs([], new Set(), specRemoval)
     consola.info('Starting MCP server over stdio transport...')
     transport.listen({
       env: 'cli' as const,
       restrictions,
       allowRules: parsedAllowRules,
-      specs: active?.specs ?? {},
+      specs: active?.specs ?? fallback!.specs,
+      specsEnabled: active?.specsEnabled ?? fallback!.specsEnabled,
       auth: active ? { tenantUrl: active.tenantUrl, authorizationHeader: active.authorizationHeader } : undefined,
     })
   },

--- a/src/cli/tenant-context.ts
+++ b/src/cli/tenant-context.ts
@@ -28,6 +28,10 @@ export interface CliTenantContext {
    * Fully resolved specs (bundled + discovered, paths pre-prefixed).
    */
   specs: Specs
+  /**
+   * Per known bundled service: installed on this tenant?
+   */
+  specsEnabled: Record<string, boolean>
 }
 
 let _context: CliTenantContext | null = null
@@ -68,11 +72,13 @@ export async function setCliTenantContext(tenantUrl: string): Promise<CliTenantC
   // discovery cache updates automatically. Call set-active-tenant again to
   // pull a refreshed snapshot into the context (or rely on server restart).
   const { specs: discovered, installedContextPaths } = await startDiscovery(tenantUrl, authHeaders)
+  const resolved = resolveSpecs(discovered, installedContextPaths, _specRemoval)
 
   _context = {
     tenantUrl,
     authorizationHeader: authHeaders.Authorization!,
-    specs: resolveSpecs(discovered, installedContextPaths, _specRemoval),
+    specs: resolved.specs,
+    specsEnabled: resolved.specsEnabled,
   }
 
   return _context

--- a/src/codemode/execute.ts
+++ b/src/codemode/execute.ts
@@ -5,7 +5,7 @@ import { createNetworkPermissionDecision } from './network-permissions'
 import { createC8yAuthHeaders, resolveC8yAuth } from '../utils/client'
 import { c8yMcpServer } from '../server-instance'
 import type { Specs } from '../utils/spec-resolution'
-import { BUNDLED_SPEC_REGISTRY } from '../utils/openapi'
+import { CORE_SPEC } from '../utils/openapi'
 import {
   compileRestrictionRule,
   compileRestrictionSegment,
@@ -97,29 +97,29 @@ function normalizeCode(functionCode: string): string {
   return normalized
 }
 
-function buildQueryScript(sourceCode: string, specsOverride?: Specs): string {
+function buildQueryScript(
+  sourceCode: string,
+  specsOverride?: Specs,
+  specsEnabledOverride?: Record<string, boolean>,
+): string {
   const functionExpression = normalizeCode(sourceCode)
-  // Read specs from the server context; tests may pass a direct override.
-  const specs = specsOverride ?? c8yMcpServer.ctx.custom?.specs ?? {}
+  // Read from the server context; tests may pass direct overrides.
+  const specs = specsOverride ?? c8yMcpServer.ctx.custom?.specs ?? { [CORE_SPEC.key]: CORE_SPEC.spec }
+  const specsEnabled = specsEnabledOverride ?? c8yMcpServer.ctx.custom?.specsEnabled ?? { [CORE_SPEC.key]: true }
 
-  // Bundled registry keys get individual named bindings (coreSpec, dtmSpec…)
-  // and contribute to specsEnabled. Everything else goes into serviceSpecs.
-  const bundledKeys = new Set(BUNDLED_SPEC_REGISTRY.map((e) => e.key))
-  const specBindings: string[] = []
-  const specsEnabled: Record<string, boolean> = {}
-  const serviceSpecsMap: Record<string, { label: string, contextPath: string, spec: unknown }> = {}
-
+  // core is the only spec with a named binding. Everything else goes into
+  // serviceSpecs keyed by contextPath. null entries (absent known services
+  // under spec removal) are omitted from serviceSpecs entirely.
+  const coreSpecBinding = `const coreSpec = ${JSON.stringify(specs[CORE_SPEC.key] ?? null)};`
+  const serviceSpecsMap: Record<string, { contextPath: string, spec: unknown }> = {}
   for (const [key, spec] of Object.entries(specs)) {
-    if (bundledKeys.has(key)) {
-      specBindings.push(`const ${key}Spec = ${JSON.stringify(spec)};`)
-      specsEnabled[key] = spec !== null
-    } else if (spec !== null) {
-      serviceSpecsMap[key] = { label: key, contextPath: key, spec }
-    }
+    if (key === CORE_SPEC.key || spec === null)
+      continue
+    serviceSpecsMap[key] = { contextPath: key, spec }
   }
 
   return [
-    ...specBindings,
+    coreSpecBinding,
     `const specsEnabled = ${JSON.stringify(specsEnabled)};`,
     `const serviceSpecs = ${JSON.stringify(serviceSpecsMap)};`,
     `const __mc8ypQuery = (${functionExpression});`,
@@ -393,8 +393,12 @@ async function runModule(code: string, entryPath: string, runtime: NodeRuntime):
   }
 }
 
-export async function query(functionCode: string, specsOverride?: Specs): Promise<string> {
-  const result = await runQueryScript(buildQueryScript(functionCode, specsOverride))
+export async function query(
+  functionCode: string,
+  specsOverride?: Specs,
+  specsEnabledOverride?: Record<string, boolean>,
+): Promise<string> {
+  const result = await runQueryScript(buildQueryScript(functionCode, specsOverride, specsEnabledOverride))
   return typeof result === 'string' ? result : JSON.stringify(result)
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,9 +66,10 @@ const app = new H3().all('/mcp', async (event) => {
     .map((s) => s.contextPath)
   const autoRestrictions = createServiceUnavailableRestrictionRules(unavailableContextPaths)
 
-  // Flat spec map: bundled (resolved against discovery) + non-bundled discovered services.
-  // specRemoval=true: service-backed bundled specs absent from this tenant are injected as null.
-  const specs = resolveSpecs(discoveredSpecs, installedContextPaths, true)
+  // Flat spec map + specsEnabled (per-service installation flags).
+  // Server mode always runs with specRemoval=true: bundled services absent from
+  // this tenant are injected as null in the sandbox.
+  const { specs, specsEnabled } = resolveSpecs(discoveredSpecs, installedContextPaths, true)
 
   const query = getQuery(event)
   const restrictionSources = collectServerRestrictionSources(query, event.req.headers)
@@ -107,6 +108,7 @@ const app = new H3().all('/mcp', async (event) => {
     restrictions: effectiveRestrictions,
     allowRules: parsedAllowRules,
     specs,
+    specsEnabled,
   })
 })
 

--- a/src/openapi-modules.d.ts
+++ b/src/openapi-modules.d.ts
@@ -10,3 +10,14 @@ declare module '#core-openapi' {
   export function setCoreOpenApiVersion(version: string): void
   export function getCoreOpenApiLabel(): string
 }
+
+declare module '#bundled-services' {
+  import type { DiscoveredApiSpec } from './utils/api-discovery'
+  /**
+   * Statically bundled service specs in the same shape produced by live
+   * discovery (paths already prefixed with servicePrefix at build time).
+   * Live discovery overrides any entry whose contextPath matches a discovered
+   * spec on the current tenant.
+   */
+  export const BUNDLED_SERVICE_SPECS: ReadonlyArray<DiscoveredApiSpec>
+}

--- a/src/prompts/codemode.ts
+++ b/src/prompts/codemode.ts
@@ -2,7 +2,7 @@ import { definePrompt } from 'tmcp/prompt'
 import { prompt } from 'tmcp/utils'
 import { getCoreOpenApiLabel } from '#core-openapi'
 import { c8yMcpServer } from '../server-instance'
-import { BUNDLED_OPENAPI_ENTRIES, BUNDLED_SPEC_REGISTRY } from '../utils/openapi'
+import { BUNDLED_OPENAPI_ENTRIES, CORE_SPEC } from '../utils/openapi'
 
 function getRuntimeSection(): string {
   return c8yMcpServer.ctx.custom?.env === 'cli'
@@ -22,8 +22,8 @@ export function createCodeModeGuidePrompt() {
     const restrictions = c8yMcpServer.ctx.custom?.restrictions ?? []
     const allowRules = c8yMcpServer.ctx.custom?.allowRules ?? []
     const specs = c8yMcpServer.ctx.custom?.specs ?? {}
-    const bundledKeys = new Set(BUNDLED_SPEC_REGISTRY.map((e) => e.key))
-    const serviceKeys = Object.keys(specs).filter((k) => !bundledKeys.has(k) && specs[k] !== null)
+    // core is the only named binding; everything else (bundled + discovered) goes into serviceSpecs.
+    const serviceKeys = Object.keys(specs).filter((k) => k !== CORE_SPEC.key && specs[k] !== null)
     const serviceSpecsType = serviceKeys.length === 0
       ? 'Record<string, ServiceSpecEntry>'
       : `{\n${serviceKeys.map((k) => `  ${k}: ServiceSpecEntry`).join('\n')}\n}`

--- a/src/tools/active-tenant.ts
+++ b/src/tools/active-tenant.ts
@@ -45,6 +45,7 @@ export function createSetActiveTenantTool() {
 
         custom.auth = { tenantUrl: ctx.tenantUrl, authorizationHeader: ctx.authorizationHeader }
         custom.specs = ctx.specs
+        custom.specsEnabled = ctx.specsEnabled
 
         const specKeys = Object.entries(ctx.specs)
           .filter(([, v]) => v !== null)

--- a/src/tools/codemode.ts
+++ b/src/tools/codemode.ts
@@ -10,7 +10,7 @@ function createCodeSchema(description: string) {
 }
 
 function getOpenApiNote(): string {
-  return `This MCP exposes the ${getCoreOpenApiLabel()} bundled core OpenAPI snapshot (${BUNDLED_OPENAPI_ENTRIES.map((e) => `${e.api} ${e.version}`).join(', ')}). Use \`coreSpec\` for inventory, alarms, events, measurements, users, tenants, and the broader Cumulocity REST surface. Microservice APIs discovered on the current tenant are available via \`serviceSpecs\`.`
+  return `This MCP exposes the ${getCoreOpenApiLabel()} bundled core OpenAPI snapshot plus bundled service specs (${BUNDLED_OPENAPI_ENTRIES.map((e) => `${e.api} ${e.version}`).join(', ')}). Use \`coreSpec\` for the main Cumulocity REST surface. Bundled and live-discovered microservices are available via \`serviceSpecs\` keyed by contextPath; live discovery on the current tenant overrides the bundled fallback when both exist.`
 }
 
 export function createQueryTool() {
@@ -59,9 +59,9 @@ declare const specsEnabled: SpecsEnabled
 declare const serviceSpecs: Record<string, ServiceSpecEntry>
 \`\`\`
 
-- \`coreSpec\` — the main Cumulocity REST surface. Always present.
-- \`specsEnabled\` — which bundled specs are available on this tenant (e.g. \`specsEnabled.dtm\`). Check before using optional specs.
-- \`serviceSpecs\` — additional microservice APIs discovered on the tenant, keyed by contextPath. Paths are already prefixed (e.g. \`/service/myservice/items\`).
+- \`coreSpec\` — the bundled Cumulocity core REST surface. Always present.
+- \`specsEnabled\` — per known bundled service: is it actually installed on this tenant? (e.g. \`specsEnabled.dtm\`). Check this before calling execute against a known service; if false the request will be blocked by connection policy.
+- \`serviceSpecs\` — microservice APIs available on the tenant, keyed by contextPath. Includes bundled service specs (e.g. \`serviceSpecs.dtm\` for Digital Twin Manager) and any live-discovered services. Paths are already prefixed (e.g. \`/service/dtm/assets\`). Live discovery on the tenant overrides the bundled fallback when present.
 
 If your function returns a string it is returned as-is. Any other value is returned as JSON.
 The current MCP connection may still block \`execute\` calls even when an operation is visible in a spec.

--- a/src/types/mcp-context.ts
+++ b/src/types/mcp-context.ts
@@ -17,11 +17,18 @@ export interface C8yMcpCustomContext extends Record<string, unknown> {
   restrictions: RestrictionRule[]
   allowRules: AllowRule[]
   /**
-   * Flat resolved spec map for the query sandbox (bundled + discovered, paths
-   * already prefixed). Always present — empty object until a tenant is activated
-   * in CLI mode; set per-request in server mode.
+   * Flat resolved spec map for the query sandbox (paths already prefixed).
+   * `core` always present; bundled service specs keyed by contextPath; live
+   * discovered services pass through. Set per-request in server mode and by
+   * set-active-tenant in CLI mode.
    */
   specs: Specs
+  /**
+   * Per bundled spec (core + every known bundled service): is it actually
+   * installed on the current tenant? Stays accurate even when --no-spec-removal
+   * keeps an absent service's bundled spec visible for reference.
+   */
+  specsEnabled: Record<string, boolean>
   /**
    * Tenant auth for the current connection.
    * Always set in server mode (per-request from the Authorization header).

--- a/src/utils/openapi.ts
+++ b/src/utils/openapi.ts
@@ -1,82 +1,44 @@
 import { getCoreOpenApiLabel, getCoreOpenApiSpec, getCoreOpenApiVersion } from '#core-openapi'
+import { BUNDLED_SERVICE_SPECS } from '#bundled-services'
 import type { RestrictionRule } from './restrictions'
 
 // ---------------------------------------------------------------------------
-// Bundled spec registry
+// Core — the only spec with special handling (version-switchable, named binding)
 // ---------------------------------------------------------------------------
 
 /**
- * A spec that is always available regardless of tenant (e.g. core).
- * No contextPath means no service-availability check is needed.
+ * The bundled Cumulocity core OpenAPI spec for the currently selected version.
+ * Always present in the query sandbox as `coreSpec`. Independent of tenant.
  */
-interface AlwaysAvailableSpec {
-  readonly key: string
-  readonly version: string
-  readonly label: string
-  readonly spec: unknown
-  readonly contextPath?: undefined
-  readonly servicePrefix?: undefined
-}
+export const CORE_SPEC = {
+  key: 'core',
+  version: getCoreOpenApiVersion(),
+  label: getCoreOpenApiLabel(),
+  spec: getCoreOpenApiSpec(),
+} as const
+
+// ---------------------------------------------------------------------------
+// Bundled service specs — generic, identical shape to live discovery results
+// ---------------------------------------------------------------------------
+
+export { BUNDLED_SERVICE_SPECS }
 
 /**
- * A spec backed by a Cumulocity microservice.
- * Discovery checks whether the service is installed on the current tenant.
+ * Per known bundled service: { contextPath, servicePrefix }.
+ * Derived generically from the bundled list — used for auto-restriction rules
+ * and for computing the `specsEnabled` map in the query sandbox.
  */
-interface ServiceBackedSpec {
-  readonly key: string
-  readonly version: string
-  readonly label: string
-  readonly spec: unknown
-  readonly contextPath: string
-  readonly servicePrefix: string
-}
-
-export type BundledSpec = AlwaysAvailableSpec | ServiceBackedSpec
+export const KNOWN_BUNDLED_SERVICES: ReadonlyArray<{ contextPath: string, servicePrefix: string }>
+  = BUNDLED_SERVICE_SPECS.map((s) => ({ contextPath: s.contextPath, servicePrefix: s.servicePrefix }))
 
 /**
- * Single source of truth for all bundled OpenAPI specs.
- *
- * - Entries without contextPath are always injected into the query sandbox.
- * - Entries with contextPath are resolved against live discovery results
- *   (see resolveAvailableSpecs in spec-resolution.ts).
- *
- * To add a new bundled spec: import its virtual-module helpers, add one entry
- * here with the appropriate contextPath/servicePrefix, and wire the virtual
- * module into tsdown.config.ts and openapi-modules.d.ts.
+ * Flat list of all bundled specs (core + service-backed) for display strings
+ * in tool descriptions and logs. Not used for resolution logic.
  */
-export const BUNDLED_SPEC_REGISTRY: readonly BundledSpec[] = [
-  {
-    key: 'core',
-    version: getCoreOpenApiVersion(),
-    label: getCoreOpenApiLabel(),
-    spec: getCoreOpenApiSpec(),
-    // No contextPath — core is always available on every tenant.
-  },
+export const BUNDLED_OPENAPI_ENTRIES: ReadonlyArray<{ api: string, version: string, label: string }> = [
+  { api: CORE_SPEC.key, version: CORE_SPEC.version, label: CORE_SPEC.label },
+  ...BUNDLED_SERVICE_SPECS.map((s) => ({ api: s.contextPath, version: 'release', label: s.specLabel })),
 ]
-
-// ---------------------------------------------------------------------------
-// Derived helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Service-backed entries from the registry, keyed by spec key.
- * Used to generate auto-restriction rules and filter serviceSpecs.
- */
-export const KNOWN_BUNDLED_SERVICES: Record<string, { contextPath: string, servicePrefix: string }>
-  = Object.fromEntries(
-    BUNDLED_SPEC_REGISTRY
-      .filter((e): e is ServiceBackedSpec => e.contextPath != null)
-      .map((e) => [e.key, { contextPath: e.contextPath, servicePrefix: e.servicePrefix }]),
-  )
-
-/**
- * Flat entries for display strings (tool descriptions, logs).
- */
-export const BUNDLED_OPENAPI_ENTRIES = BUNDLED_SPEC_REGISTRY.map((e) => ({
-  api: e.key,
-  version: e.version,
-  label: e.label,
-}))
 
 // ---------------------------------------------------------------------------
 // Auto-restriction helpers
@@ -85,10 +47,10 @@ export const BUNDLED_OPENAPI_ENTRIES = BUNDLED_SPEC_REGISTRY.map((e) => ({
 /**
  * Generate deny rules that block all access to a service's routes.
  * Called when a known bundled service is not installed on the current tenant
- * so that execute calls fail with a clear policy message rather than a
- * network error or unexpected 404.
+ * so that execute calls fail with a clear policy message rather than a network
+ * error or unexpected 404.
  *
- * @param unavailableContextPaths - Context paths of services confirmed absent on the tenant
+ * @param unavailableContextPaths - Context paths confirmed absent on the tenant
  */
 export function createServiceUnavailableRestrictionRules(
   unavailableContextPaths: readonly string[],

--- a/src/utils/spec-resolution.ts
+++ b/src/utils/spec-resolution.ts
@@ -1,76 +1,82 @@
 import type { DiscoveredApiSpec } from './api-discovery'
-import { BUNDLED_SPEC_REGISTRY } from './openapi'
+import { BUNDLED_SERVICE_SPECS, CORE_SPEC } from './openapi'
 
 /**
- * Flat map of all specs available for the query sandbox — bundled and
- * discovered services in one object, keyed by the name used as the sandbox
- * binding (e.g. "core" → coreSpec, "myservice" → serviceSpecs entry).
+ * Flat spec map for the query sandbox.
+ * `core` is always present. Every other key is a service contextPath — either a
+ * bundled service spec, a live-discovered spec, or null (service known-but-absent
+ * with spec removal enabled).
  *
- * A null value means the service is not installed on this tenant and
- * specRemoval is enabled. The binding is still injected so the agent can
- * check specsEnabled before attempting to use it.
- *
- * Path rewriting guarantee: all spec values have their paths already
- * prefixed with the service route before being placed in this map.
- * Bundled service specs are rewritten at build time (tsdown.config.ts).
- * Discovered specs are rewritten in discoverApiSpecs before caching.
+ * Paths inside each spec value are already prefixed with the service route.
+ * Bundled service specs are rewritten at build time; discovered specs are
+ * rewritten in src/utils/api-discovery.ts.
  */
 export type Specs = Record<string, unknown | null>
 
 /**
- * Resolve all specs for the current tenant into a single flat map.
+ * Resolved view passed into the query sandbox.
+ */
+export interface ResolvedSpecs {
+  /**
+   * Spec values for sandbox bindings — `core` always present, others keyed by contextPath.
+   */
+  specs: Specs
+  /**
+   * Per known bundled service (plus core): is it actually installed on the
+   * current tenant? Stays accurate even when --no-spec-removal keeps an absent
+   * service's bundled spec visible for reference.
+   */
+  specsEnabled: Record<string, boolean>
+}
+
+/**
+ * Resolve all specs for the current tenant by merging:
+ *   - core (always),
+ *   - bundled service specs (static seed, identical shape to discovery results),
+ *   - live discovered specs (override bundled per contextPath; pass through if not bundled).
  *
- * Bundled registry entries (see BUNDLED_SPEC_REGISTRY in openapi.ts):
- *   - No contextPath (core): always included.
- *   - With contextPath (service-backed, e.g. dtm once added):
- *     A. Service installed + live OpenAPI spec URL → use discovered spec
- *     B. Service installed + no spec URL in manifest → bundled spec fallback
- *     C. Service not installed → null (specRemoval true) or bundled (false)
+ * Service-backed resolution per known bundled service:
+ *   A. Live discovered → use live spec (live ⇒ installed).
+ *   B. Installed but no live spec → use the bundled fallback.
+ *   C. Not installed → null (specRemoval true) or bundled (specRemoval false, kept for reference).
  *
- * Non-bundled discovered services are added as-is, keyed by their contextPath.
- * @param discoveredSpecs
- * @param installedContextPaths
- * @param specRemoval
+ * @param liveDiscovered          - DiscoveredApiSpec[] from the per-tenant discovery cache
+ * @param installedContextPaths   - All subscribed app context paths on this tenant
+ * @param specRemoval             - Whether to inject null for absent known services
  */
 export function resolveSpecs(
-  discoveredSpecs: readonly DiscoveredApiSpec[],
+  liveDiscovered: readonly DiscoveredApiSpec[],
   installedContextPaths: ReadonlySet<string>,
   specRemoval: boolean,
-): Specs {
-  const result: Specs = {}
+): ResolvedSpecs {
+  const specs: Specs = { [CORE_SPEC.key]: CORE_SPEC.spec }
+  const specsEnabled: Record<string, boolean> = { [CORE_SPEC.key]: true }
 
-  // Bundled registry entries
-  for (const entry of BUNDLED_SPEC_REGISTRY) {
-    const contextPath = 'contextPath' in entry ? entry.contextPath : undefined
+  const liveByContextPath = new Map(liveDiscovered.map((s) => [s.contextPath, s]))
 
-    if (contextPath == null) {
-      result[entry.key] = entry.spec
-      continue
-    }
+  // Known bundled service specs — apply A / B / C
+  for (const bundled of BUNDLED_SERVICE_SPECS) {
+    const cp = bundled.contextPath
+    const installed = installedContextPaths.has(cp)
+    specsEnabled[cp] = installed
 
-    const discovered = discoveredSpecs.find((s) => s.contextPath === contextPath)
-    const installed = installedContextPaths.has(contextPath)
-
-    if (discovered) {
-      result[entry.key] = discovered.spec // A: live spec
+    const live = liveByContextPath.get(cp)
+    if (live) {
+      specs[cp] = live.spec // A
     } else if (installed) {
-      result[entry.key] = entry.spec // B: installed, use bundled fallback
+      specs[cp] = bundled.spec // B
     } else {
-      result[entry.key] = specRemoval ? null : entry.spec // C
+      specs[cp] = specRemoval ? null : bundled.spec // C
     }
   }
 
-  // Non-bundled discovered services
-  const knownContextPaths = new Set(
-    BUNDLED_SPEC_REGISTRY
-      .filter((e): e is (typeof e & { contextPath: string }) => 'contextPath' in e && e.contextPath != null)
-      .map((e) => e.contextPath),
-  )
-  for (const ds of discoveredSpecs) {
-    if (!knownContextPaths.has(ds.contextPath)) {
-      result[ds.contextPath] = ds.spec
+  // Non-bundled live-discovered services pass through unchanged
+  const bundledContextPaths = new Set(BUNDLED_SERVICE_SPECS.map((s) => s.contextPath))
+  for (const live of liveDiscovered) {
+    if (!bundledContextPaths.has(live.contextPath)) {
+      specs[live.contextPath] = live.spec
     }
   }
 
-  return result
+  return { specs, specsEnabled }
 }

--- a/test/excute.test.ts
+++ b/test/excute.test.ts
@@ -414,21 +414,44 @@ describe('query', () => {
     expect(JSON.parse(result)).toEqual({ hasCore: true, hasSpecsEnabled: true, hasServiceSpecs: true })
   })
 
-  it('injects each bundled registry key as a named ${key}Spec binding', async () => {
-    const result = await query('() => ({ hasCore: !!coreSpec })', { core: { paths: {} } } satisfies Specs)
-    expect(JSON.parse(result)).toEqual({ hasCore: true })
+  it('injects coreSpec as the only named binding', async () => {
+    const result = await query(
+      '() => ({ hasCore: !!coreSpec, hasDtmSpec: typeof dtmSpec !== "undefined" })',
+      { core: { paths: {} } } satisfies Specs,
+      { core: true },
+    )
+    // coreSpec exists; dtmSpec does NOT — dtm goes into serviceSpecs, not a named binding
+    expect(JSON.parse(result)).toEqual({ hasCore: true, hasDtmSpec: false })
   })
 
-  it('injects null for bundled entries marked unavailable; specsEnabled reflects that', async () => {
-    const result = await query('() => ({ coreSpec, specsEnabled })', { core: null } satisfies Specs)
-    expect(JSON.parse(result)).toEqual({ coreSpec: null, specsEnabled: { core: false } })
+  it('specsEnabled is passed as a separate input, not derived from null spec values', async () => {
+    // dtm spec is visible (bundled fallback for reference) but service is NOT installed.
+    // specsEnabled must report dtm: false even though the spec itself is non-null.
+    const result = await query(
+      '() => ({ dtmInServiceSpecs: !!serviceSpecs.dtm, specsEnabled })',
+      { core: { paths: {} }, dtm: { paths: {} } } satisfies Specs,
+      { core: true, dtm: false },
+    )
+    expect(JSON.parse(result)).toEqual({
+      dtmInServiceSpecs: true,
+      specsEnabled: { core: true, dtm: false },
+    })
   })
 
-  it('reads specs from c8yMcpServer.ctx.custom when no specsOverride is passed', async () => {
+  it('null spec entries are omitted from serviceSpecs', async () => {
+    const result = await query(
+      '() => Object.keys(serviceSpecs)',
+      { core: { paths: {} }, dtm: null } satisfies Specs,
+      { core: true, dtm: false },
+    )
+    expect(JSON.parse(result)).toEqual([])
+  })
+
+  it('reads specs from c8yMcpServer.ctx.custom when no override is passed', async () => {
     // ctx is an AsyncLocalStorage-backed getter — mock it instead of mutating.
-    const mockSpecs = resolveSpecs([], new Set(), true)
+    const resolved = resolveSpecs([], new Set(), true)
     const ctxSpy = vi.spyOn(c8yMcpServer, 'ctx', 'get').mockReturnValue({
-      custom: { env: 'cli' as const, restrictions: [], allowRules: [], specs: mockSpecs },
+      custom: { env: 'cli' as const, restrictions: [], allowRules: [], specs: resolved.specs, specsEnabled: resolved.specsEnabled },
     } as unknown as ReturnType<typeof c8yMcpServer['ctx']['valueOf']>)
     try {
       const result = await query('() => typeof coreSpec !== "undefined"')
@@ -438,9 +461,13 @@ describe('query', () => {
     }
   })
 
-  it('puts non-bundled-registry entries into serviceSpecs', async () => {
-    const result = await query('() => Object.keys(serviceSpecs)', { core: { paths: {} }, svc: { paths: {} } } satisfies Specs)
-    expect(JSON.parse(result)).toEqual(['svc'])
+  it('puts non-core entries into serviceSpecs (bundled + discovered alike)', async () => {
+    const result = await query(
+      '() => Object.keys(serviceSpecs).sort()',
+      { core: { paths: {} }, dtm: { paths: {} }, svc: { paths: {} } } satisfies Specs,
+      { core: true, dtm: true },
+    )
+    expect(JSON.parse(result)).toEqual(['dtm', 'svc'])
   })
 })
 

--- a/test/restrictions.test.ts
+++ b/test/restrictions.test.ts
@@ -124,8 +124,9 @@ describe('allow parsing', () => {
 })
 
 describe('bundled openapi entries', () => {
-  it('core is the only bundled spec entry', () => {
-    expect(BUNDLED_OPENAPI_ENTRIES.map((e) => e.api)).toEqual(['core'])
+  it('bundled openapi entries surface core plus every bundled service', () => {
+    // core is always first; bundled service entries follow (currently: dtm)
+    expect(BUNDLED_OPENAPI_ENTRIES.map((e) => e.api)).toEqual(['core', 'dtm'])
   })
 })
 

--- a/test/spec-resolution.test.ts
+++ b/test/spec-resolution.test.ts
@@ -9,61 +9,94 @@ function makeDiscovered(contextPath: string, spec: object = {}): DiscoveredApiSp
 }
 
 // ---------------------------------------------------------------------------
-// resolveSpecs — flat unified map (bundled + discovered services)
+// resolveSpecs — returns { specs, specsEnabled }
 // ---------------------------------------------------------------------------
 
-describe('resolveSpecs — core (always-available, no contextPath)', () => {
+describe('resolveSpecs — core (always-available)', () => {
   it('always includes core regardless of discovery results or specRemoval', () => {
-    const result = resolveSpecs([], EMPTY_INSTALLED, true)
-    expect(result.core).not.toBeNull()
-    expect(result.core).not.toBeUndefined()
-    expect(result.core).toBeTruthy()
+    const { specs, specsEnabled } = resolveSpecs([], EMPTY_INSTALLED, true)
+    expect(specs.core).toBeTruthy()
+    expect(specsEnabled.core).toBe(true)
   })
 
-  it('core is always true in specsEnabled (derived by buildQueryScript)', () => {
-    const result = resolveSpecs([], EMPTY_INSTALLED, true)
-    expect(result.core !== null).toBe(true)
+  it('core never depends on specRemoval', () => {
+    const a = resolveSpecs([], EMPTY_INSTALLED, true)
+    const b = resolveSpecs([], EMPTY_INSTALLED, false)
+    expect(a.specs.core).toEqual(b.specs.core)
+    expect(a.specsEnabled.core).toBe(true)
+    expect(b.specsEnabled.core).toBe(true)
   })
 })
 
-describe('resolveSpecs — output shape', () => {
-  it('only bundled keys when no services discovered', () => {
-    const result = resolveSpecs([], EMPTY_INSTALLED, true)
-    expect(Object.keys(result)).toEqual(['core'])
+describe('resolveSpecs — bundled service-backed entries (currently dtm)', () => {
+  it('A: live discovered dtm spec → uses the live spec', () => {
+    const liveSpec = { paths: { '/service/dtm/live': {} } }
+    const discovered = [makeDiscovered('dtm', liveSpec)]
+    const { specs, specsEnabled } = resolveSpecs(discovered, new Set(['dtm']), true)
+    expect(specs.dtm).toEqual(liveSpec)
+    expect(specsEnabled.dtm).toBe(true)
   })
 
+  it('B: dtm installed but no live spec → uses bundled fallback', () => {
+    const { specs, specsEnabled } = resolveSpecs([], new Set(['dtm']), true)
+    expect(specs.dtm).not.toBeNull()
+    expect(specs.dtm).toBeTruthy()
+    expect(specsEnabled.dtm).toBe(true)
+  })
+
+  it('C: dtm not installed + specRemoval=true → null', () => {
+    const { specs, specsEnabled } = resolveSpecs([], EMPTY_INSTALLED, true)
+    expect(specs.dtm).toBeNull()
+    expect(specsEnabled.dtm).toBe(false)
+  })
+
+  it('C: dtm not installed + specRemoval=false → bundled spec kept for reference', () => {
+    const { specs, specsEnabled } = resolveSpecs([], EMPTY_INSTALLED, false)
+    expect(specs.dtm).not.toBeNull()
+    expect(specs.dtm).toBeTruthy()
+    // specsEnabled still false: the spec is visible but the service is absent
+    expect(specsEnabled.dtm).toBe(false)
+  })
+
+  it('dtm appears exactly once even when both bundled and live exist', () => {
+    const liveSpec = { paths: { '/service/dtm/live': {} } }
+    const discovered = [makeDiscovered('dtm', liveSpec)]
+    const { specs } = resolveSpecs(discovered, new Set(['dtm']), true)
+    // dtm key is present once; bundled fallback is not duplicated under any other key
+    expect(specs.dtm).toEqual(liveSpec)
+    expect(Object.keys(specs).filter((k) => k === 'dtm')).toHaveLength(1)
+  })
+})
+
+describe('resolveSpecs — non-bundled discovered services', () => {
   it('adds non-bundled discovered services as additional flat entries', () => {
     const discovered = [makeDiscovered('svcA'), makeDiscovered('svcB')]
-    const result = resolveSpecs(discovered, new Set(['svcA', 'svcB']), true)
-    expect(Object.keys(result).sort()).toEqual(['core', 'svcA', 'svcB'])
-    expect(result.svcA).not.toBeNull()
-    expect(result.svcB).not.toBeNull()
+    const { specs } = resolveSpecs(discovered, new Set(['svcA', 'svcB']), true)
+    expect(Object.keys(specs).sort()).toEqual(['core', 'dtm', 'svcA', 'svcB'])
+    expect(specs.svcA).not.toBeNull()
+    expect(specs.svcB).not.toBeNull()
   })
 
-  it('non-bundled service entry value is the spec object directly', () => {
+  it('non-bundled service value is the spec object directly', () => {
     const spec = { paths: { '/items': {} } }
     const discovered = [makeDiscovered('myservice', spec)]
-    const result = resolveSpecs(discovered, new Set(['myservice']), true)
-    expect(result.myservice).toEqual(spec)
+    const { specs } = resolveSpecs(discovered, new Set(['myservice']), true)
+    expect(specs.myservice).toEqual(spec)
   })
 
-  it('core always present even with service discoveries', () => {
-    const discovered = [makeDiscovered('svc')]
-    const result = resolveSpecs(discovered, new Set(['svc']), true)
-    expect(result.core).toBeTruthy()
-  })
-})
-
-describe('resolveSpecs — service-backed bundled entries (e.g. dtm once added)', () => {
-  it('specRemoval flag does not affect core (no contextPath = always present)', () => {
-    const withRemoval = resolveSpecs([], EMPTY_INSTALLED, true)
-    const withoutRemoval = resolveSpecs([], EMPTY_INSTALLED, false)
-    expect(withRemoval.core).toEqual(withoutRemoval.core)
-  })
-
-  it('non-bundled discovered services are included regardless of specRemoval', () => {
+  it('non-bundled services are included regardless of specRemoval', () => {
     const discovered = [makeDiscovered('ext')]
-    const result = resolveSpecs(discovered, new Set(['ext']), true)
-    expect(result.ext).not.toBeNull()
+    const a = resolveSpecs(discovered, new Set(['ext']), true)
+    const b = resolveSpecs(discovered, new Set(['ext']), false)
+    expect(a.specs.ext).not.toBeNull()
+    expect(b.specs.ext).not.toBeNull()
+  })
+
+  it('specsEnabled does NOT include non-bundled services', () => {
+    // specsEnabled is a fixed-key map of known bundled services; unknown
+    // services have to be checked via Object.hasOwn(serviceSpecs, key) instead.
+    const discovered = [makeDiscovered('arbitrary')]
+    const { specsEnabled } = resolveSpecs(discovered, new Set(['arbitrary']), true)
+    expect(Object.keys(specsEnabled).sort()).toEqual(['core', 'dtm'])
   })
 })

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -5,53 +5,78 @@ import { defineConfig } from 'tsdown'
 
 const rootDir = path.dirname(fileURLToPath(import.meta.url))
 
-const OPENAPI_MODULES = {
-  core: {
-    virtualId: '#core-openapi',
-    resolvedId: '\0virtual:core-openapi',
-    entryType: 'CoreOpenApiEntry',
-    entryConst: 'specs',
-    getSpec: 'getCoreOpenApiSpec',
-    getVersion: 'getCoreOpenApiVersion',
-    setVersion: 'setCoreOpenApiVersion',
-    getLabel: 'getCoreOpenApiLabel',
-    pluginName: 'mc8yp:core-openapi',
-  },
-} as const
+// ---------------------------------------------------------------------------
+// openapi-builds.json schema
+// ---------------------------------------------------------------------------
 
-type OpenApiModuleName = keyof typeof OPENAPI_MODULES
-
-interface OpenApiSourceEntry {
+interface CoreVersionEntry {
   version: string
   label: string
   url: string
-  servicePrefix?: string
   default?: boolean
 }
 
-interface OpenApiBuildEntry {
+interface ServiceEntry {
+  /**
+   * Microservice context path key (also the file name under openapi/services/).
+   */
+  key: string
+  label: string
+  url: string
+  /**
+   * URL prefix prepended to spec paths at build time.
+   */
+  servicePrefix: string
+}
+
+interface BuildEntry {
   version: string
   label: string
-  artifact: string
-  apis: Record<string, string>
+  /**
+   * Which core version this build inlines. Bundled services are always included as-is.
+   */
+  core: string
   default?: boolean
+}
+
+interface OpenApiConfig {
+  core: { versions: CoreVersionEntry[] }
+  services: ServiceEntry[]
+  builds: BuildEntry[]
 }
 
 const OPENAPI_CONFIG = JSON.parse(
   readFileSync(path.join(rootDir, 'openapi-builds.json'), 'utf8'),
-) as {
-  sources: Record<string, OpenApiSourceEntry[]>
-  builds: OpenApiBuildEntry[]
-}
+) as OpenApiConfig
 
-function getSourceConfig(api: OpenApiModuleName, version: string): OpenApiSourceEntry {
-  const entry = OPENAPI_CONFIG.sources[api]?.find((candidate) => candidate.version === version)
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function getCoreVersion(version: string): CoreVersionEntry {
+  const entry = OPENAPI_CONFIG.core.versions.find((v) => v.version === version)
   if (!entry) {
-    throw new Error(`Unknown ${api} OpenAPI version ${version}.`)
+    throw new Error(`Unknown core OpenAPI version: ${version}`)
   }
   return entry
 }
 
+function readCoreSpecJson(version: string): string {
+  return readFileSync(path.join(rootDir, 'openapi', 'core', `${version}.json`), 'utf8').trim()
+}
+
+function readServiceSpecJson(key: string): string {
+  return readFileSync(path.join(rootDir, 'openapi', 'services', `${key}.json`), 'utf8').trim()
+}
+
+/**
+ * Rewrite an OpenAPI spec so every `paths` key is prefixed with `servicePrefix`,
+ * and any `servers[].url` template placeholder includes the prefix too.
+ * Applied to bundled service specs at build time so they look identical to
+ * what live discovery produces in src/utils/api-discovery.ts.
+ * @param specJson
+ * @param servicePrefix
+ */
 function rewriteSpecPaths(specJson: string, servicePrefix: string): string {
   const spec = JSON.parse(specJson) as {
     paths?: Record<string, unknown>
@@ -73,90 +98,120 @@ function rewriteSpecPaths(specJson: string, servicePrefix: string): string {
   return JSON.stringify(spec)
 }
 
-function readSpecJson(api: OpenApiModuleName, version: string): string {
-  const raw = readFileSync(path.join(rootDir, 'openapi', api, `${version}.json`), 'utf8').trim()
-  const source = getSourceConfig(api, version)
-  return source.servicePrefix ? rewriteSpecPaths(raw, source.servicePrefix) : raw
-}
+// ---------------------------------------------------------------------------
+// #core-openapi — special-cased: version-switchable in CLI, single-version in server
+// ---------------------------------------------------------------------------
 
-function generateEntries(api: OpenApiModuleName, versions: readonly string[]): string {
+const CORE_VIRTUAL_ID = '#core-openapi'
+const CORE_RESOLVED_ID = '\0virtual:core-openapi'
+
+function generateCoreEntries(versions: readonly string[]): string {
   return versions.map((version) => {
-    const source = getSourceConfig(api, version)
-    return `  { version: ${JSON.stringify(version)}, label: ${JSON.stringify(source.label)}, spec: ${readSpecJson(api, version)} },`
+    const source = getCoreVersion(version)
+    return `  { version: ${JSON.stringify(version)}, label: ${JSON.stringify(source.label)}, spec: ${readCoreSpecJson(version)} },`
   }).join('\n')
 }
 
-function generateCliModule(api: OpenApiModuleName): string {
-  const moduleInfo = OPENAPI_MODULES[api]
-  const versions = OPENAPI_CONFIG.sources[api].map((entry) => entry.version)
-  const defaultVersion = OPENAPI_CONFIG.sources[api].find((entry) => entry.default)?.version ?? versions[0] ?? 'release'
+function generateCoreCliModule(): string {
+  const versions = OPENAPI_CONFIG.core.versions.map((v) => v.version)
+  const defaultVersion = OPENAPI_CONFIG.core.versions.find((v) => v.default)?.version ?? versions[0] ?? 'release'
 
-  return `export const ${moduleInfo.entryConst} = Object.freeze([\n${generateEntries(api, versions)}\n]);
+  return `export const specs = Object.freeze([
+${generateCoreEntries(versions)}
+]);
 let activeVersion = ${JSON.stringify(defaultVersion)};
-export function ${moduleInfo.getSpec}() {
-  return ${moduleInfo.entryConst}.find((entry) => entry.version === activeVersion)?.spec ?? ${moduleInfo.entryConst}[0]?.spec;
+export function getCoreOpenApiSpec() {
+  return specs.find((entry) => entry.version === activeVersion)?.spec ?? specs[0]?.spec;
 }
-export function ${moduleInfo.getVersion}() {
+export function getCoreOpenApiVersion() {
   return activeVersion;
 }
-export function ${moduleInfo.setVersion}(version) {
-  if (!${moduleInfo.entryConst}.some((entry) => entry.version === version)) {
-    throw new Error("Unknown ${api} OpenAPI version: " + version + ". Available: " + ${moduleInfo.entryConst}.map((entry) => entry.version).join(", "));
+export function setCoreOpenApiVersion(version) {
+  if (!specs.some((entry) => entry.version === version)) {
+    throw new Error("Unknown core OpenAPI version: " + version + ". Available: " + specs.map((entry) => entry.version).join(", "));
   }
   activeVersion = version;
 }
-export function ${moduleInfo.getLabel}() {
-  return ${moduleInfo.entryConst}.find((entry) => entry.version === activeVersion)?.label ?? ${moduleInfo.entryConst}[0]?.label ?? activeVersion;
+export function getCoreOpenApiLabel() {
+  return specs.find((entry) => entry.version === activeVersion)?.label ?? specs[0]?.label ?? activeVersion;
 }
 `
 }
 
-function generateServerModule(api: OpenApiModuleName, build: OpenApiBuildEntry): string {
-  const moduleInfo = OPENAPI_MODULES[api]
-  const version = build.apis[api]
-  const label = getSourceConfig(api, version).label
+function generateCoreServerModule(build: BuildEntry): string {
+  const version = build.core
+  const label = getCoreVersion(version).label
 
-  return `export const ${moduleInfo.entryConst} = Object.freeze([\n${generateEntries(api, [version])}\n]);
-export function ${moduleInfo.getSpec}() {
-  return ${moduleInfo.entryConst}[0]?.spec;
+  return `export const specs = Object.freeze([
+${generateCoreEntries([version])}
+]);
+export function getCoreOpenApiSpec() {
+  return specs[0]?.spec;
 }
-export function ${moduleInfo.getVersion}() {
-  return ${moduleInfo.entryConst}[0]?.version ?? ${JSON.stringify(version)};
+export function getCoreOpenApiVersion() {
+  return specs[0]?.version ?? ${JSON.stringify(version)};
 }
-export function ${moduleInfo.setVersion}() {
-  throw new Error("This server build is locked to ${api} OpenAPI version " + (${moduleInfo.entryConst}[0]?.version ?? ${JSON.stringify(version)}) + ".");
+export function setCoreOpenApiVersion() {
+  throw new Error("This server build is locked to core OpenAPI version " + (specs[0]?.version ?? ${JSON.stringify(version)}) + ".");
 }
-export function ${moduleInfo.getLabel}() {
-  return ${moduleInfo.entryConst}[0]?.label ?? ${JSON.stringify(label)};
+export function getCoreOpenApiLabel() {
+  return specs[0]?.label ?? ${JSON.stringify(label)};
 }
 `
 }
 
-function createOpenApiPlugin(api: OpenApiModuleName, options: { mode: 'cli' } | { mode: 'server', build: OpenApiBuildEntry }) {
-  const moduleInfo = OPENAPI_MODULES[api]
-
+export function coreOpenApiPlugin(options: { mode: 'cli' } | { mode: 'server', build: BuildEntry }) {
   return {
-    name: moduleInfo.pluginName,
+    name: 'mc8yp:core-openapi',
     resolveId(id: string) {
-      if (id === moduleInfo.virtualId) {
-        return moduleInfo.resolvedId
-      }
-      return null
+      return id === CORE_VIRTUAL_ID ? CORE_RESOLVED_ID : null
     },
     load(id: string) {
-      if (id !== moduleInfo.resolvedId) {
+      if (id !== CORE_RESOLVED_ID)
         return null
-      }
-      return options.mode === 'cli'
-        ? generateCliModule(api)
-        : generateServerModule(api, options.build)
+      return options.mode === 'cli' ? generateCoreCliModule() : generateCoreServerModule(options.build)
     },
   }
 }
 
-export function coreOpenApiPlugin(options: { mode: 'cli' } | { mode: 'server', build: OpenApiBuildEntry }) {
-  return createOpenApiPlugin('core', options)
+// ---------------------------------------------------------------------------
+// #bundled-services — generic: emits BUNDLED_SERVICE_SPECS as DiscoveredApiSpec[]
+// Identical content for CLI and server builds — bundled services have no version axis.
+// ---------------------------------------------------------------------------
+
+const SERVICES_VIRTUAL_ID = '#bundled-services'
+const SERVICES_RESOLVED_ID = '\0virtual:bundled-services'
+
+function generateBundledServicesModule(): string {
+  const entries = OPENAPI_CONFIG.services.map((service) => {
+    const rawSpec = readServiceSpecJson(service.key)
+    const rewrittenSpec = rewriteSpecPaths(rawSpec, service.servicePrefix)
+    return `  { contextPath: ${JSON.stringify(service.key)}, appLabel: ${JSON.stringify(service.label)}, specLabel: ${JSON.stringify(service.label)}, servicePrefix: ${JSON.stringify(service.servicePrefix)}, spec: ${rewrittenSpec} },`
+  }).join('\n')
+
+  return `export const BUNDLED_SERVICE_SPECS = Object.freeze([
+${entries}
+]);
+`
 }
+
+export function bundledServicesPlugin() {
+  return {
+    name: 'mc8yp:bundled-services',
+    resolveId(id: string) {
+      return id === SERVICES_VIRTUAL_ID ? SERVICES_RESOLVED_ID : null
+    },
+    load(id: string) {
+      if (id !== SERVICES_RESOLVED_ID)
+        return null
+      return generateBundledServicesModule()
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Build matrix
+// ---------------------------------------------------------------------------
 
 const serverBuilds = OPENAPI_CONFIG.builds.map((build) => ({
   name: `mc8yp-server-build-${build.version}`,
@@ -165,7 +220,7 @@ const serverBuilds = OPENAPI_CONFIG.builds.map((build) => ({
   clean: build.version === OPENAPI_CONFIG.builds[0]?.version,
   dts: false,
   format: 'module' as const,
-  plugins: [coreOpenApiPlugin({ mode: 'server', build })],
+  plugins: [coreOpenApiPlugin({ mode: 'server', build }), bundledServicesPlugin()],
   outDir: `.output/${build.version}`,
 }))
 
@@ -178,7 +233,7 @@ export default defineConfig([
     clean: true,
     dts: false,
     format: 'module',
-    plugins: [coreOpenApiPlugin({ mode: 'cli' })],
+    plugins: [coreOpenApiPlugin({ mode: 'cli' }), bundledServicesPlugin()],
     // no external -> everything starting with @c8y/ should be bundled for cli usage
     noExternal: [/^@c8y\/.*$/],
     outDir: 'dist',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vitest/config'
-import { coreOpenApiPlugin } from './tsdown.config'
+import { bundledServicesPlugin, coreOpenApiPlugin } from './tsdown.config'
 
 export default defineConfig({
-  plugins: [coreOpenApiPlugin({ mode: 'cli' })],
+  plugins: [coreOpenApiPlugin({ mode: 'cli' }), bundledServicesPlugin()],
 })


### PR DESCRIPTION
Re-bundles DTM (which was deleted in #28) **without** any DTM-specific code. `core` is the only spec that gets special handling; everything else flows through one generic pipeline.

## Goal

> all bundled specs besides the core should be in a format we later also discover and then update. no more custom handling besides the core.

After this PR, **adding a new bundled service spec requires:**

1. drop the JSON at `openapi/services/<key>.json` (or let the nightly action fetch it)
2. add one entry to `openapi-builds.json#services`: `{ key, label, url, servicePrefix }`

**No code edits in `src/`, `tsdown.config.ts`, `*.d.ts`, or tests required.**

---

## What changed

### 1. `openapi-builds.json` — new shape

```json
{
  "core": { "versions": [{ version, label, url, default? }, ...] },
  "services": [{ key, label, url, servicePrefix }],
  "builds":   [{ version, label, core, default? }]
}
```

- `core.versions` (versioned, switchable) replaces `sources.core`.
- `services` (flat list, single version per service) replaces `sources.dtm`/etc.
- `builds[].core` replaces `builds[].apis.core`.
- `builds[].artifact` removed — computed generically (`core-<core>-<service1>-<service2>-…`, sorted).

### 2. File layout

```
openapi/
├── core/{release,2026,2025,2024}.json
└── services/dtm.json   ← new; replaces openapi/dtm/release.json
```

### 3. Two virtual modules

- **`#core-openapi`** — unchanged, version-switchable in CLI builds, single-version in server builds.
- **`#bundled-services`** _(new, generic)_ — loops `openapi-builds.json#services`, applies the existing `rewriteSpecPaths(raw, servicePrefix)`, emits:

  ```ts
  export const BUNDLED_SERVICE_SPECS: readonly DiscoveredApiSpec[]
  ```

  Same `DiscoveredApiSpec` shape live discovery produces. No per-service code.

### 4. `resolveSpecs` now returns `{ specs, specsEnabled }`

`specsEnabled` is computed in resolution time (not derived in the sandbox) so it stays accurate when `--no-spec-removal` keeps a bundled spec visible for a service that isn't installed.

A/B/C resolution per bundled service, generic across all entries:
- **A** live discovered → use live spec
- **B** installed but no spec URL → use bundled fallback
- **C** not installed → `null` (specRemoval on) or bundled (off)

### 5. Sandbox bindings — `core` is the only named binding

`buildQueryScript` injects:

- `coreSpec` — always (the only `${key}Spec` binding)
- `specsEnabled` — `{ core, dtm, … }` per known bundled service
- `serviceSpecs` — record keyed by contextPath: bundled service specs (e.g. `serviceSpecs.dtm`) + live-discovered services. Live overrides bundled per contextPath.

DTM is now accessed via `serviceSpecs.dtm`, not `dtmSpec`.

### 6. Scripts reworked

- **`scripts/update-openapi.mjs`** — generic two-loop (core versions + services). One `fetchAndWrite` helper, identical handling.
- **`scripts/package-microservices.mjs`** — artifact name computed: `core-<coreVersion>` + sorted service keys appended. Old behaviour preserved (`mc8yp-core-release-dtm-…`) but generic.

### 7. Auto-restrictions — unchanged, generic source

`KNOWN_BUNDLED_SERVICES` now derived from `BUNDLED_SERVICE_SPECS`. When discovery confirms a bundled service isn't installed, `*:/service/<contextPath>/**` deny rules are auto-merged into `effectiveRestrictions`.

---

## Removed

- `#dtm-openapi` virtual module
- `BUNDLED_SPEC_REGISTRY` + `BundledSpec`/`AlwaysAvailableSpec`/`ServiceBackedSpec` types (core and services are now distinct, not a union)
- `dtmSpec` named binding in the sandbox
- `apis.dtm` / hand-written `artifact` field in `openapi-builds.json`
- Stale `--disable-openapi` / `openapi-disabled` references in README (those mechanisms were already gone)

## Tests

- 154 tests across 7 files, all passing.
- New A/B/C tests for the bundled DTM service via `resolveSpecs`.
- New test: `specsEnabled.dtm === false` even when `--no-spec-removal` keeps the bundled spec visible.
- Sandbox injection tests updated: `coreSpec` is the only named binding; `serviceSpecs` contains both bundled and live-discovered entries.

## Verification

`pnpm typecheck` ✓ · `pnpm lint:fix` ✓ (5 pre-existing JSDoc warnings, 0 errors) · `pnpm test:run` ✓ 154/154 · `pnpm build` ✓ all four server bundles + CLI build. Sanity-checked that `/service/dtm/` paths and the DTM spec content are inlined in `.output/release/server.mjs`.