### PR TITLE
feat: Resolve $ref in OpenAPI spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@napi-rs/keyring": "catalog:"
   },
   "devDependencies": {
+    "@apidevtools/json-schema-ref-parser": "catalog:",
     "@c8y/client": "catalog:",
     "@clack/prompts": "catalog:",
     "@iso4/fetch": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@apidevtools/json-schema-ref-parser':
+      specifier: ^15.3.6
+      version: 15.3.6
     '@c8y/client':
       specifier: ^1023.83.4
       version: 1023.83.4
@@ -90,6 +93,9 @@ importers:
         specifier: 'catalog:'
         version: 1.3.0
     devDependencies:
+      '@apidevtools/json-schema-ref-parser':
+        specifier: 'catalog:'
+        version: 15.3.6(@types/json-schema@7.0.15)
       '@c8y/client':
         specifier: 'catalog:'
         version: 1023.83.4
@@ -281,6 +287,12 @@ packages:
     resolution: {integrity: sha512-S8jExTjxPJILwpg2lu3DohSASVZ8DLhSNCmOe7z0qF9VskRSjC7SIQv1rq36tsJkenxuA72gjVOHZv+uSRT8HA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
     hasBin: true
+
+  '@apidevtools/json-schema-ref-parser@15.3.6':
+    resolution: {integrity: sha512-oPFDSviRrreUmCZn09LCD4S9QQa6j7zfEwBM1pkGa/kXY0O4sXsEXn4emLP/Tt6tik2+BtgwKk2eldAeOWZ2Rw==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@types/json-schema': ^7.0.15
 
   '@babel/generator@8.0.0-rc.6':
     resolution: {integrity: sha512-6mIzgVK8DgEzvIapoQwhXTMnnkuE4STQmVv9H03i/tZ2ml8oev3TRvZJgTenK2Bsq0YWNtzOrFdTyNzCMFtjJQ==}
@@ -1294,6 +1306,9 @@ packages:
     resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
     engines: {node: '>=14'}
 
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
   args-tokenizer@0.3.0:
     resolution: {integrity: sha512-xXAd7G2Mll5W8uo37GETpQ2VrE84M181Z7ugHFGQnJZ50M2mbOv0osSZ9VsSgPfJQ+LVG0prSi0th+ELMsno7Q==}
 
@@ -2264,6 +2279,10 @@ packages:
 
   jose@6.2.3:
     resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  js-yaml@4.2.0:
+    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+    hasBin: true
 
   jsdoc-type-pratt-parser@7.2.0:
     resolution: {integrity: sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==}
@@ -3753,6 +3772,11 @@ snapshots:
       - chokidar
       - supports-color
 
+  '@apidevtools/json-schema-ref-parser@15.3.6(@types/json-schema@7.0.15)':
+    dependencies:
+      '@types/json-schema': 7.0.15
+      js-yaml: 4.2.0
+
   '@babel/generator@8.0.0-rc.6':
     dependencies:
       '@babel/parser': 8.0.0-rc.6
@@ -4797,6 +4821,8 @@ snapshots:
 
   are-docs-informative@0.0.2: {}
 
+  argparse@2.0.1: {}
+
   args-tokenizer@0.3.0: {}
 
   aria-query@5.3.2: {}
@@ -5774,6 +5800,10 @@ snapshots:
   jiti@2.7.0: {}
 
   jose@6.2.3: {}
+
+  js-yaml@4.2.0:
+    dependencies:
+      argparse: 2.0.1
 
   jsdoc-type-pratt-parser@7.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,6 +13,7 @@ trustPolicyExclude:
   - tinyexec@1.2.2
 
 catalog:
+  '@apidevtools/json-schema-ref-parser': ^15.3.6
   '@c8y/client': ^1023.83.4
   '@clack/prompts': ^1.5.1
   '@iso4/fetch': ^0.0.1

--- a/src/utils/api-discovery.ts
+++ b/src/utils/api-discovery.ts
@@ -13,6 +13,7 @@
 import consola from 'consola'
 import type { Client, IApplication } from '@c8y/client'
 import { c8yErrorSummary } from './client'
+import { resolveInternalRefs } from './resolve-refs'
 import type { PathItem, Spec } from './spec-resolution'
 
 // ---------------------------------------------------------------------------
@@ -251,12 +252,13 @@ export async function discoverApiSpecs(client: Client, tenantId: string): Promis
         const specRes = await client.core.fetch(`${servicePrefix}/${entry.path.replace(/^\//, '')}`)
         if (!specRes.ok)
           continue
+        const resolvedSpec = await resolveInternalRefs(await specRes.json() as Spec)
         specs.push({
           contextPath: app.contextPath,
           appLabel: app.name,
           specLabel: entry.label,
           servicePrefix,
-          spec: rewriteDiscoveredSpecPaths(await specRes.json() as Spec, servicePrefix),
+          spec: rewriteDiscoveredSpecPaths(resolvedSpec, servicePrefix),
         })
       } catch { /* skip individual spec failures */ }
     }

--- a/src/utils/resolve-refs.ts
+++ b/src/utils/resolve-refs.ts
@@ -1,0 +1,37 @@
+/**
+ * Internal $ref resolution for OpenAPI documents.
+ *
+ * Both the build-time bundled specs (tsdown.config.ts) and the live-discovered
+ * specs (api-discovery.ts) are run through this before use so consumers — the
+ * code-mode query sandbox, prompt builders, tool generation — see fully inlined
+ * schemas instead of `$ref` pointers.
+ */
+
+import $RefParser from '@apidevtools/json-schema-ref-parser'
+
+/**
+ * Dereference same-document ($ref: "#/...") pointers in place and return the
+ * spec with refs inlined.
+ *
+ * - External file/URL resolution is disabled (`resolve.external = false`), so
+ *   the operation is purely in-memory: no disk or network access, and only
+ *   internal references are touched.
+ * - Circular references are left untouched (`circular: 'ignore'`) so the result
+ *   stays JSON-serialisable. The specs are later `JSON.stringify`'d into the
+ *   sandbox entry script and inlined into the build output; a dereferenced
+ *   circular structure would throw "Converting circular structure to JSON".
+ *
+ * On any parser error the original spec is returned unchanged so a malformed
+ * or unusual document never breaks spec loading.
+ * @param spec OpenAPI document to dereference. Mutated in place on success.
+ */
+export async function resolveInternalRefs<T extends object>(spec: T): Promise<T> {
+  try {
+    return await $RefParser.dereference(spec, {
+      resolve: { external: false },
+      dereference: { circular: 'ignore' },
+    }) as T
+  } catch {
+    return spec
+  }
+}

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'tsdown'
+import { resolveInternalRefs } from './src/utils/resolve-refs.ts'
 
 const rootDir = path.dirname(fileURLToPath(import.meta.url))
 
@@ -52,46 +53,60 @@ function getSourceConfig(api: OpenApiModuleName, version: string): OpenApiSource
   return entry
 }
 
-function rewriteSpecPaths(specJson: string, servicePrefix: string): string {
-  const spec = JSON.parse(specJson) as {
+/**
+ * Parse a raw spec JSON string, dereference its internal $ref pointers, then
+ * (optionally) rewrite paths/servers with the service prefix. Returns a JSON
+ * string ready to inline into a generated module.
+ *
+ * $ref resolution happens here so the bundled specs that ship in the build
+ * carry fully inlined schemas, matching the resolution applied to live
+ * discovered specs at runtime (see src/utils/resolve-refs.ts).
+ * @param specJson Raw spec contents read from disk.
+ * @param servicePrefix Optional prefix to prepend to paths/servers (service specs only).
+ */
+async function prepareSpecJson(specJson: string, servicePrefix?: string): Promise<string> {
+  const spec = await resolveInternalRefs(JSON.parse(specJson) as {
     paths?: Record<string, unknown>
     servers?: Array<{ url: string, description?: string }>
-  }
-  if (spec.paths) {
-    const rewritten: Record<string, unknown> = {}
-    for (const [p, item] of Object.entries(spec.paths)) {
-      rewritten[`${servicePrefix}${p}`] = item
+  })
+  if (servicePrefix) {
+    if (spec.paths) {
+      const rewritten: Record<string, unknown> = {}
+      for (const [p, item] of Object.entries(spec.paths)) {
+        rewritten[`${servicePrefix}${p}`] = item
+      }
+      spec.paths = rewritten
     }
-    spec.paths = rewritten
-  }
-  if (spec.servers) {
-    spec.servers = spec.servers.map((server) => ({
-      ...server,
-      url: server.url.replace('<TENANT_DOMAIN>', `<TENANT_DOMAIN>${servicePrefix}`),
-    }))
+    if (spec.servers) {
+      spec.servers = spec.servers.map((server) => ({
+        ...server,
+        url: server.url.replace('<TENANT_DOMAIN>', `<TENANT_DOMAIN>${servicePrefix}`),
+      }))
+    }
   }
   return JSON.stringify(spec)
 }
 
-function readSpecJson(api: OpenApiModuleName, version: string): string {
+async function readSpecJson(api: OpenApiModuleName, version: string): Promise<string> {
   const raw = readFileSync(path.join(rootDir, 'openapi', api, `${version}.json`), 'utf8').trim()
   const source = getSourceConfig(api, version)
-  return source.servicePrefix ? rewriteSpecPaths(raw, source.servicePrefix) : raw
+  return prepareSpecJson(raw, source.servicePrefix)
 }
 
-function generateEntries(api: OpenApiModuleName, versions: readonly string[]): string {
-  return versions.map((version) => {
+async function generateEntries(api: OpenApiModuleName, versions: readonly string[]): Promise<string> {
+  const lines = await Promise.all(versions.map(async (version) => {
     const source = getSourceConfig(api, version)
-    return `  { version: ${JSON.stringify(version)}, label: ${JSON.stringify(source.label)}, spec: ${readSpecJson(api, version)} },`
-  }).join('\n')
+    return `  { version: ${JSON.stringify(version)}, label: ${JSON.stringify(source.label)}, spec: ${await readSpecJson(api, version)} },`
+  }))
+  return lines.join('\n')
 }
 
-function generateCliModule(api: OpenApiModuleName): string {
+async function generateCliModule(api: OpenApiModuleName): Promise<string> {
   const moduleInfo = OPENAPI_MODULES[api]
   const versions = OPENAPI_CONFIG.sources[api].map((entry) => entry.version)
   const defaultVersion = OPENAPI_CONFIG.sources[api].find((entry) => entry.default)?.version ?? versions[0] ?? 'release'
 
-  return `export const ${moduleInfo.entryConst} = Object.freeze([\n${generateEntries(api, versions)}\n]);
+  return `export const ${moduleInfo.entryConst} = Object.freeze([\n${await generateEntries(api, versions)}\n]);
 let activeVersion = ${JSON.stringify(defaultVersion)};
 export function ${moduleInfo.getSpec}() {
   return ${moduleInfo.entryConst}.find((entry) => entry.version === activeVersion)?.spec ?? ${moduleInfo.entryConst}[0]?.spec;
@@ -111,12 +126,12 @@ export function ${moduleInfo.getLabel}() {
 `
 }
 
-function generateServerModule(api: OpenApiModuleName, build: OpenApiBuildEntry): string {
+async function generateServerModule(api: OpenApiModuleName, build: OpenApiBuildEntry): Promise<string> {
   const moduleInfo = OPENAPI_MODULES[api]
   const version = build.apis[api]
   const label = getSourceConfig(api, version).label
 
-  return `export const ${moduleInfo.entryConst} = Object.freeze([\n${generateEntries(api, [version])}\n]);
+  return `export const ${moduleInfo.entryConst} = Object.freeze([\n${await generateEntries(api, [version])}\n]);
 export function ${moduleInfo.getSpec}() {
   return ${moduleInfo.entryConst}[0]?.spec;
 }
@@ -180,7 +195,7 @@ export function bundledServicesPlugin(options: { mode: 'cli' } | { mode: 'server
         return RESOLVED_ID
       return null
     },
-    load(id: string) {
+    async load(id: string) {
       if (id !== RESOLVED_ID)
         return null
 
@@ -205,7 +220,7 @@ export function bundledServicesPlugin(options: { mode: 'cli' } | { mode: 'server
           continue
 
         const rawJson = readFileSync(path.join(rootDir, 'openapi', key, `${version}.json`), 'utf8').trim()
-        const rewrittenJson = rewriteSpecPaths(rawJson, entry.servicePrefix)
+        const rewrittenJson = await prepareSpecJson(rawJson, entry.servicePrefix)
         const contextPath = entry.servicePrefix.replace(/^\/service\//, '')
 
         entryLines.push(


### PR DESCRIPTION
## Resolve internal `$ref` pointers in OpenAPI specs before use

Add `@apidevtools/json-schema-ref-parser` and dereference all same-document `$ref` pointers in OpenAPI specs at both **build time** (bundled specs) and **runtime** (live specs discovered from tenant microservices).

### Why

Without ref resolution, with **code mode**, schemas that are defined once and reused across many operations stay as opaque `{ "$ref": "#/components/schemas/Foo" }` pointers. The agent sees the pointer, not the shape — it cannot infer field names, types, required properties, or enum values from a ref string alone. This leads to:

- Guessed or hallucinated request bodies / query parameters
- Missed required fields that only exist in the referenced schema
- No awareness of discriminators, oneOf/anyOf branches, or nested structures

Fully dereferencing the specs means every operation's `requestBody`, `parameters`, and `responses` carry the complete inline schema instead of the refs allowing the agent to read the full structure directly from the spec constants without needing to resolve pointers itself, producing more accurate and complete API calls. 

In my first tests improved response quality for DTM OpenAPI significantly as the agent now has missing schema information. We might still need to improve and optimize the schema in the spec itself for further improvements. Current bundled DTM OpenAPI contains 326 references. 

### Details

- **`src/utils/resolve-refs.ts`** — thin wrapper around `$RefParser.dereference`   with `resolve.external = false` (no disk/network) and `dereference.circular = 'ignore'` (keeps the result JSON-serialisable, since  specs are later `JSON.stringify`'d into the sandbox entry script)
- **`src/utils/api-discovery.ts`** — each fetched live spec is dereferenced before path rewriting
- **`tsdown.config.ts`** — `prepareSpecJson` dereferences before path/server rewriting; all spec-generation and plugin `load` hooks made async accordingly
