### PR TITLE
feat: Add x-codemode extension for OpenAPI spec

### DIFF
--- a/openapi/dtm/release.json
+++ b/openapi/dtm/release.json
@@ -2706,7 +2706,16 @@
             "Basic": []
           }
         ],
-        "x-c8y-client-semantic": "create"
+        "x-c8y-client-semantic": "create",
+        "x-codemode": [
+          {
+            "instruction": "When creating an Asset Definition, you might want to link it to an existing Property Definition. Before creating the Asset Definition, ensure Property Definitions are in place by checking existing Definitions or creating new ones for the required properties (fragments). Once you have the necessary Property Definitions, reference them in the Asset Definition.",
+            "include": "/definitions/properties"
+          },
+          {
+            "instruction": "Create Asset Definitions for hierarchies in dependency order. When creating multiple Asset Definitions that reference each other in a parent-child hierarchy, ensure to create the child Asset Definitions before the parent ones. This way, when you can create the parent Asset Definition, all referenced child Asset Definitions will already exist, preventing any reference errors during creation."
+          }
+        ]
       }
     },
     "/definitions/alarms": {

--- a/src/prompts/codemode.ts
+++ b/src/prompts/codemode.ts
@@ -55,6 +55,15 @@ Use \`query\` to inspect OpenAPI specs (bundled core or discovered microservices
 The function must accept **no parameters**. The bindings below are scope-level constants, not function arguments.
 
 \`\`\`ts
+type XCodemodeItem = {
+  instruction: string      // always present — standalone guidance or LLM-only context
+  // include-mode: prerequisite spec embedded inline — follow before executing
+  includedPath?: string    // service-prefixed path to use in cumulocity.request()
+  includedSpec?: PathItem  // full operations & schemas for the prerequisite endpoint
+  // query-mode: advisory hint — query only if the user's request requires it
+  queryPath?: string       // service-prefixed path to query if the dependency applies
+}
+
 type OperationInfo = {
   summary?: string
   description?: string
@@ -62,6 +71,7 @@ type OperationInfo = {
   parameters?: Array<{ name: string, in: string, required?: boolean, schema?: unknown, description?: string }>
   requestBody?: { required?: boolean, content?: Record<string, { schema?: unknown }> }
   responses?: Record<string, { description?: string, content?: Record<string, { schema?: unknown }> }>
+  'x-codemode'?: XCodemodeItem[]
 }
 
 type PathItem = {
@@ -155,8 +165,12 @@ ${getOpenApiSection()}
 
 ## Working Pattern
 1. Use \`query\` to find the right endpoint, parameters, and response shape.
-2. Use \`execute\` with a small async function expression that calls that endpoint and returns only the needed result.
-3. Keep functions small and return only the data needed for the next reasoning step.
+2. Check the operation for \`x-codemode\` hints and act on every item in the array before executing:
+   - **Instruction only** (no path fields): follow the instruction — it describes idempotency behavior, required headers, or other LLM-only context not surfaced in standard API docs.
+   - **\`includedPath\` + \`includedSpec\` present**: mandatory prerequisite — fulfill the instruction completely before executing the target operation. The embedded spec contains everything needed (schemas, parameters) to complete the prerequisite step without an additional query.
+   - **\`queryPath\` present** (no \`includedSpec\`): optional dependency — query that path only if the user's actual request requires it. Skip if the dependency does not apply to the specific request.
+3. Use \`execute\` with a small async function expression that calls that endpoint and returns only the needed result.
+4. Keep functions small and return only the data needed for the next reasoning step.
 ${restrictionSection}
 `,
     )

--- a/src/tools/codemode.ts
+++ b/src/tools/codemode.ts
@@ -48,6 +48,15 @@ ${getOpenApiNote()}
 Available bindings (all zero-parameter — do NOT declare these as function parameters):
 
 \`\`\`ts
+type XCodemodeItem = {
+  instruction: string      // always present — standalone guidance or LLM-only context
+  // include-mode: prerequisite spec embedded inline — follow before executing
+  includedPath?: string    // service-prefixed path to use in cumulocity.request()
+  includedSpec?: PathItem  // full operations & schemas for the prerequisite endpoint
+  // query-mode: advisory hint — query only if the user's request requires it
+  queryPath?: string       // service-prefixed path to query if the dependency applies
+}
+
 type OperationInfo = {
   summary?: string
   description?: string
@@ -55,6 +64,7 @@ type OperationInfo = {
   parameters?: Array<{ name: string, in: string, required?: boolean, schema?: unknown, description?: string }>
   requestBody?: { required?: boolean, content?: Record<string, { schema?: unknown }> }
   responses?: Record<string, { description?: string, content?: Record<string, { schema?: unknown }> }>
+  'x-codemode'?: XCodemodeItem[]
 }
 
 type PathItem = {

--- a/src/utils/api-discovery.ts
+++ b/src/utils/api-discovery.ts
@@ -13,6 +13,7 @@
 import consola from 'consola'
 import type { Client, IApplication } from '@c8y/client'
 import { c8yErrorSummary } from './client'
+import { resolveCodeModeExtension } from './resolve-xcodemode'
 import type { PathItem, Spec } from './spec-resolution'
 
 // ---------------------------------------------------------------------------
@@ -251,12 +252,16 @@ export async function discoverApiSpecs(client: Client, tenantId: string): Promis
         const specRes = await client.core.fetch(`${servicePrefix}/${entry.path.replace(/^\//, '')}`)
         if (!specRes.ok)
           continue
+
+        const resolvedSpec = await specRes.json() as Spec
+        resolveCodeModeExtension(resolvedSpec, servicePrefix)
+
         specs.push({
           contextPath: app.contextPath,
           appLabel: app.name,
           specLabel: entry.label,
           servicePrefix,
-          spec: rewriteDiscoveredSpecPaths(await specRes.json() as Spec, servicePrefix),
+          spec: rewriteDiscoveredSpecPaths(resolvedSpec, servicePrefix),
         })
       } catch { /* skip individual spec failures */ }
     }

--- a/src/utils/resolve-xcodemode.ts
+++ b/src/utils/resolve-xcodemode.ts
@@ -1,0 +1,55 @@
+import type { PathItem, Spec } from './spec-resolution'
+
+interface XCodemodeItem {
+  instruction: string
+  include?: string
+  includedPath?: string
+  includedSpec?: PathItem
+  query?: string
+  queryPath?: string
+}
+
+const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete'] as const
+
+/**
+ * Resolve `include` and `query` references in `x-codemode` operation hints.
+ *
+ * For `include` items: looks up the referenced path in the spec (pre-rewrite
+ * paths, so `include` values match directly) and embeds the PathItem inline as
+ * `includedSpec`. Also computes `includedPath` = servicePrefix + include so the
+ * LLM can call `cumulocity.request()` with the correct post-rewrite path.
+ *
+ * For `query` items: only computes `queryPath` = servicePrefix + query. The
+ * spec is NOT embedded — the LLM decides whether to query based on context.
+ *
+ * Instruction-only items (no `include`/`query`) pass through unchanged.
+ *
+ * Must be called BEFORE path rewriting so that `include`/`query` values still
+ * match the keys in `spec.paths`.
+ *
+ * @param spec The OpenAPI spec to enrich in-place with resolved `x-codemode` includes/queries
+ * @param servicePrefix Optional prefix to prepend to included/query paths (e.g.
+ *   for bundled services, the context path like `/service/dtm`). Should be the
+ *   same prefix that will be applied in the path rewriting step later.
+ */
+export function resolveCodeModeExtension(spec: Spec, servicePrefix?: string): void {
+  for (const pathItem of Object.values(spec.paths)) {
+    for (const method of HTTP_METHODS) {
+      const op = (pathItem as Record<string, unknown>)[method] as Record<string, unknown> | undefined
+      const hints = op?.['x-codemode'] as XCodemodeItem[] | undefined
+      if (!Array.isArray(hints))
+        continue
+      for (const hint of hints) {
+        if (hint.include) {
+          const resolved = spec.paths[hint.include]
+          if (resolved)
+            hint.includedSpec = resolved
+          hint.includedPath = (servicePrefix ?? '') + hint.include
+        }
+        if (hint.query) {
+          hint.queryPath = (servicePrefix ?? '') + hint.query
+        }
+      }
+    }
+  }
+}

--- a/src/utils/spec-resolution.ts
+++ b/src/utils/spec-resolution.ts
@@ -2,6 +2,15 @@ import { BUNDLED_SERVICE_SPECS } from '#bundled-services'
 import { getCoreOpenApiSpec } from '#core-openapi'
 import type { DiscoveredApiSpec } from './api-discovery'
 
+interface XCodemodeItem {
+  instruction: string
+  include?: string
+  includedPath?: string
+  includedSpec?: PathItem
+  query?: string
+  queryPath?: string
+}
+
 interface OperationInfo {
   summary?: string
   description?: string
@@ -9,6 +18,7 @@ interface OperationInfo {
   parameters?: Array<{ name: string, in: string, required?: boolean, schema?: unknown, description?: string }>
   requestBody?: { required?: boolean, content?: Record<string, { schema?: unknown }> }
   responses?: Record<string, { description?: string, content?: Record<string, { schema?: unknown }> }>
+  'x-codemode'?: XCodemodeItem[]
 }
 
 export interface PathItem {

--- a/test/resolve-xcodemode.test.ts
+++ b/test/resolve-xcodemode.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest'
+import { resolveCodeModeExtension } from '../src/utils/resolve-xcodemode'
+import type { Spec } from '../src/utils/spec-resolution'
+
+const PROP_PATH_ITEM = {
+  get: { summary: 'List property definitions' },
+  post: { summary: 'Create property definition', requestBody: { required: true, content: {} } },
+}
+
+function makeSpec(overrides: Partial<Spec['paths']> = {}): Spec {
+  return {
+    paths: {
+      '/definitions/properties': PROP_PATH_ITEM,
+      '/definitions/assets': {
+        post: {
+          'summary': 'Create asset definition',
+          'x-codemode': [
+            {
+              instruction: 'Ensure property definitions exist before creating an asset definition.',
+              include: '/definitions/properties',
+            },
+          ],
+        },
+      },
+      ...overrides,
+    },
+  }
+}
+
+describe('resolveCodeModeExtension — include mode', () => {
+  it('embeds the referenced PathItem as includedSpec', () => {
+    const spec = makeSpec()
+    resolveCodeModeExtension(spec, '/service/dtm')
+    const hints = (spec.paths['/definitions/assets']?.post as Record<string, unknown>)?.['x-codemode'] as { includedSpec?: unknown }[]
+    expect(hints[0]?.includedSpec).toEqual(PROP_PATH_ITEM)
+  })
+
+  it('sets includedPath to servicePrefix + include', () => {
+    const spec = makeSpec()
+    resolveCodeModeExtension(spec, '/service/dtm')
+    const hints = (spec.paths['/definitions/assets']?.post as Record<string, unknown>)?.['x-codemode'] as { includedPath?: string }[]
+    expect(hints[0]?.includedPath).toBe('/service/dtm/definitions/properties')
+  })
+
+  it('works without a servicePrefix', () => {
+    const spec = makeSpec()
+    resolveCodeModeExtension(spec)
+    const hints = (spec.paths['/definitions/assets']?.post as Record<string, unknown>)?.['x-codemode'] as { includedPath?: string, includedSpec?: unknown }[]
+    expect(hints[0]?.includedPath).toBe('/definitions/properties')
+    expect(hints[0]?.includedSpec).toEqual(PROP_PATH_ITEM)
+  })
+
+  it('leaves includedSpec unset when include target path is absent', () => {
+    const spec: Spec = {
+      paths: {
+        '/definitions/assets': {
+          post: {
+            'x-codemode': [{ instruction: 'hint', include: '/does/not/exist' }],
+          },
+        },
+      },
+    }
+    resolveCodeModeExtension(spec, '/service/dtm')
+    const hints = (spec.paths['/definitions/assets']?.post as Record<string, unknown>)?.['x-codemode'] as { includedSpec?: unknown, includedPath?: string }[]
+    expect(hints[0]?.includedSpec).toBeUndefined()
+    expect(hints[0]?.includedPath).toBe('/service/dtm/does/not/exist')
+  })
+})
+
+describe('resolveCodeModeExtension — query mode', () => {
+  it('sets queryPath to servicePrefix + query', () => {
+    const spec: Spec = {
+      paths: {
+        '/definitions/properties': PROP_PATH_ITEM,
+        '/definitions/assets': {
+          post: {
+            'x-codemode': [
+              {
+                instruction: 'Check property definitions if needed.',
+                query: '/definitions/properties',
+              },
+            ],
+          },
+        },
+      },
+    }
+    resolveCodeModeExtension(spec, '/service/dtm')
+    const hints = (spec.paths['/definitions/assets']?.post as Record<string, unknown>)?.['x-codemode'] as { queryPath?: string, includedSpec?: unknown }[]
+    expect(hints[0]?.queryPath).toBe('/service/dtm/definitions/properties')
+    expect(hints[0]?.includedSpec).toBeUndefined()
+  })
+})
+
+describe('resolveCodeModeExtension — instruction-only', () => {
+  it('leaves instruction-only items unchanged', () => {
+    const spec: Spec = {
+      paths: {
+        '/things': {
+          post: {
+            'x-codemode': [{ instruction: 'Use X-Upsert-Mode for idempotency.' }],
+          },
+        },
+      },
+    }
+    resolveCodeModeExtension(spec, '/service/dtm')
+    const hints = (spec.paths['/things']?.post as Record<string, unknown>)?.['x-codemode'] as Record<string, unknown>[]
+    expect(hints[0]).toEqual({ instruction: 'Use X-Upsert-Mode for idempotency.' })
+  })
+})
+
+describe('resolveCodeModeExtension — multiple items', () => {
+  it('processes all items in the array independently', () => {
+    const spec: Spec = {
+      paths: {
+        '/definitions/properties': PROP_PATH_ITEM,
+        '/definitions/assets': {
+          post: {
+            'x-codemode': [
+              { instruction: 'Instruction only.' },
+              { instruction: 'Embed this.', include: '/definitions/properties' },
+              { instruction: 'Hint this.', query: '/definitions/properties' },
+            ],
+          },
+        },
+      },
+    }
+    resolveCodeModeExtension(spec, '/service/dtm')
+    const hints = (spec.paths['/definitions/assets']?.post as Record<string, unknown>)?.['x-codemode'] as Record<string, unknown>[]
+    expect(hints[0]).toEqual({ instruction: 'Instruction only.' })
+    expect(hints[1]?.includedSpec).toEqual(PROP_PATH_ITEM)
+    expect(hints[1]?.includedPath).toBe('/service/dtm/definitions/properties')
+    expect(hints[2]?.queryPath).toBe('/service/dtm/definitions/properties')
+    expect(hints[2]?.includedSpec).toBeUndefined()
+  })
+})
+
+describe('resolveCodeModeExtension — spec without x-codemode', () => {
+  it('is a no-op on operations without x-codemode', () => {
+    const spec: Spec = {
+      paths: {
+        '/items': {
+          get: { summary: 'List items' },
+          post: { summary: 'Create item' },
+        },
+      },
+    }
+    const before = JSON.stringify(spec)
+    resolveCodeModeExtension(spec, '/service/foo')
+    expect(JSON.stringify(spec)).toBe(before)
+  })
+})

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -2,6 +2,8 @@ import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'tsdown'
+import { resolveCodeModeExtension } from './src/utils/resolve-xcodemode.ts'
+import type { Spec } from './src/utils/spec-resolution.ts'
 
 const rootDir = path.dirname(fileURLToPath(import.meta.url))
 
@@ -57,6 +59,7 @@ function rewriteSpecPaths(specJson: string, servicePrefix: string): string {
     paths?: Record<string, unknown>
     servers?: Array<{ url: string, description?: string }>
   }
+  resolveCodeModeExtension(spec as unknown as Spec, servicePrefix)
   if (spec.paths) {
     const rewritten: Record<string, unknown> = {}
     for (const [p, item] of Object.entries(spec.paths)) {


### PR DESCRIPTION
## Summary

Introduces `x-codemode`, an OpenAPI extension to allow providing additional instructions or include additional operations into a code mode response. The DTM spec includeas a simple example for testing (e.g. PropertyDefinitions as prerequisite for AssetDefinition).

Each `x-codemode` item on an operation carries an `instruction` for the LLM and an optional path reference (`include` or `query`) that controls how much context is pre-loaded:

| Field | Behavior |
|-------|----------|
| `instruction` | Pure LLM-only context — idempotency hints, required headers, constraints not visible in standard tooling |
| `include` | Mandatory prerequisite — the referenced path's full spec is embedded inline at build/discovery time. The LLM gets everything it needs without an extra `query` call. |
| `query` | Advisory hint — only the service-prefixed path (`queryPath`) is computed. The LLM queries it if and only if the user's request actually requires the dependency. |

## Notes

This is meant as an extension to improve modelling of agent experience within the OpenAPI. It depends on the use case and spec itself of when to include information into the user doc or as a code-mode extension only for the agent. Needs some more thoughts and use case evaluation. Results have been much better with DTM example extension for creating Asset Definitions including Property Definitions.