### PR TITLE
feat: Add code mode instructions to use tags

### DIFF
--- a/src/prompts/codemode.ts
+++ b/src/prompts/codemode.ts
@@ -81,6 +81,31 @@ declare const coreSpec: Spec
 declare const serviceSpecs: ${serviceSpecsType}
 \`\`\`
 
+### Tag Documentation
+
+Both \`coreSpec\` and each \`serviceSpecs\` entry have a top-level \`tags\` array with domain documentation. 
+Each operation may reference one or more tags by name via its \`tags[]\` field. When you need deeper context 
+about an API area or resource, look up the matching tag entry by name and read its \`description\`.
+
+\`\`\`js
+// Get all tag names to find relevant documentation areas - use first when you know the domain but not the exact path
+() => serviceSpecs.dtm?.tags?.map(t => t.name)
+\`\`\`
+
+\`\`\`js
+// Find documentation for a known tag name
+() => serviceSpecs.dtm?.tags?.find(t => t.name === 'Assets')?.description
+\`\`\`
+
+\`\`\`js
+// Follow the tag reference from a specific operation
+() => {
+  const op = serviceSpecs.dtm?.paths['/service/dtm/assets/linkedSeries']?.get
+  const tagName = op?.tags?.[0]
+  return tagName ? serviceSpecs.dtm?.tags?.find(t => t.name === tagName)?.description : null
+}
+\`\`\`
+
 Examples (all zero-parameter — note no arguments in the arrow function signatures):
 \`\`\`js
 () => Object.keys(coreSpec.paths).filter((path) => path.includes('inventory'))

--- a/src/prompts/codemode.ts
+++ b/src/prompts/codemode.ts
@@ -49,6 +49,9 @@ Use \`query\` to inspect OpenAPI specs (bundled core or discovered microservices
 - Strings are returned as-is; other results are returned as JSON text
 - The \`query\` tool shows the raw bundled OpenAPI specs for the selected build
 - The current MCP connection may still block \`execute\` requests through deny rules and/or an allow list even when an operation exists in a visible spec
+- Prefer endpoint-native filters/expansions/selectors over manual traversal loops when they can express the same result
+- Inspect operation \`parameters\` first, then use referenced \`tags\` documentation to discover domain query-language features and constraints
+- Fall back to custom traversal/aggregation only when endpoint-native options cannot express the required output
 
 ### Available Shape
 
@@ -118,6 +121,18 @@ Examples (all zero-parameter — note no arguments in the arrow function signatu
 }
 \`\`\`
 
+\`\`\`js
+() => coreSpec.paths['/inventory/managedObjects']?.get
+\`\`\`
+
+\`\`\`js
+() => {
+  const op = coreSpec.paths['/inventory/managedObjects']?.get
+  const tagName = op?.tags?.[0]
+  return tagName ? coreSpec.tags?.find((t) => t.name === tagName)?.description : null
+}
+\`\`\`
+
 ## execute
 Use \`execute\` when you want to call the real Cumulocity API.
 
@@ -180,8 +195,10 @@ ${getOpenApiSection()}
 
 ## Working Pattern
 1. Use \`query\` to find the right endpoint, parameters, and response shape.
-2. Use \`execute\` with a small async function expression that calls that endpoint and returns only the needed result.
-3. Keep functions small and return only the data needed for the next reasoning step.
+2. Use operation tags and tag documentation to discover domain-specific query language/functions before implementing custom control flow.
+3. Prefer endpoint-native filters/expansions/selectors before manual traversal.
+4. Use \`execute\` with a small async function expression that calls that endpoint and returns only the needed result.
+5. Keep functions small and return only the data needed for the next reasoning step.
 ${restrictionSection}
 `,
     )

--- a/src/tools/codemode.ts
+++ b/src/tools/codemode.ts
@@ -77,6 +77,27 @@ declare const serviceSpecs: Record<string, Spec>
 - \`coreSpec\` — the main Cumulocity REST surface. Always present.
 - \`serviceSpecs\` — microservice APIs available on the active tenant, keyed by contextPath. An entry is **present iff** the service is reachable on this tenant. Paths are already prefixed (e.g. \`/service/myservice/items\`). Check with \`serviceSpecs.dtm\` (or \`'dtm' in serviceSpecs\`) before reaching in.
 
+Both \`coreSpec\` and each \`serviceSpecs\` entry have a top-level \`tags\` array with domain documentation. Each operation may reference one or more tags by name via its \`tags[]\` field. When you need deeper context about an API area or resource, look up the matching tag entry by name and read its \`description\`.
+
+\`\`\`js
+// Get all tag names to find relevant documentation areas — use first when you know the domain but not the exact path
+() => serviceSpecs.dtm?.tags?.map(t => t.name)
+\`\`\`
+
+\`\`\`js
+// Find documentation for a known tag name
+() => serviceSpecs.dtm?.tags?.find(t => t.name === 'Assets')?.description
+\`\`\`
+
+\`\`\`js
+// Follow the tag reference from a specific operation
+() => {
+  const op = serviceSpecs.dtm?.paths['/service/dtm/assets/linkedSeries']?.get
+  const tagName = op?.tags?.[0]
+  return tagName ? serviceSpecs.dtm?.tags?.find(t => t.name === tagName)?.description : null
+}
+\`\`\`
+
 ${getQueryResultDescription(env)}
 The current MCP connection may still block \`execute\` calls even when an operation is visible in a spec.
 

--- a/src/tools/codemode.ts
+++ b/src/tools/codemode.ts
@@ -9,7 +9,7 @@ function createCodeSchema(description: string) {
 }
 
 function getOpenApiNote(): string {
-  return 'This MCP exposes a bundled Cumulocity core OpenAPI snapshot. Use `coreSpec` for inventory, alarms, events, measurements, users, tenants, and the broader Cumulocity REST surface. Bundled and discovered microservice APIs available on the current tenant are exposed via `serviceSpecs` (keyed by contextPath).'
+  return 'This MCP exposes a bundled Cumulocity core OpenAPI snapshot. Use `coreSpec` for inventory, alarms, events, measurements, users, tenants, and the broader Cumulocity REST surface. Bundled and discovered microservice APIs available on the current tenant are exposed via `serviceSpecs` (keyed by contextPath). Prefer endpoint-native parameters (filters, expansions, paging, sorting) over manual multi-call traversal when they can express the request.'
 }
 
 function getQuerySafetyPreface(env: Env): string {
@@ -76,6 +76,9 @@ declare const serviceSpecs: Record<string, Spec>
 
 - \`coreSpec\` — the main Cumulocity REST surface. Always present.
 - \`serviceSpecs\` — microservice APIs available on the active tenant, keyed by contextPath. An entry is **present iff** the service is reachable on this tenant. Paths are already prefixed (e.g. \`/service/myservice/items\`). Check with \`serviceSpecs.dtm\` (or \`'dtm' in serviceSpecs\`) before reaching in.
+- Prefer checking operation \`parameters\` before designing multi-step logic. If filters, expansions, or selectors exist, use them first.
+- When an operation has \`tags\`, read the matching tag descriptions to discover domain-specific query language/functions and recommended usage patterns.
+- Fall back to custom traversal/aggregation only when endpoint-native options cannot express the needed result shape.
 
 Both \`coreSpec\` and each \`serviceSpecs\` entry have a top-level \`tags\` array with domain documentation. Each operation may reference one or more tags by name via its \`tags[]\` field. When you need deeper context about an API area or resource, look up the matching tag entry by name and read its \`description\`.
 
@@ -154,12 +157,25 @@ declare const cumulocity: {
 
 Your code must evaluate to an async function. Return the final value you want.
 
+Execution strategy:
+- First inspect endpoint parameters with \`query\` and choose the lowest-call approach.
+- Read relevant tag documentation to discover domain query language/features before writing custom control flow.
+- Prefer native API filters/expansions/selectors over manual traversal loops when both satisfy the request.
+- Use manual traversal only when endpoint-native options cannot express the needed result shape.
+
 On success the result is returned in Toon format. On a blocked or failed execution a plain text message is returned. A blocked message means the operation was denied by connection policy — retrying through the same connection will not help.
 
 Examples:
 \`\`\`js
 async () => {
   return await cumulocity.request({ method: 'GET', path: '/inventory/managedObjects?pageSize=5' })
+}
+
+async () => {
+  return await cumulocity.request({
+    method: 'GET',
+    path: '/alarm/alarms?pageSize=10&type=myAlarmType',
+  })
 }
 \`\`\`
 `,


### PR DESCRIPTION
Adds a **Tag Documentation** section to the `code-mode-guide` prompt explaining that top-level `spec.tags` / `serviceSpecs.<key>.tags` entries carry domain-level documentation linked to operations via their `tags[]` field. Includes example query-tool snippets covering exact-name lookup, keyword search, and following a tag reference from a specific operation path — so the LLM can surface detailed API context (e.g. DTM Linked Series behaviour) without guessing.

Tested with prompts like:
- Explain the concept of DTM Linked Series

Very good results with only a few tool calls.

Required `dropTags` to be false in OpenAPI preprocessing of #39.
