### PR TITLE
feat!: replace query/execute with a single codemode tool exposing typed API namespaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,11 +4,13 @@
 
 **mc8yp** is a Cumulocity IoT MCP server.
 
-The project exposes a small code-mode surface to AI agents instead of a large fixed toolset:
+The project exposes a single code-mode tool to AI agents instead of a large fixed toolset:
 
-- `query` inspects the bundled Cumulocity OpenAPI specs
-- `execute` calls the live Cumulocity API through a sandboxed request helper
-- `status` is available only in CLI mode: it lists the active tenant, stored credentials, and the specs currently visible to `query`. It accepts `{ refresh: true }` to force a fresh API discovery on demand (noop when no tenant is active). Server mode has no in-protocol equivalent yet — use the `POST /refresh-apis` HTTP route for ops-driven refresh; an in-protocol server-side flow will land in a separate PR.
+- `codemode` runs an async JavaScript function in a sandbox where API discovery, documentation search, and typed live API calls are all available as globals:
+  - `codemode.search(query)` / `codemode.describe(target?)` — ranked method search and on-demand TypeScript interface rendering over operations derived from the OpenAPI specs
+  - `docs.search(query, opts?)` / `docs.read(id)` — MiniSearch-backed fuzzy full-text search over spec prose (tag docs like query-language grammars, info blocks, operation/parameter descriptions)
+  - `c8y` (core, always present) plus one namespace per service available on the tenant (e.g. `dtm`) — one typed method per derived operation plus a `request({ method, path, params?, body?, headers? })` escape hatch with tenant-relative paths
+- `status` is available only in CLI mode: it lists the active tenant, stored credentials, and the API namespaces currently visible. It accepts `{ refresh: true }` to force a fresh API discovery on demand (noop when no tenant is active). Server mode has no in-protocol equivalent yet — use the `POST /refresh-apis` HTTP route for ops-driven refresh; an in-protocol server-side flow will land in a separate PR.
 
 The repository supports two runtime modes:
 
@@ -32,17 +34,22 @@ src/
         list.ts               List stored credentials
         remove.ts             Remove stored credentials
   codemode/
-    execute.ts                Sandboxed query/execute runtime generation
-    network-permissions.ts    Secure-exec network permission decisions for execute mode
-    semaphore.ts              Concurrency limiter for sandbox execution
+    execute.ts                Sandbox runtime: module assembly, host-side request dispatch, safeFetch wiring
+    derive-operations.ts      OpenAPI spec → derived typed operations (cached by spec identity)
+    namespaces.ts             Per-connection namespace assembly with policy filtering
+    describe.ts               codemode.describe rendering (overview / namespace listing / method types)
+    method-search.ts          MiniSearch-backed fuzzy method search (codemode.search), index cached per tenant
+    docs-index.ts             Host-side MiniSearch index over spec tag topics + overviews (docs.search / docs.read)
+    operation-naming.ts       Method naming policy: sanitized operationId, readable method+path synthesis fallback
+    type-render.ts            JSON Schema → TypeScript declaration rendering
   ctx/
     auth.ts                   Per-request auth context for server mode
   prompts/
     codemode.ts               `code-mode-guide` prompt
     index.ts                  Prompt registration
   tools/
-    codemode.ts               `query` and `execute` tool definitions
-    status.ts                 `status` tool (CLI only: active tenant + stored credentials + visible specs + on-demand refresh)
+    codemode.ts               `codemode` tool definition
+    status.ts                 `status` tool (CLI only: active tenant + stored credentials + visible namespaces + on-demand refresh)
     index.ts                  Tool registration
   types/
     mcp-context.ts            MCP custom context shape
@@ -57,11 +64,15 @@ src/
     schema.ts                 Shared schema helpers
     spec-resolution.ts        `resolveSpecs` plus the shared `Spec`/`PathItem`/`OperationInfo` types
 test/
-  excute.test.ts
+  excute.test.ts              Integration tests against the real sandbox (dispatch, policy, discovery, markers)
+  derive-operations.test.ts
+  describe.test.ts
+  docs-index.test.ts
+  method-search.test.ts
+  type-render.test.ts
   restriction-core.test.ts
   restrictions.test.ts
   restrictions.bench.ts
-  semaphore.test.ts
 openapi.json                 Self-describing OpenAPI for mc8yp's non-MCP HTTP surface; referenced from cumulocity.json so the deployed microservice is discoverable via the standard openApiSpec discovery flow
 openapi/
   core/
@@ -84,7 +95,7 @@ src/openapi-modules.d.ts      Ambient type declarations for the `#core-openapi` 
 #### CLI mode
 
 1. `src/cli/index.ts` parses CLI arguments and access-policy flags (`-r`, `--restrict`, `--restriction`, `-a`, `--allow`, and `--allowed`).
-2. It accepts `--spec` / `-s` to select the bundled core-versioned OpenAPI build exposed by `query`.
+2. It accepts `--spec` / `-s` to select the bundled core-versioned OpenAPI build the `c8y` namespace derives from.
 3. It sets `globalThis.executionEnvironment = 'cli'`.
 4. It exposes credential lookup helpers on `globalThis` for tools and subcommands.
 5. It starts the shared MCP server over stdio transport.
@@ -102,24 +113,27 @@ src/openapi-modules.d.ts      Ambient type declarations for the `#core-openapi` 
 
 - `src/server.ts` creates the MCP server, registers tools and prompts, and conditionally enables `status` and `set-active-tenant` only in CLI mode.
 - `openapi/core/` and `openapi/dtm/` contain the bundled OpenAPI snapshots consumed by the build.
-- `src/tools/codemode.ts` defines the `query` and `execute` tools.
+- `src/tools/codemode.ts` defines the `codemode` tool.
 - `src/prompts/codemode.ts` defines the `code-mode-guide` prompt.
 
 ## Codemode Behavior
 
 `src/codemode/execute.ts` is the main control surface for sandbox execution.
 
-- `query` executes JavaScript against the bundled OpenAPI specs with network access disabled.
-- `execute` executes JavaScript with a provided `cumulocity.request()` helper.
-- Both runtimes use [`@iso4/sandbox`](https://www.npmjs.com/package/@iso4/sandbox) — a V8-isolate sandbox running in a separate Rust subprocess — with a 128 MB memory limit and 50 second CPU time limit. A single lazy-initialised `Sandbox` is shared across all `query`/`execute` calls; iso4's connection pool serialises runs across isolate slots.
-- `execute` exposes the tenant API to sandbox code through a single bridged global: `cumulocity.request({ method, path, body, headers })`. The host-side handler (`createCumulocityRequestHandler` in `src/codemode/execute.ts`) injects auth headers, evaluates restriction/allow rules, performs the live request through [`@iso4/fetch`](https://www.npmjs.com/package/@iso4/fetch)'s `createSafeFetch` (which adds DNS-pinning and SSRF protection at the network layer), and returns plain parsed data. The sandbox never sees raw `fetch`.
+- The runtime uses [`@iso4/sandbox`](https://www.npmjs.com/package/@iso4/sandbox) (>= 0.2.x) — a V8-isolate sandbox running in a separate Rust subprocess — with a 128 MB memory limit, 50 s CPU / 120 s wall time, and 200 bridge calls per run. A single lazy-initialised `Sandbox` is shared across all `codemode` calls; iso4's connection pool serialises runs across isolate slots.
+- Execution is module-based, not string-preamble-based: a **static entry module** imports the `mc8yp:api` host module and the `mc8yp:agent` source module, wires the API exports onto `globalThis` (`codemode`, `docs`, one global per namespace), and calls the agent function. The agent's code is wrapped into its own ESM module (`mc8yp:agent`) — the only string interpolation left in the pipeline.
+- `mc8yp:api` is an iso4 **host module**: a plain object whose function leaves become bridge stubs inside a generated ESM module. Its shape is `{ codemode: { search, describe }, docs: { search, read }, namespaces: { c8y: { <method>..., request }, ... } }`, assembled per run by `buildApiModule`.
+- Every live call — derived namespace method or `.request` escape hatch — dispatches host-side through `performRequest`, which builds the URL and invokes the `createSafeFetch` handler directly. The safeFetch middleware injects auth headers (last write wins so the agent cannot override), evaluates restriction/allow rules, and parses/unwraps responses. The sandbox has **no fetch surface at all**.
+- Operation derivation (`deriveOperations`) is cached in a WeakMap by spec object identity and MUST stay policy-independent; per-connection policy filtering happens in `buildNamespaces` at namespace-assembly time. The docs index (`getDocsIndex`) is likewise cached by resolved-specs identity with policy applied at query time via an `isHidden` predicate.
+- Operations annotated `x-mc8yp-exclude: true` in a spec are skipped by derivation and the docs index (discoverability-only exclusion — the `.request` escape hatch is still governed solely by the connection access policy).
 - Input code is normalized before execution so fenced code blocks can still run.
+- In CLI mode with no active tenant, execution degrades instead of failing: discovery (search/describe/docs) works against the bundled reference specs while the live-call dispatchers throw the missing-auth error.
 
 ### Bundled OpenAPI Selection
 
 There are exactly two virtual modules:
 
-- **`#core-openapi`** — the always-available core spec. Exports `specs`, `getCoreOpenApiSpec()`, `getCoreOpenApiVersion()`, `setCoreOpenApiVersion()`, `getCoreOpenApiLabel()`. Core is the only spec with a named sandbox binding (`coreSpec`).
+- **`#core-openapi`** — the always-available core spec. Exports `specs`, `getCoreOpenApiSpec()`, `getCoreOpenApiVersion()`, `setCoreOpenApiVersion()`, `getCoreOpenApiLabel()`. Core is the only spec with a fixed namespace name (`c8y`, `CORE_NAMESPACE` in `src/codemode/namespaces.ts`).
 - **`#bundled-services`** — a generic registry of all bundled service-backed specs (DTM today). Exports `BUNDLED_SERVICE_SPECS: ReadonlyArray<BundledServiceSpec>` where each entry has `{ contextPath, appLabel, specLabel, servicePrefix, spec }`. The plugin loops every entry in `openapi-builds.json` `sources.*` that has a `servicePrefix` and inlines the resolved version for that build, with paths already rewritten via `rewriteSpecPaths`.
 
 Both modules return `Spec`-typed data (not `unknown`); the `Spec`/`PathItem`/`OperationInfo` types live in `src/utils/spec-resolution.ts` and are referenced from `src/openapi-modules.d.ts`.
@@ -135,14 +149,19 @@ Build-time behaviour:
   - The packaging script writes a temporary generated Dockerfile under `.c8y/`, builds from the repository root, copies the selected `.output/<version>/` bundle into `/app/server/`, and installs production dependencies inside the Linux image with pnpm before copying them into the runtime stage.
   - The packaging script builds Docker images for `linux/amd64` by default so release zips created on Apple Silicon remain deployable in typical Cumulocity environments; override with `DOCKER_PLATFORM` only when you intentionally need a different target.
 
-### Query vs Execute
+### The Sandbox Surface
 
-- `query` expects a JavaScript function expression and returns strings directly or other values as JSON text.
-- `query` injects two deterministic top-level bindings into the sandbox: `coreSpec` and `serviceSpecs`.
-- `coreSpec` is the main Cumulocity REST surface (always present). `serviceSpecs` is a `Record<string, Spec>` keyed by contextPath; bundled and discovered service specs like DTM land here as `serviceSpecs.dtm` only when actually available on the tenant.
-- An unavailable spec is **absent** from `serviceSpecs`, not `null`. Agent code should check `serviceSpecs.dtm` (or `'dtm' in serviceSpecs`) before reaching into an optional surface.
-- `execute` expects a JavaScript function expression and returns successful results in Toon format.
-- Visible operations remain raw OpenAPI data; blocked live requests fail before network access.
+- `codemode` expects an async JavaScript function expression and returns successful results in Toon format.
+- Discovery, documentation, and live calls compose inside one run: `codemode.search` → `codemode.describe` → `c8y.<method>({...})` without leaving the sandbox.
+- Namespace names: `c8y` for core (always present) plus `sanitizeToolName(contextPath)` per available service. An unavailable service simply has **no global** — agent code checks `typeof dtm !== 'undefined'` before reaching into an optional surface.
+- Method names come from `operationName` in `src/codemode/operation-naming.ts`: the sanitized `operationId` when present (all bundled specs have full coverage; Cumulocity's convention embeds the HTTP verb, e.g. `getAlarmCollectionResource` vs `postAlarmCollectionResource` on the same path), otherwise a readable camelCase synthesis from method+path where `{param}` segments become `By<Param>` (`GET /alarm/alarms/{id}` → `getAlarmAlarmsById`). Method input is a single flat object: path/query/header parameters as top-level keys, request payload under `body`. Output types render from the first 2xx JSON response schema.
+- Rendered property JSDoc carries the description plus one compact tag line: `@minimum`/`@maximum`, `@example`, and `@format` (e.g. `@format c8y:query`, the docs.search hook). Deliberately excluded: `@default`, `@minLength` (113× `minLength: 1` noise in core), and `@explode` — serialization is handled host-side, so the tag would only invite the agent to pre-encode values.
+- Query serialization honours per-parameter `explode`: arrays for `explode: false` params (nearly all Cumulocity multi-value params — the spec prose says "comma-separate the values") are comma-joined into one key by `toRequest`; the OpenAPI default stays repeated keys. The `.request` escape hatch has no parameter metadata and always uses repeated keys for arrays.
+- Reserved namespaces: `codemode`, `docs`, `c8y`, `cumulocity` (`RESERVED_NAMESPACES`); reserved method name per namespace: `request`. Colliding services/operations are skipped with a warning.
+- `codemode.describe("<ns>")` deliberately returns a one-line-per-method **listing**, not full types — core has ~250 operations and a full typed block would flood context. Full input/output types are method-level (`describe("<ns>.<method>")`).
+- Policy-blocked operations are omitted from namespaces, search results, describe output, and docs hits; blocked live requests additionally fail in the middleware before network access (two layers, both required — the second also covers `.request` and template-vs-concrete path gaps).
+- The set of operation keys walked during derivation/doc-indexing is `OPERATION_KEYS` in `derive-operations.ts`, derived from the shared `HTTP_METHODS` constant in `src/utils/restrictions.ts` (which includes the new `QUERY` method) — one source of truth for spec walking, restriction parsing, and `.request` method validation.
+- `docs.search` contains ONLY tag topics and spec info overviews — endpoints contribute nothing to the docs index. Per-endpoint prose (operation description, parameter docs) is delivered by `codemode.describe("<ns>.<method>")`, and finding endpoints is `codemode.search`'s job. The discovery chain for domain syntax is: param JSDoc says "details in Query language" → the agent turns that phrase into `docs.search("query language")` → the topic title match ranks first → `docs.read` returns the grammar (pinned by a real-spec test). No cross-reference/anchor tracing exists by design.
 
 ### Restrictions
 
@@ -152,13 +171,13 @@ Restrictions and allow rules both use the format `[METHOD:]<path-pattern>`.
 - Allow rules are allow-list entries. When any allow rule exists, requests must match at least one allow rule unless a restriction blocks them first.
 - Restrictions take priority over allow rules.
 - In microservice mode, prefer the project-scoped `mc8yp-restriction` and `mc8yp-allow` headers for HTTP policy transport; repeated headers and comma-separated values are both accepted.
-- Bundled services that are not installed on the tenant are simply absent from `serviceSpecs`. There is no pre-emptive auto-restriction layer — if an `execute` call ends up hitting an uninstalled service route, the Cumulocity API itself returns the failure and the sandbox propagates it. The connection-level restriction/allow policy is the only layer above that.
+- Bundled services that are not installed on the tenant simply get no namespace. There is no pre-emptive auto-restriction layer — if a live call ends up hitting an uninstalled service route via `.request`, the Cumulocity API itself returns the failure and the sandbox propagates it. The connection-level restriction/allow policy is the only layer above that.
 
 The restriction system is implemented in two places:
 
 - `src/utils/restrictions.ts` parses both deny rules and allow rules and handles CLI/query input.
 - `src/utils/restriction-matcher.ts` owns rule compilation, path matching, and restriction-vs-allow precedence.
-- Restriction and allow-rule enforcement live entirely on the host inside `createCumulocityRequestHandler`. There is no separate network-permission layer file — `evaluateAccessPolicy` from `src/utils/restriction-matcher.ts` is called directly before any HTTP request leaves the host.
+- Enforcement lives on the host in two spots: `buildNamespaces` (`src/codemode/namespaces.ts`) filters blocked operations out of discovery, and the safeFetch middleware in `src/codemode/execute.ts` calls `evaluateAccessPolicy` before any HTTP request leaves the host. Discovery filtering is a UX optimization; the middleware is the actual security boundary.
 
 ## Authentication And Credentials
 
@@ -168,7 +187,7 @@ The restriction system is implemented in two places:
 - `src/utils/credentials.ts` is the source of truth for storing, listing, resolving, and deleting tenant credentials.
 - Stored credentials are normalized by tenant URL.
 - User/password credentials may resolve and persist the tenant ID if it is not provided.
-- The active tenant is persisted to `~/.config/mc8yp/active-tenant.json` by the `set-active-tenant` MCP tool. `src/cli/active-tenant.ts` owns read/write. Any read error or bad JSON shape returns null silently. Tools that require a tenant (`query`, `execute`) throw a descriptive error when null.
+- The active tenant is persisted to `~/.config/mc8yp/active-tenant.json` by the `set-active-tenant` MCP tool. `src/cli/active-tenant.ts` owns read/write. Any read error or bad JSON shape returns null silently. With no tenant, `codemode` runs in discovery-only mode and live calls throw a descriptive missing-auth error.
 
 ### Microservice mode
 
@@ -224,8 +243,8 @@ pnpm prerelease    # lint + typecheck + build
 
 - If a change affects tool behavior, inspect both the tool definition and the codemode runtime.
 - If a change affects bundled OpenAPI selection, update the `#core-openapi` / `#bundled-services` plugins in `tsdown.config.ts`, the ambient declarations in `src/openapi-modules.d.ts`, and the source/build matrix in `openapi-builds.json`.
-- If you add a new bundled **service-backed** OpenAPI spec in the future: drop the JSON under `openapi/<key>/<version>.json` and add one entry under `sources.<key>` in `openapi-builds.json` with a `servicePrefix` (e.g. `"servicePrefix": "/service/<key>"`). `bundledServicesPlugin` picks it up automatically; `resolveSpecs`, `buildQueryScript`, and the auto-restriction logic all handle new entries generically. No code edits required.
-- If you add a new always-available (non-service-backed) bundled spec like core: that needs a new virtual module wired into `tsdown.config.ts`, `src/openapi-modules.d.ts`, and a new named binding in `buildQueryScript`. This is a much bigger change and the bundled-services flow is _not_ the right place for it.
+- If you add a new bundled **service-backed** OpenAPI spec in the future: drop the JSON under `openapi/<key>/<version>.json` and add one entry under `sources.<key>` in `openapi-builds.json` with a `servicePrefix` (e.g. `"servicePrefix": "/service/<key>"`). `bundledServicesPlugin` picks it up automatically; `resolveSpecs`, `buildNamespaces`, derivation, and the docs index all handle new entries generically. No code edits required.
+- If you add a new always-available (non-service-backed) bundled spec like core: that needs a new virtual module wired into `tsdown.config.ts`, `src/openapi-modules.d.ts`, and a new fixed namespace in `src/codemode/namespaces.ts`. This is a much bigger change and the bundled-services flow is _not_ the right place for it.
 - If a change affects restrictions or allow rules, verify both policy messaging and live request blocking.
 - If a change affects auth, verify the CLI and server paths separately.
 - If a change affects public MCP behavior, update `README.md` as well as this file.
@@ -238,8 +257,14 @@ pnpm prerelease    # lint + typecheck + build
 - Use `*.test.ts` for tests and `*.bench.ts` for benchmarks
 - Prefer adding targeted tests near the affected behavior:
   - restriction/allow parsing or matching changes: `test/restriction-core.test.ts` or `test/restrictions.test.ts`
-  - codemode runtime changes: `test/excute.test.ts`
-  - concurrency behavior: `test/semaphore.test.ts`
+  - codemode runtime changes (real-sandbox integration): `test/excute.test.ts`
+  - operation derivation: `test/derive-operations.test.ts`
+  - namespace assembly / describe rendering: `test/describe.test.ts`
+  - method search ranking: `test/method-search.test.ts`
+  - method naming policy: `test/operation-naming.test.ts`
+  - derivation/rendering against the real bundled specs: `test/real-spec.test.ts`
+  - docs indexing/search: `test/docs-index.test.ts`
+  - JSON Schema → TS rendering: `test/type-render.test.ts`
   - spec resolution logic: `test/spec-resolution.test.ts`
   - active tenant persistence: `test/active-tenant.test.ts`
 
@@ -263,7 +288,7 @@ When working on this project:
 1. Start from the actual controlling surface. For most feature work that is `src/tools/`, `src/prompts/`, `src/codemode/execute.ts`, or restriction/auth utilities.
 2. Treat CLI mode and microservice mode as separate execution environments with different auth and tool availability.
 3. Run focused tests first when changing a narrow subsystem, then run the full validation set if the change is broader. Use this exact validation order: `pnpm test:run`, then `pnpm lint:fix`, then `pnpm typecheck`.
-4. The `query` sandbox reads `ResolvedSpecs` (`{ core: Spec, specs: Record<string, Spec> }`) from `c8yMcpServer.ctx.custom?.specs`. In server mode it is computed per-request by the H3 handler via `resolveSpecs(discoveredSpecs, installedContextPaths)`. In CLI mode it is set on tenant activation by `setCliTenantContext` and falls back to `getBundledOnlySpecs()` (every bundled snapshot, no removal) before any tenant is active. Spec removal is unconditional inside `resolveSpecs`: when a tenant is active the agent only sees what is reachable on that tenant. The no-tenant CLI fallback is the only path that exposes all bundled snapshots, and `execute` errors loudly on missing auth in that state. In CLI mode only, the `query` tool appends a one-line footer to every result naming the active tenant (or noting there is none) and `execute` prepends an `Executed against tenant: <url>` marker, so the agent can verify which tenant the result reflects. Server mode omits both — the tenant is fixed by deployment/request auth there, so the marker would just be noise. Both hints read from `c8yMcpServer.ctx.custom.auth.tenantUrl` — no extra metadata is threaded. `buildQueryScript` is pure injection — no resolution logic belongs there.
+4. The codemode runtime reads `ResolvedSpecs` (`{ core: Spec, specs: Record<string, Spec> }`) from `c8yMcpServer.ctx.custom?.specs`. In server mode it is computed per-request by the H3 handler via `resolveSpecs(discoveredSpecs, installedContextPaths)`. In CLI mode it is set on tenant activation by `setCliTenantContext` and falls back to `getBundledOnlySpecs()` (every bundled snapshot, no removal) before any tenant is active. Spec removal is unconditional inside `resolveSpecs`: when a tenant is active the agent only sees what is reachable on that tenant. The no-tenant CLI fallback is the only path that exposes all bundled snapshots, and in that state `codemode` runs discovery-only — live calls throw the missing-auth error and the result marker says `No active tenant — discovery only`. In CLI mode only, every `codemode` result starts with a marker line (`Executed against tenant: <url>` or the no-tenant notice) so the agent can verify which tenant the result reflects. Server mode omits it — the tenant is fixed by deployment/request auth there, so the marker would just be noise. The marker reads from `c8yMcpServer.ctx.custom.auth.tenantUrl` — no extra metadata is threaded.
 5. Keep public MCP tool and prompt descriptions aligned with actual runtime behavior.
 6. Preserve the current sandbox limits and request boundary logic unless the task explicitly changes them.
 7. Record recurring project-specific lessons in the section below when they are likely to prevent future mistakes.
@@ -279,8 +304,9 @@ This section captures project-specific knowledge, tool quirks, and lessons learn
 
 ### Tools & Dependencies
 
-- `@iso4/sandbox` is the execution boundary for both `query` and `execute`. It spawns a long-lived Rust child process on first use; `disposeSandbox()` shuts it down (called from the `excute.test.ts` `afterAll` hook and via a `process.once('exit')` handler in `execute.ts`).
-- `@iso4/fetch` provides the hardened `safeFetch` used by the `cumulocity.request` host handler.
+- `@iso4/sandbox` (>= 0.2.x) is the execution boundary for `codemode`. It spawns a long-lived Rust child process on first use; `disposeSandbox()` shuts it down (called from the `excute.test.ts` `afterAll` hook and via a `process.once('exit')` handler in `execute.ts`). 0.2.x adds `imports` (source modules + host modules) — the runtime is built on those instead of string preambles, and its `ResourceLimits` include `wallTimeMs` (default 30 s — must be raised explicitly when `cpuTimeMs` exceeds it).
+- `@iso4/fetch` provides the hardened `safeFetch`. Its `handler` is invoked directly host-side by `performRequest` (it is no longer installed as a sandbox global); the middleware carries policy enforcement, auth injection, and response unwrapping.
+- `minisearch` powers the `docs.search` prose index; it is a devDependency inlined at build time.
 - `tsdown` produces separate server and CLI bundles.
 - `@napi-rs/keyring` is used for local(cli) credential storage.
 - `@clack/prompts` is used for interactive CLI credential entry so password input is masked.
@@ -288,11 +314,11 @@ This section captures project-specific knowledge, tool quirks, and lessons learn
 
 ### Patterns & Conventions
 
-- `execute` uses a generated ESM module entry and reads the default export from sandbox execution.
-- `query` and `execute` accept function-expression style code and normalize fenced code input before evaluation.
+- `codemode` runs a static entry module that imports the `mc8yp:api` host module and the agent's `mc8yp:agent` source module, and reads the default export from sandbox execution.
+- `codemode` accepts function-expression style code and normalizes fenced code input before evaluation.
 - `#core-openapi` and `#bundled-services` are virtual modules synthesized by tsdown plugins; consumers must not import the JSON snapshots directly.
 - The CLI build inlines all bundled core snapshots plus the default version of every service-backed source (currently DTM `release`); each server build inlines exactly the configured combination for that build.
-- Bundled service specs land in the query sandbox as `serviceSpecs[contextPath]`, alongside any non-bundled services discovered live on the tenant. Core is the only named binding (`coreSpec`).
+- Service specs land in the sandbox as one typed namespace per contextPath (bundled and live-discovered alike). Core is the only fixed namespace name (`c8y`).
 - `resolveSpecs` returns a single `{ core, specs }` object. An absent key in `specs` means the spec is unavailable for this tenant; there are no `null` values.
 - API discovery lists applications via paginated `GET /application/applications?tenant=<id>&type=MICROSERVICE` (100 per page), NOT `applicationsByTenant`. The unpaginated `applicationsByTenant?pageSize=2000` response included every HOSTED web-app manifest and got cut off by the internal gateway mid-body ("Premature close") on app-heavy tenants, permanently breaking discovery for that tenant. HOSTED/EXTERNAL apps can never contribute specs (spec download goes through `/service/<contextPath>/`, microservices only), so `installedContextPaths` intentionally contains only microservice context paths.
 - `@iso4/fetch` is pure JS (`rou3` + `undici`) and is bundled into both CLI and server outputs. Only `@iso4/sandbox` must stay external in all builds.
@@ -302,13 +328,19 @@ This section captures project-specific knowledge, tool quirks, and lessons learn
 - If the user asks to open a PR from an already-active feature branch, treat that existing branch as the PR head by default and target `main` unless they say otherwise.
 - Server-mode auth must stay request-local.
 - For deployed microservice mode, prefer POST-only streamable HTTP over long-lived GET/SSE. The optional SSE channel can go inactive behind Cumulocity ingress and break later tool calls even when initialization and tool discovery succeeded.
-- The `status` tool is the in-protocol on-demand refresh path for CLI mode. It busts the per-tenant discovery cache via `refreshApiSpecs`, re-resolves specs, and patches both `getCliTenantContext().specs` and `c8yMcpServer.ctx.custom.specs` so the very next `query`/`execute` sees the new surface. There is no rate-limit — a local human-driven session has no runaway-agent risk and a forced refresh after a deploy should always work.
+- The `status` tool is the in-protocol on-demand refresh path for CLI mode. It busts the per-tenant discovery cache via `refreshApiSpecs`, re-resolves specs, and patches both `getCliTenantContext().specs` and `c8yMcpServer.ctx.custom.specs` so the very next `codemode` call sees the new surface. There is no rate-limit — a local human-driven session has no runaway-agent risk and a forced refresh after a deploy should always work.
 - Server mode has no in-protocol `status` tool yet; only the `POST /refresh-apis` HTTP route exists for ops/CI use. An in-protocol server-side equivalent (with rate-limiting) is planned for a separate PR and will need to re-introduce a tenant-ID stash on `c8yMcpServer.ctx.custom` and a global cooldown timestamp in `src/utils/api-discovery.ts`.
-- mc8yp ships its own `openapi.json` (repo root) describing the non-MCP HTTP surface (`/refresh-apis`, `/health`). It is referenced from `cumulocity.json#openApiSpec` and served by the H3 server at `GET /openapi.json` via a `with { type: 'json' }` import in `src/index.ts` so it inlines into every server bundle. When mc8yp is subscribed on a tenant, the standard discovery loop in `src/utils/api-discovery.ts` picks it up and exposes it to agents as `serviceSpecs['mc8yp-server']`. The MCP endpoint at `/mcp` is intentionally NOT documented in this spec — MCP discovery is out-of-band via `tools/list`. Keep `openapi.json` in sync with any change to the HTTP surface, and never list `/mcp` there.
+- mc8yp ships its own `openapi.json` (repo root) describing the non-MCP HTTP surface (`/refresh-apis`, `/health`). It is referenced from `cumulocity.json#openApiSpec` and served by the H3 server at `GET /openapi.json` via a `with { type: 'json' }` import in `src/index.ts` so it inlines into every server bundle. When mc8yp is subscribed on a tenant, the standard discovery loop in `src/utils/api-discovery.ts` picks it up and exposes it to agents as the `mc8yp_server` namespace (contextPath `mc8yp-server`, sanitized). The MCP endpoint at `/mcp` is intentionally NOT documented in this spec — MCP discovery is out-of-band via `tools/list`. Keep `openapi.json` in sync with any change to the HTTP surface, and never list `/mcp` there.
 - CLI mode is a single stdio process; there is no IPC channel from a second terminal into the running CLI. Out-of-process triggers (e.g. "refresh from a shell after deploying") are intentionally not supported. Refresh has to flow through the in-protocol `status` tool.
+
+- The namespace/discovery layer: host-side derivation of one typed method per OpenAPI operation, `search`/`describe` as the discovery SDK, a `request` escape hatch per namespace. Design choices to know: namespace-level describe is deliberately rejected (core is too big for full type dumps), output types are derived from response schemas, and prose docs get their own MiniSearch-backed `docs` global because name-oriented method search scores long prose poorly.
+- Caches in the codemode layer (`deriveOperations` WeakMap, `getDocsIndex` WeakMap) are keyed by spec/resolved-specs object identity and MUST stay policy-independent — restrictions differ per connection in server mode. Apply policy at assembly/query time (`buildNamespaces` filter, `isHidden` predicate), never inside the cached artifact.
+- `codemode.search` is MiniSearch-backed (same engine as docs), replacing the hand-tuned CF token scorer: fuzzy matching absorbs singular/plural drift and OR-combination keeps recall when a query word has no counterpart in the spec vocabulary ("list assets" still ranks `getAssets`). It accepts `string | string[]` — the calling agent is the semantic layer and passes phrasing variants in one call. The index is policy-independent and cached per tenant (same WeakMap pattern as docs/derivation); the connection's policy filters hits at query time via a visible-targets predicate. Search RESULTS are deliberately never cached: they are policy-dependent, the query keyspace is unbounded, and a query over ~300 entries costs well under a millisecond. Host main-thread impact is negligible (agent code runs in the separate Rust sandbox process); if a tenant ever surfaces thousands of operations, moving index+query into a worker_thread is a clean follow-up.
+- The whole cache chain hangs on object identity: per-tenant discovery cache (30-min TTL in `api-discovery.ts`) → memoized `resolveSpecs` (WeakMap on the (discoveredSpecs, installedContextPaths) pair, so the server's per-request call returns the same `ResolvedSpecs` for a tenant until refresh) → `deriveOperations`/`getDocsIndex` keyed on those stable objects. A discovery refresh mints new objects, everything downstream repopulates lazily, and old entries are GC'd. Do NOT "clean up" the `resolveSpecs` memoization — removing it silently turns the docs index into a per-request rebuild.
 
 ### Common Mistakes To Avoid
 
+- Do not assume the runtime specs are dereferenced — `preprocessOpenApi` runs with `dereference: false` at both call sites (tsdown plugin and live discovery). Parameter entries, requestBody, and response objects may still be structural `$ref`s into `components`, Cumulocity content is keyed by vendor media types (`application/vnd.com.nsn.cumulocity.*+json`, so match any `json`-bearing media type, never just `application/json`), and `{id}` path parameters are declared at the **path-item** level, not on the operation. `derive-operations.ts` handles all three (`derefObject`, `jsonContentSchema`, path-item parameter merge); any new spec-reading code must too. `test/real-spec.test.ts` exists precisely because synthetic fixtures cannot catch this class of bug.
 - Do not assume tests live in `tests/`; this repository uses `test/`.
 - Do not add tenant URL handling to server mode user flows; deployed mode derives tenant context from the environment and request auth.
 - Do not bypass `src/codemode/execute.ts` when changing execution behavior; that file is the main runtime boundary.

--- a/README.md
+++ b/README.md
@@ -4,25 +4,26 @@
 ![License](https://img.shields.io/npm/l/mc8yp)
 ![Node Version](https://img.shields.io/node/v/mc8yp)
 
-mc8yp is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that gives AI agents access to the **full Cumulocity API surface** through just two code-mode tools instead of a huge fixed tool inventory:
+mc8yp is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that gives AI agents access to the **full Cumulocity API surface** through a single code-mode tool instead of a huge fixed tool inventory:
 
-- **`query`** — inspect the OpenAPI specs available on the current tenant
-- **`execute`** — call the live Cumulocity API
+- **`codemode`** — run an async JavaScript function in a sandbox where API discovery, documentation search, and typed live API calls are all available as globals
 
-The agent sees not only the bundled **Core** and **DTM** specs, but **any microservice installed on the tenant** that declares an OpenAPI spec in its manifest — mc8yp discovers those live and exposes them alongside the bundled ones. No code changes or rebuild required to support a new service.
+Inside the sandbox the agent sees one **typed namespace per API**: `c8y` for the Cumulocity core REST surface plus one namespace per microservice available on the tenant (e.g. `dtm`), each with one method per operation derived from the OpenAPI specs — `c8y.getAlarmCollectionResource({ pageSize: 10 })` instead of hand-built REST calls. Discovery happens in-sandbox through `codemode.search`/`codemode.describe` (ranked method search + on-demand TypeScript interfaces) and `docs.search`/`docs.read` (fuzzy full-text search over the specs' prose documentation, e.g. query-language grammars).
+
+The agent sees not only the bundled **Core** and **DTM** specs, but **any microservice installed on the tenant** that declares an OpenAPI spec in its manifest — mc8yp discovers those live and derives namespaces for them alongside the bundled ones. No code changes or rebuild required to support a new service.
 
 Operators stay in control through per-connection **restrictions** and **allow rules**, so the same broad capability can be deployed as a read-only agent, a non-destructive production agent, or anything in between.
 
 ## How it works
 
-1. mc8yp discovers every microservice installed on the tenant that declares an OpenAPI spec, and exposes those alongside the bundled Core (+ DTM) specs.
-2. The agent uses `query` to inspect the available specs and pick an endpoint.
-3. The agent uses `execute` to call the live Cumulocity API.
-4. mc8yp enforces configured restrictions and allow rules before the request leaves the host.
+1. mc8yp discovers every microservice installed on the tenant that declares an OpenAPI spec, and derives typed method namespaces from those alongside the bundled Core (+ DTM) specs.
+2. Inside a `codemode` run, the agent finds the right method with `codemode.search`, inspects its exact input/output types with `codemode.describe`, and reads prose documentation (domain query languages, parameter syntax) with `docs.search`/`docs.read`.
+3. In the same run, the agent calls the live Cumulocity API through the derived methods (`c8y.<method>({ ... })`) or the low-level `<namespace>.request()` escape hatch.
+4. mc8yp enforces configured restrictions and allow rules before any request leaves the host — blocked operations are also omitted from discovery entirely.
 
 ### Live microservice API discovery
 
-When a tenant is active, mc8yp asks Cumulocity which applications the tenant is subscribed to, reads the `openApiSpec` declaration from each application manifest, fetches the spec, prefixes its paths with the service's `contextPath`, and exposes it to the sandbox as `serviceSpecs[contextPath]`. Results are cached per tenant for 30 minutes.
+When a tenant is active, mc8yp asks Cumulocity which applications the tenant is subscribed to, reads the `openApiSpec` declaration from each application manifest, fetches the spec, prefixes its paths with the service's `contextPath`, and exposes it to the sandbox as a typed namespace named after the contextPath. Results are cached per tenant for 30 minutes.
 
 The practical effect: **any Cumulocity microservice that ships an OpenAPI spec is automatically usable by the agent**, whether it is one of the bundled snapshots, a Cumulocity-provided service, or a custom microservice built in-house. The bundled specs are just guaranteed offline coverage; the discovery layer fills in everything else.
 
@@ -87,7 +88,7 @@ The sandboxed V8 runtime ([`@iso4/sandbox`](https://www.npmjs.com/package/@iso4/
 # Run directly (recommended)
 pnpm dlx mc8yp
 
-# Pick a specific bundled core OpenAPI build for `query`
+# Pick a specific bundled core OpenAPI build for the codemode tool
 pnpm dlx mc8yp --spec 2025
 
 # Or install globally
@@ -185,13 +186,13 @@ After this, `mc8yp creds add` will work.
 
 ### Activate a tenant
 
-Adding credentials does **not** auto-activate a tenant. `execute` only runs against a live tenant once one has been selected, and the agent does that itself through MCP tools:
+Adding credentials does **not** auto-activate a tenant. Live API calls only run against a tenant once one has been selected, and the agent does that itself through MCP tools:
 
-1. The agent calls `status` to see stored credentials, the current active tenant, and the specs currently visible to `query`.
+1. The agent calls `status` to see stored credentials, the current active tenant, and the API namespaces currently visible.
 2. The agent calls `set-active-tenant` with one of the tenant URLs. The selection is written to `~/.config/mc8yp/active-tenant.json` and reused across CLI restarts.
-3. The agent runs `query` and `execute` as needed. Each result includes a footer or marker line showing which tenant it ran against.
+3. The agent runs `codemode` as needed. Each result starts with a marker line showing which tenant it ran against.
 
-To switch tenants, call `set-active-tenant` again. To stop targeting any tenant (browse bundled specs only), call it with `tenantUrl: null` — `query` keeps working, `execute` returns a missing-auth error so the agent cannot accidentally hit a tenant.
+To switch tenants, call `set-active-tenant` again. To stop targeting any tenant (browse bundled specs only), call it with `tenantUrl: null` — discovery (`codemode.search`/`describe`, `docs`) keeps working against the bundled reference snapshots, while live API calls return a missing-auth error so the agent cannot accidentally hit a tenant.
 
 If the active tenant's credentials are removed via `mc8yp creds remove`, the next `status` call clears the active tenant automatically.
 
@@ -235,42 +236,53 @@ With read-only access rules:
 
 ## Tools and prompts
 
-| Tool                | Description                                                                                                                                                                                                                                                                                                                                               |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `query`             | Inspect the bundled and discovered OpenAPI specs by running a JavaScript function expression in a sandbox. Exposes `coreSpec` and `serviceSpecs` (keyed by `contextPath`). Returns JSON text.                                                                                                                                                             |
-| `execute`           | Run an async JavaScript function expression that calls the live Cumulocity API via `cumulocity.request({ method, path, body?, headers? })`. Returns the function result in [Toon format](https://github.com/nicepkg/toon).                                                                                                                                |
-| `status`            | _(CLI only)_ Show the active tenant, stored credentials, and the specs currently visible to `query`. Auto-clears the active tenant if its credentials are gone. Pass `refresh: true` to bust the 30-minute discovery cache and re-run discovery for the active tenant — useful right after (un)subscribing a microservice. Noop when no tenant is active. |
-| `set-active-tenant` | _(CLI only)_ Select the tenant `query` and `execute` operate against. Pass `tenantUrl: null` to clear.                                                                                                                                                                                                                                                    |
+| Tool                | Description                                                                                                                                                                                                                                                                                                                                             |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `codemode`          | Run an async JavaScript function in a sandbox with discovery (`codemode.search`/`describe`), documentation (`docs.search`/`read`), and typed API namespaces (`c8y`, per-service globals) available. Returns the function result in [Toon format](https://github.com/nicepkg/toon).                                                                      |
+| `status`            | _(CLI only)_ Show the active tenant, stored credentials, and the API namespaces currently visible. Auto-clears the active tenant if its credentials are gone. Pass `refresh: true` to bust the 30-minute discovery cache and re-run discovery for the active tenant — useful right after (un)subscribing a microservice. Noop when no tenant is active. |
+| `set-active-tenant` | _(CLI only)_ Select the tenant `codemode` operates against. Pass `tenantUrl: null` to clear.                                                                                                                                                                                                                                                            |
 
-Both code-mode tools run in a sandboxed V8 runtime ([`@iso4/sandbox`](https://github.com/schplitt/iso4)) hosted in a separate Rust subprocess. The sandbox has no `fetch` global — the only path to the tenant is the host-bridged `cumulocity.request` helper, which is DNS-pinned and SSRF-hardened via [`@iso4/fetch`](https://www.npmjs.com/package/@iso4/fetch).
+The codemode tool runs in a sandboxed V8 runtime ([`@iso4/sandbox`](https://github.com/schplitt/iso4)) hosted in a separate Rust subprocess. The sandbox has no `fetch` global — every live call is dispatched host-side through a hardened request funnel built on [`@iso4/fetch`](https://www.npmjs.com/package/@iso4/fetch), which injects auth, enforces the access policy, and parses responses before anything reaches the sandbox.
 
-The **`code-mode-guide`** prompt contains the full reference for `query` and `execute`, including types, examples, and the active access policy for the current connection.
+The **`code-mode-guide`** prompt contains the full reference for the codemode tool, including types, examples, and the active access policy for the current connection.
 
-### `execute` input shape
-
-`execute` expects an async function expression:
+### The sandbox surface
 
 ```js
 async () => {
-  return await cumulocity.request({
-    method: 'GET',
-    path: '/inventory/managedObjects?pageSize=5',
-  })
-}
-```
+  // 1. Find the method
+  const { results } = await codemode.search('managed objects')
 
-You can do intermediate work before returning:
+  // 2. Inspect its exact typed interface (input/output types, per-field docs)
+  const { content } = await codemode.describe(results[0].target)
 
-```js
-async () => {
-  const devices = await cumulocity.request({
-    method: 'GET',
-    path: '/inventory/managedObjects?pageSize=20&withTotalPages=true',
+  // 3. When parameter syntax is unknown, search the prose documentation
+  const hits = await docs.search('inventory query language')
+  const grammar = await docs.read(hits[0].id)
+
+  // 4. Call it — path/query/header params and `body` share one flat object
+  const devices = await c8y.getManagedObjectCollectionResource({
+    query: '$filter=(type eq \'c8y_Device\')',
+    pageSize: 20,
   })
 
   return devices.managedObjects?.map((d) => ({ id: d.id, name: d.name }))
 }
 ```
+
+Every namespace also carries a low-level escape hatch for anything not covered by a derived method:
+
+```js
+async () => {
+  return await c8y.request({
+    method: 'GET',
+    path: '/inventory/managedObjects',
+    params: { pageSize: 5 },
+  })
+}
+```
+
+Operations can be hidden from derivation and discovery by annotating them in the OpenAPI spec with the vendor extension `x-mc8yp-exclude: true` (the `.request` escape hatch is still governed by the connection access policy).
 
 ---
 
@@ -291,7 +303,7 @@ If both apply to the same operation, **restrictions win**. This is how you expos
 ```
 
 - No method prefix → matches all HTTP methods.
-- With a method prefix → only that method. Supported: `DELETE`, `GET`, `HEAD`, `OPTIONS`, `PATCH`, `POST`, `PUT`, `TRACE`, or `*`. Case-insensitive.
+- With a method prefix → only that method. Supported: `DELETE`, `GET`, `HEAD`, `OPTIONS`, `PATCH`, `POST`, `PUT`, `QUERY`, `TRACE`, or `*`. Case-insensitive.
 - Patterns must start with `/`. Query strings and fragments are not allowed in patterns.
 - Wildcards: `*` matches within a single path segment; `**` matches zero or more whole segments and must be its own segment.
 
@@ -365,22 +377,22 @@ mc8yp-restriction: /inventory/**
 mc8yp-allow: GET:/measurement/**
 ```
 
-When `execute` is blocked by connection policy, the tool returns explanatory text, no request is sent to Cumulocity, and retrying through the same connection will not help.
+When a live call is blocked by connection policy, the codemode run returns explanatory text, no request is sent to Cumulocity, and retrying through the same connection will not help. Blocked operations are additionally omitted from `codemode.search`/`describe` and the docs index, so the agent never plans around a method it cannot call.
 
 ---
 
 ## OpenAPI coverage
 
-What the agent sees through `query` comes from two layers:
+What the agent sees through codemode discovery comes from two layers:
 
-1. **Live-discovered specs** — every microservice subscribed on the active tenant whose manifest declares an `openApiSpec`. Discovered at runtime, cached for 30 minutes per tenant, exposed as `serviceSpecs[contextPath]`. This works for any service, not just the ones bundled here.
+1. **Live-discovered specs** — every microservice subscribed on the active tenant whose manifest declares an `openApiSpec`. Discovered at runtime, cached for 30 minutes per tenant, exposed as a typed namespace named after the contextPath. This works for any service, not just the ones bundled here.
 2. **Bundled snapshots** — shipped with the build so Core and DTM are always available even when discovery hasn't run yet:
    - **Core** snapshots: `release`, `2026`, `2025`, `2024`
    - **DTM** snapshot bundled alongside each supported core build
 
-With an active tenant, services not installed on that tenant are dropped from the sandbox so the agent only sees what is actually reachable.
+With an active tenant, services not installed on that tenant get no namespace at all, so the agent only sees what is actually reachable.
 
-In CLI mode, pick which **core** snapshot `query` exposes:
+In CLI mode, pick which **core** snapshot the `c8y` namespace derives from:
 
 ```sh
 mc8yp              # default: latest bundled release
@@ -388,7 +400,7 @@ mc8yp --spec 2025  # use the 2025 snapshot
 mc8yp -s 2024      # short form
 ```
 
-This only affects the bundled core view. `execute` always hits the live Cumulocity API of the selected tenant or deployed service environment.
+This only affects the bundled core view. Live calls always hit the Cumulocity API of the selected tenant or deployed service environment.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "consola": "catalog:",
     "eslint": "catalog:",
     "h3": "catalog:",
+    "minisearch": "catalog:",
     "tmcp": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,8 @@ catalogs:
       specifier: ^0.0.1
       version: 0.0.1
     '@iso4/sandbox':
-      specifier: ^0.0.3
-      version: 0.0.3
+      specifier: ^0.2.2
+      version: 0.2.2
     '@napi-rs/keyring':
       specifier: ^1.3.0
       version: 1.3.0
@@ -60,6 +60,9 @@ catalogs:
     h3:
       specifier: 2.0.1-rc.22
       version: 2.0.1-rc.22
+    minisearch:
+      specifier: ^7.2.0
+      version: 7.2.0
     tmcp:
       specifier: ^1.19.4
       version: 1.19.4
@@ -88,7 +91,7 @@ importers:
     dependencies:
       '@iso4/sandbox':
         specifier: 'catalog:'
-        version: 0.0.3
+        version: 0.2.2
       '@napi-rs/keyring':
         specifier: 'catalog:'
         version: 1.3.0
@@ -141,6 +144,9 @@ importers:
       h3:
         specifier: 'catalog:'
         version: 2.0.1-rc.22
+      minisearch:
+        specifier: 'catalog:'
+        version: 7.2.0
       tmcp:
         specifier: 'catalog:'
         version: 1.19.4(typescript@6.0.3)
@@ -576,33 +582,33 @@ packages:
     resolution: {integrity: sha512-9moEW0miSoMzyX4OEEFtAZGsLKGSCFqDh+VZap5/qhvCD1OPV/jzPrQ1Bu2RdzHttjqhQ9kAnZQN9/9+yejfKQ==}
     engines: {node: '>=24.0.0'}
 
-  '@iso4/sandbox@0.0.3':
-    resolution: {integrity: sha512-bQyLNQbmJGf4RiHAEojCkQjUeXZxEpOb43DWcv7Zai7WR4c6hBe5Btniz5nNXTQvsKrhZqODDM1Y1No1kyqUEw==}
+  '@iso4/sandbox@0.2.2':
+    resolution: {integrity: sha512-2nYzX2JhYXY+UVWbkUxYXF/bdD60/GZOMphYtB5XJxHv6cmJdDadZU46aw+WGZiPpJh8LILKRQ4bTgQV2wIw9w==}
     engines: {node: '>=24.0.0'}
 
-  '@iso4/v8-darwin-arm64@0.0.3':
-    resolution: {integrity: sha512-9iZtvgA3d1q5zHFgCQiab8X5UxPRUvdvUJZajXfYaeMXdR96vMShSV50pRUOyLZzJYjAA0QVIgqqpK4Fj9ERXg==}
+  '@iso4/v8-darwin-arm64@0.2.2':
+    resolution: {integrity: sha512-+5uLCagCZoJ00b62Ci5tyv3P+QzKqgAcx5660+K3G9068IPV6yIwKSSt7gfRYalYgzKgmj9q2xNwhNvGgBb/LA==}
     engines: {node: '>=24.0.0'}
     cpu: [arm64]
     os: [darwin]
     hasBin: true
 
-  '@iso4/v8-darwin-x64@0.0.3':
-    resolution: {integrity: sha512-56QuxWBWG8WzKdROWRdhxIc2L3Fhlbb2UYg99vW7ZoRQKFPRLQHBk6FFmaSXdTqhjb1TB4RctaUHHA848SqNKg==}
+  '@iso4/v8-darwin-x64@0.2.2':
+    resolution: {integrity: sha512-UJIAH64m7gwtPeMksEcqwqJ1oHMGk/MbWKujeOR9ryoc0OW+Ym0lnrQgYW3ZzYCnV2vRnTBT08M7RFVUfCLS6Q==}
     engines: {node: '>=24.0.0'}
     cpu: [x64]
     os: [darwin]
     hasBin: true
 
-  '@iso4/v8-linux-arm64-gnu@0.0.3':
-    resolution: {integrity: sha512-4BJdoUbUdMCN2JFOuHIiIvv/whEIYaH94PGU2jlBzpzI5VzBSq8bGGnkG1oVkNTiEOkLRzSy7sY678/Sxn2azw==}
+  '@iso4/v8-linux-arm64-gnu@0.2.2':
+    resolution: {integrity: sha512-NA6OUqJRZY+ycC3YVZubDqB2BCJyy4AXwkcBObu299/OywMjHTR6ey7w9zdE4wPDmmxl7JIDZFpjgQg7PcOM0A==}
     engines: {node: '>=24.0.0'}
     cpu: [arm64]
     os: [linux]
     hasBin: true
 
-  '@iso4/v8-linux-x64-gnu@0.0.3':
-    resolution: {integrity: sha512-7k13ZO3pizvjDrvyfFQCSzr0MtIaZWJPmpoTkPVhZZf4U19rxWOKKk8emzurmmaBXxNpGJspo53wAKJ8yLJ56A==}
+  '@iso4/v8-linux-x64-gnu@0.2.2':
+    resolution: {integrity: sha512-I59ODWRUlFUjRl6hcu+x3gfR03QLxbBJSVEs/Erx5inj7XazgstC0tMmTIS+DIYw85WX05d4HxSj4f09z98AIA==}
     engines: {node: '>=24.0.0'}
     cpu: [x64]
     os: [linux]
@@ -2641,6 +2647,9 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minisearch@7.2.0:
+    resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
+
   minizlib@2.1.2:
     resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
     engines: {node: '>= 8'}
@@ -4076,23 +4085,23 @@ snapshots:
       rou3: 0.8.1
       undici: 6.26.0
 
-  '@iso4/sandbox@0.0.3':
+  '@iso4/sandbox@0.2.2':
     optionalDependencies:
-      '@iso4/v8-darwin-arm64': 0.0.3
-      '@iso4/v8-darwin-x64': 0.0.3
-      '@iso4/v8-linux-arm64-gnu': 0.0.3
-      '@iso4/v8-linux-x64-gnu': 0.0.3
+      '@iso4/v8-darwin-arm64': 0.2.2
+      '@iso4/v8-darwin-x64': 0.2.2
+      '@iso4/v8-linux-arm64-gnu': 0.2.2
+      '@iso4/v8-linux-x64-gnu': 0.2.2
 
-  '@iso4/v8-darwin-arm64@0.0.3':
+  '@iso4/v8-darwin-arm64@0.2.2':
     optional: true
 
-  '@iso4/v8-darwin-x64@0.0.3':
+  '@iso4/v8-darwin-x64@0.2.2':
     optional: true
 
-  '@iso4/v8-linux-arm64-gnu@0.0.3':
+  '@iso4/v8-linux-arm64-gnu@0.2.2':
     optional: true
 
-  '@iso4/v8-linux-x64-gnu@0.0.3':
+  '@iso4/v8-linux-x64-gnu@0.2.2':
     optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -6336,6 +6345,8 @@ snapshots:
   minipass@5.0.0: {}
 
   minipass@7.1.3: {}
+
+  minisearch@7.2.0: {}
 
   minizlib@2.1.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ catalog:
   '@c8y/client': ^1023.83.4
   '@clack/prompts': ^1.5.1
   '@iso4/fetch': ^0.0.1
-  '@iso4/sandbox': ^0.0.3
+  '@iso4/sandbox': ^0.2.2
   '@napi-rs/keyring': ^1.3.0
   '@schplitt/eslint-config': ^1.5.1
   '@tmcp/adapter-valibot': ^0.1.6
@@ -31,6 +31,7 @@ catalog:
   consola: ^3.4.2
   eslint: ^10.4.1
   h3: 2.0.1-rc.22
+  minisearch: ^7.2.0
   tmcp: ^1.19.4
   tsdown: ^0.22.2
   typescript: ^6.0.3

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,7 +30,7 @@ const main = defineCommand({
     },
     spec: {
       type: 'string',
-      description: `Bundled core OpenAPI snapshot to expose to query. Available: ${specs.map((e) => `${e.version} (${e.label})`).join(', ')}.`,
+      description: `Bundled core OpenAPI snapshot to expose to codemode. Available: ${specs.map((e) => `${e.version} (${e.label})`).join(', ')}.`,
       alias: 's',
       default: getCoreOpenApiVersion(),
     },
@@ -102,7 +102,7 @@ const main = defineCommand({
         }
       }
     } else {
-      consola.info('No active tenant set. Call set-active-tenant to connect before using query or execute. Discovery will run once a tenant is activated.')
+      consola.info('No active tenant set. Call set-active-tenant to connect before making live API calls through codemode. Discovery will run once a tenant is activated.')
     }
 
     setupMcpServer('cli')
@@ -114,9 +114,9 @@ const main = defineCommand({
       env: 'cli' as const,
       restrictions,
       allowRules: parsedAllowRules,
-      // No active tenant: expose every bundled spec so the query tool stays
-      // useful as a reference. execute throws a clear missing-auth error so
-      // the agent cannot misuse this state for real calls.
+      // No active tenant: expose every bundled spec so codemode discovery
+      // stays useful as a reference. Live API calls throw a clear
+      // missing-auth error so the agent cannot misuse this state.
       specs: active?.specs ?? getBundledOnlySpecs(),
       auth: active ? { tenantUrl: active.tenantUrl, authorizationHeader: active.authorizationHeader } : undefined,
     })

--- a/src/codemode/derive-operations.ts
+++ b/src/codemode/derive-operations.ts
@@ -1,0 +1,380 @@
+import consola from 'consola'
+import { operationName } from './operation-naming'
+import type { JsonSchema, JsonSchemaDefinition } from './type-render'
+import { HTTP_METHODS } from '../utils/restrictions'
+import type { Spec } from '../utils/spec-resolution'
+
+// ─────────────────────────────────────────────────────────────────────────
+// OpenAPI spec → derived operations.
+//
+// Each operation becomes one callable namespace method: name from its
+// operationId, input as a single flattened object (path/query/header params
+// as top-level keys plus `body`), output type from the first 2xx JSON
+// response.
+//
+// Derivation is cached in a WeakMap keyed by spec object identity and MUST
+// stay policy-independent: restriction/allow rules differ per connection in
+// server mode, so policy filtering happens where namespaces are assembled
+// per request — never here.
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Path-item keys that hold operations — every HTTP method the OpenAPI spec
+ * (and the shared restrictions constant) knows, lowercased. Single source of
+ * truth with request-time method validation.
+ */
+export const OPERATION_KEYS = HTTP_METHODS.map((m) => m.toLowerCase())
+
+/**
+ * Vendor extension that hides an operation from derivation and discovery.
+ */
+const EXCLUDE_EXTENSION = 'x-mc8yp-exclude'
+
+/**
+ * Names every namespace reserves for its own surface.
+ */
+export const RESERVED_METHOD_NAMES = new Set(['request'])
+
+interface OpenApiParameter {
+  name: string
+  in: 'path' | 'query' | 'header' | 'cookie'
+  required?: boolean
+  description?: string
+  schema?: JsonSchemaDefinition
+  /**
+   * OpenAPI array serialization: `false` → one comma-joined key
+   * (`?severity=MAJOR,MINOR`), `true`/absent (the OpenAPI default) →
+   * repeated keys (`?severity=MAJOR&severity=MINOR`). Nearly every array
+   * parameter in the Cumulocity specs declares `explode: false`.
+   */
+  explode?: boolean
+}
+
+/**
+ * Loose runtime view of one operation. The narrow `OperationInfo` type in
+ * spec-resolution omits `operationId` and vendor extensions, but they survive
+ * preprocessing and are present at runtime.
+ */
+interface OpenApiOperation {
+  'operationId'?: string
+  'summary'?: string
+  'description'?: string
+  'tags'?: string[]
+  'parameters'?: OpenApiParameter[]
+  'requestBody'?: {
+    required?: boolean
+    content?: Record<string, { schema?: JsonSchemaDefinition }>
+  }
+  'responses'?: Record<string, { content?: Record<string, { schema?: JsonSchemaDefinition }> }>
+  'x-mc8yp-exclude'?: unknown
+}
+
+export interface DerivedOperation {
+  /**
+   * Sanitized operationId (fallback: `method_path`), unique per spec.
+   */
+  name: string
+  /**
+   * Short one-line doc: summary, falling back to `METHOD /path`.
+   */
+  summary: string
+  /**
+   * Full operation description when present and distinct from the summary.
+   */
+  description?: string
+  /**
+   * Flattened input: path/query/header params as top-level keys plus `body`.
+   */
+  inputSchema: JsonSchema
+  /**
+   * First 2xx `application/json` response schema. Absent = `unknown`.
+   */
+  outputSchema?: JsonSchema
+  path: string
+  /**
+   * Uppercase HTTP method.
+   */
+  method: string
+  parameters: OpenApiParameter[]
+  tags: string[]
+}
+
+/**
+ * A concrete request built from a derived operation and agent-supplied args.
+ */
+export interface DerivedRequest {
+  method: string
+  path: string
+  query: Record<string, unknown>
+  headers: Record<string, string>
+  body?: unknown
+}
+
+const operationCache = new WeakMap<object, DerivedOperation[]>()
+
+/**
+ * Derive every callable operation from a spec. Pure and cached by spec object
+ * identity — safe because resolved specs are stable per tenant/build.
+ * @param spec
+ */
+export function deriveOperations(spec: Spec): DerivedOperation[] {
+  const cached = operationCache.get(spec)
+  if (cached)
+    return cached
+  const derived = buildOperations(spec as unknown as { paths?: Record<string, Record<string, unknown>> })
+  operationCache.set(spec, derived)
+  return derived
+}
+
+function buildOperations(doc: { paths?: Record<string, Record<string, unknown>> }): DerivedOperation[] {
+  const operations: DerivedOperation[] = []
+  const used = new Set<string>()
+
+  for (const [path, pathItem] of Object.entries(doc.paths ?? {})) {
+    if (!pathItem || typeof pathItem !== 'object')
+      continue
+    for (const method of OPERATION_KEYS) {
+      const operation = pathItem[method] as OpenApiOperation | undefined
+      if (!operation || typeof operation !== 'object')
+        continue
+      if (operation[EXCLUDE_EXTENSION])
+        continue
+
+      const name = operationName(method, path, operation.operationId)
+      if (RESERVED_METHOD_NAMES.has(name) || used.has(name)) {
+        consola.warn(
+          `[codemode] operation ${method.toUpperCase()} ${path} maps to method name "${name}", which is `
+          + `${RESERVED_METHOD_NAMES.has(name) ? 'reserved' : 'already used'} — skipping. Set a unique operationId to expose it.`,
+        )
+        continue
+      }
+      used.add(name)
+      const pathItemParameters = Array.isArray(pathItem.parameters) ? pathItem.parameters as OpenApiParameter[] : []
+      operations.push(buildOperation(doc, path, method, operation, name, pathItemParameters))
+    }
+  }
+
+  return operations
+}
+
+function buildOperation(
+  doc: object,
+  path: string,
+  method: string,
+  operation: OpenApiOperation,
+  name: string,
+  pathItemParameters: readonly OpenApiParameter[],
+): DerivedOperation {
+  // The runtime specs are preprocessed but NOT dereferenced — parameter
+  // entries, requestBody, and response objects may still be `$ref`s into
+  // `components`. Structural refs are resolved here; schema-level refs are
+  // inlined by `inlineRefs`. Path-item-level parameters (shared by every
+  // operation on the path — Cumulocity declares `{id}` params there) are
+  // merged in, with operation-level entries overriding on (in, name).
+  const mergedParameters = new Map<string, OpenApiParameter>()
+  for (const raw of [...pathItemParameters, ...(operation.parameters ?? [])]) {
+    const param = raw && typeof raw === 'object' ? derefObject<OpenApiParameter>(raw, doc) : undefined
+    if (param && typeof param === 'object' && param.name)
+      mergedParameters.set(`${param.in}:${param.name}`, param)
+  }
+  const parameters = [...mergedParameters.values()]
+
+  const properties: Record<string, JsonSchemaDefinition> = {}
+  const required: string[] = []
+  for (const param of parameters) {
+    properties[param.name] = withDescription(inlineRefs(param.schema, doc) ?? {}, param.description)
+    if (param.required)
+      required.push(param.name)
+  }
+
+  const requestBody = derefObject(operation.requestBody, doc)
+  const bodySchema = inlineRefs(jsonContentSchema(requestBody?.content), doc)
+  if (bodySchema !== undefined) {
+    properties.body = bodySchema
+    if (requestBody?.required === true)
+      required.push('body')
+  }
+
+  const summary = operation.summary?.trim() || `${method.toUpperCase()} ${path}`
+  const detail = operation.description?.trim()
+
+  const outputSchemaDefinition = firstSuccessResponseSchema(operation, doc)
+
+  return {
+    name,
+    summary,
+    description: detail && detail !== summary ? detail : undefined,
+    inputSchema: {
+      type: 'object',
+      properties,
+      ...(required.length > 0 ? { required } : {}),
+    },
+    outputSchema: typeof outputSchemaDefinition === 'object' ? outputSchemaDefinition : undefined,
+    path,
+    method: method.toUpperCase(),
+    parameters,
+    tags: Array.isArray(operation.tags) ? operation.tags : [],
+  }
+}
+
+/**
+ * Best-effort output schema: the first 2xx response carrying an
+ * `application/json` schema. Any missing link (204, non-JSON content, no
+ * responses at all) yields undefined so the rendered type falls back to
+ * `unknown`.
+ * @param operation
+ * @param doc
+ */
+function firstSuccessResponseSchema(operation: OpenApiOperation, doc: object): JsonSchemaDefinition | undefined {
+  const responses = operation.responses
+  if (!responses || typeof responses !== 'object')
+    return undefined
+  // The preprocessor keeps numeric 2xx keys, the `2XX` range form, and a
+  // bare `default` — the range form counts as success here too.
+  for (const status of Object.keys(responses).sort()) {
+    if (!/^2\d\d$/.test(status) && !/^2xx$/i.test(status))
+      continue
+    const response = derefObject(responses[status], doc)
+    const schema = jsonContentSchema(response?.content)
+    if (schema !== undefined)
+      return inlineRefs(schema, doc)
+  }
+  return undefined
+}
+
+/**
+ * Pick the schema of the first JSON-bearing media type. Cumulocity uses
+ * vendor types like `application/vnd.com.nsn.cumulocity.alarm+json`, so any
+ * media type containing `json` counts — not just `application/json`.
+ * @param content
+ */
+function jsonContentSchema(content: Record<string, { schema?: JsonSchemaDefinition }> | undefined): JsonSchemaDefinition | undefined {
+  if (!content || typeof content !== 'object')
+    return undefined
+  for (const [mediaType, media] of Object.entries(content)) {
+    if (mediaType.toLowerCase().includes('json') && media?.schema !== undefined)
+      return media.schema
+  }
+  return undefined
+}
+
+/**
+ * Resolve an OpenAPI structural-level `$ref` (parameter object, requestBody,
+ * response object) against the document root, following chains with a cycle
+ * guard. Schema-level refs are handled by `inlineRefs` instead. Unresolvable
+ * refs yield undefined so the operation degrades instead of throwing.
+ * @param node
+ * @param doc
+ */
+export function derefObject<T extends object>(node: T | undefined, doc: object): T | undefined {
+  let current: unknown = node
+  const seen = new Set<string>()
+  while (current && typeof current === 'object' && typeof (current as { $ref?: unknown }).$ref === 'string') {
+    const ref = (current as { $ref: string }).$ref
+    if (!ref.startsWith('#/') || seen.has(ref))
+      return undefined
+    seen.add(ref)
+    current = pointer(doc, ref.slice(2).split('/'))
+  }
+  return current === null || typeof current !== 'object' ? undefined : current as T
+}
+
+/**
+ * Build the concrete request for a derived operation: substitute path params,
+ * split the remaining args into query/header maps, and pass `body` through.
+ * @param op
+ * @param args
+ */
+export function toRequest(op: DerivedOperation, args: unknown): DerivedRequest {
+  const input = (args && typeof args === 'object' ? args : {}) as Record<string, unknown>
+  let resolvedPath = op.path
+  const query: Record<string, unknown> = {}
+  const headers: Record<string, string> = {}
+
+  for (const param of op.parameters) {
+    const value = input[param.name]
+    if (value === undefined)
+      continue
+    if (param.in === 'path') {
+      resolvedPath = resolvedPath.replace(`{${param.name}}`, encodeURIComponent(String(value)))
+    } else if (param.in === 'query') {
+      // `explode: false` arrays serialize as one comma-joined key; the
+      // OpenAPI default (explode true) stays an array and is emitted as
+      // repeated keys by the request funnel.
+      query[param.name] = Array.isArray(value) && param.explode === false ? value.join(',') : value
+    } else if (param.in === 'header') {
+      headers[param.name] = String(value)
+    }
+  }
+
+  return {
+    method: op.method,
+    path: resolvedPath,
+    query,
+    headers,
+    ...('body' in input ? { body: input.body } : {}),
+  }
+}
+
+function withDescription(schema: JsonSchemaDefinition, description?: string): JsonSchemaDefinition {
+  if (!description || typeof schema !== 'object')
+    return schema
+  return { ...schema, description: schema.description ?? description }
+}
+
+/**
+ * Inline local `#/...` `$ref`s so flattened input/output schemas stay usable
+ * once detached from the OpenAPI document root, recursing through
+ * `properties`, `items`, `additionalProperties`, and the combinators.
+ * External refs and cycles degrade to an open object rather than throwing.
+ * @param schema
+ * @param root
+ * @param seen
+ */
+function inlineRefs(
+  schema: JsonSchemaDefinition | undefined,
+  root: object,
+  seen: Set<string> = new Set(),
+): JsonSchemaDefinition | undefined {
+  if (schema === undefined || typeof schema === 'boolean')
+    return schema
+
+  if (typeof schema.$ref === 'string') {
+    const ref = schema.$ref
+    if (!ref.startsWith('#/') || seen.has(ref))
+      return { type: 'object' }
+    const target = pointer(root, ref.slice(2).split('/'))
+    if (target === undefined || target === null || typeof target !== 'object')
+      return { type: 'object' }
+    return inlineRefs(target as JsonSchema, root, new Set(seen).add(ref))
+  }
+
+  const out: JsonSchema = { ...schema }
+  if (schema.properties) {
+    out.properties = {}
+    for (const [key, value] of Object.entries(schema.properties)) {
+      out.properties[key] = inlineRefs(value, root, seen) ?? {}
+    }
+  }
+  if (schema.items && !Array.isArray(schema.items))
+    out.items = inlineRefs(schema.items, root, seen)
+  if (schema.additionalProperties && typeof schema.additionalProperties === 'object')
+    out.additionalProperties = inlineRefs(schema.additionalProperties, root, seen)
+  for (const key of ['allOf', 'oneOf', 'anyOf'] as const) {
+    const branch = schema[key]
+    if (Array.isArray(branch))
+      out[key] = branch.map((s) => inlineRefs(s, root, seen) ?? {})
+  }
+  return out
+}
+
+function pointer(root: unknown, segments: string[]): unknown {
+  let current: unknown = root
+  for (const segment of segments) {
+    const key = segment.replace(/~1/g, '/').replace(/~0/g, '~')
+    if (!current || typeof current !== 'object')
+      return undefined
+    current = (current as Record<string, unknown>)[key]
+  }
+  return current
+}

--- a/src/codemode/describe.ts
+++ b/src/codemode/describe.ts
@@ -1,0 +1,113 @@
+import { searchMethods } from './method-search'
+import { renderMethodDeclaration } from './type-render'
+import type { MethodIndex } from './method-search'
+import type { CodemodeNamespace } from './namespaces'
+import type { DerivedOperation } from './derive-operations'
+
+// ─────────────────────────────────────────────────────────────────────────
+// codemode.describe — on-demand documentation rendering.
+//
+// Deliberately method-only: rendering the full typed block for a whole
+// namespace would flood the agent's context (c8y alone has ~250 operations).
+// The only real target is a single method — `describe("dtm.getAssets")` —
+// and its output is lean: the request line, prose, the bare signature, and
+// the input/output types (whose properties carry the OpenAPI descriptions
+// as JSDoc). Discovery across methods is codemode.search's job, not a
+// namespace dump.
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface DescribeOutput {
+  target: string
+  kind: 'overview' | 'method'
+  content: string
+}
+
+interface SpecWithInfo {
+  info?: { title?: string, description?: string }
+}
+
+function renderOverview(namespaces: readonly CodemodeNamespace[]): string {
+  const lines = ['Available API namespaces on this tenant (do not assume capabilities from prior knowledge — search each relevant domain):']
+  for (const ns of namespaces) {
+    const info = (ns.spec as SpecWithInfo).info
+    const title = info?.title
+    // One flattened, truncated line of the spec's own description — enough
+    // to route a problem domain to its namespace without flooding context.
+    const summary = info?.description?.trim().replace(/\s+/g, ' ')
+    const short = summary ? (summary.length > 220 ? `${summary.slice(0, 220)}…` : summary) : undefined
+    lines.push(`- ${ns.name}${title ? ` — ${title}` : ''} (${ns.operations.length} methods)${short ? `: ${short}` : ''}`)
+  }
+  lines.push(
+    '',
+    'Workflow:',
+    '- codemode.search("keywords") — find methods by name/path/summary (top 20 by score)',
+    '- codemode.describe("<namespace>.<method>") — types and docs for one method',
+    '- docs.search("keywords") / docs.read(id) — documentation topics (domain query languages, concepts)',
+    '- <namespace>.<method>({ ...params, body }) — call the API',
+    '- <namespace>.request({ method, path, params, body, headers }) — low-level escape hatch',
+  )
+  return lines.join('\n')
+}
+
+function renderMethod(namespace: CodemodeNamespace, op: DerivedOperation): string {
+  const { types, signature } = renderMethodDeclaration(namespace.name, op.name, {
+    inputSchema: op.inputSchema,
+    outputSchema: op.outputSchema,
+  })
+
+  const lines = [`${op.method} ${op.path} — ${op.summary}`]
+  if (op.description)
+    lines.push('', op.description)
+
+  lines.push('', '```ts', signature, '', types, '```')
+
+  const specTags = new Set((namespace.spec as { tags?: Array<{ name?: string }> }).tags?.map((t) => t?.name) ?? [])
+  const docPointers = op.tags.filter((tag) => specTags.has(tag)).map((tag) => `${namespace.name}::topic::${tag}`)
+  if (docPointers.length > 0)
+    lines.push('', `Related documentation: ${docPointers.map((id) => `docs.read(${JSON.stringify(id)})`).join(', ')}`)
+
+  return lines.join('\n')
+}
+
+function renderSearchRedirect(target: string, namespaces: readonly CodemodeNamespace[], methodIndex: MethodIndex): string {
+  const visible = new Set(namespaces.flatMap((ns) => ns.operations.map((op) => `${ns.name}.${op.name}`)))
+  const { results } = searchMethods(methodIndex, target, (t) => visible.has(t))
+  const suggestions = results.slice(0, 3)
+  const lines = [`"${target}" is not a method target. Use codemode.describe("<namespace>.<method>") for one method, or codemode.search("keywords") to find methods.`]
+  if (suggestions.length > 0) {
+    lines.push('', 'Closest methods:')
+    for (const s of suggestions) lines.push(`- ${s.target} — ${s.httpMethod} ${s.apiPath}`)
+  }
+  return lines.join('\n')
+}
+
+/**
+ * Resolve a describe target: nothing (short overview of namespaces), a
+ * `namespace.method` pair, or a bare method name searched across all
+ * namespaces. Namespace-only targets are intentionally rejected — a full
+ * method dump floods context; search is the discovery path.
+ * @param namespaces
+ * @param methodIndex
+ * @param target
+ */
+export function describeTarget(namespaces: readonly CodemodeNamespace[], methodIndex: MethodIndex, target?: string): DescribeOutput {
+  const trimmed = target?.trim() ?? ''
+  if (trimmed === '')
+    return { target: '', kind: 'overview', content: renderOverview(namespaces) }
+
+  const [maybeNamespace, maybeMethod] = trimmed.includes('.')
+    ? [trimmed.slice(0, trimmed.indexOf('.')), trimmed.slice(trimmed.indexOf('.') + 1)]
+    : [trimmed, undefined]
+
+  const namespace = namespaces.find((ns) => ns.name === maybeNamespace)
+
+  const methodName = maybeMethod ?? trimmed
+  const candidates = namespace && maybeMethod !== undefined ? [namespace] : namespaces
+  for (const candidate of candidates) {
+    const op = candidate.operations.find((o) => o.name === methodName)
+    if (op)
+      return { target: `${candidate.name}.${op.name}`, kind: 'method', content: renderMethod(candidate, op) }
+  }
+
+  return { target: trimmed, kind: 'method', content: renderSearchRedirect(trimmed, namespaces, methodIndex) }
+}

--- a/src/codemode/docs-index.ts
+++ b/src/codemode/docs-index.ts
@@ -1,0 +1,210 @@
+import MiniSearch from 'minisearch'
+
+// ─────────────────────────────────────────────────────────────────────────
+// Host-side MiniSearch index over spec documentation.
+//
+// This is the prose search ("how do I use it") complementing the
+// name-oriented method search. It carries exactly two kinds of documents:
+//
+//   - `topic`    — one per spec tag. Tag descriptions hold the cross-cutting
+//                  domain docs (the Cumulocity query grammar lives in the
+//                  "Query language" tag, notifications in "About
+//                  notifications 2.0", …).
+//   - `overview` — one per spec info block.
+//
+// Endpoints deliberately contribute NOTHING here. Per-endpoint prose
+// (operation description, parameter docs) is delivered by
+// codemode.describe("<ns>.<method>"), and finding endpoints is
+// codemode.search's job. When a parameter description points at a concept
+// ("details in Query language"), the agent turns that phrase into a
+// docs.search — the topic title match ranks it first.
+//
+// Search hits carry a truncated PREVIEW that names the `docs.read(id)` call
+// returning the full text — truncation happens only in search results,
+// never in the stored docs.
+//
+// The index is cached by caller-supplied object identity (the resolved-specs
+// object). Topics and overviews are tenant-level documentation, not
+// operations, so no per-connection policy filtering applies.
+// ─────────────────────────────────────────────────────────────────────────
+
+const DEFAULT_PREVIEW_LENGTH = 800
+
+/**
+ * Loose runtime view of the spec fields the index reads.
+ */
+interface IndexSpec {
+  info?: { title?: string, description?: string }
+  tags?: Array<{ name?: string, description?: string }>
+}
+
+export interface DocsIndexEntry {
+  /**
+   * Sandbox namespace the spec is exposed under (e.g. `c8y`, `dtm`).
+   */
+  namespace: string
+  spec: unknown
+}
+
+export interface SpecDoc {
+  id: string
+  title: string
+  text: string
+  kind: 'topic' | 'overview'
+  namespace: string
+}
+
+export interface DocsSearchOptions {
+  limit?: number
+  fuzzy?: number
+  prefix?: boolean
+  minScore?: number
+  maxTextLength?: number
+}
+
+export interface DocsSearchHit {
+  id: string
+  title: string
+  /**
+   * Preview of the matched text — read the full text via `docs.read(id)`.
+   */
+  text: string
+  truncated: boolean
+  kind: SpecDoc['kind']
+  namespace: string
+  score: number
+}
+
+export interface DocsIndex {
+  mini: MiniSearch
+  docs: Map<string, SpecDoc>
+}
+
+function joinText(parts: Array<string | undefined>): string {
+  return parts.filter((p): p is string => typeof p === 'string' && p.length > 0).join(' ')
+}
+
+/**
+ * Flatten every visible spec into uniform docs: one per declared tag
+ * (topic) and one per spec info block (overview).
+ * @param entries
+ */
+export function buildSpecDocs(entries: readonly DocsIndexEntry[]): SpecDoc[] {
+  const docs: SpecDoc[] = []
+
+  for (const { namespace, spec } of entries) {
+    const indexSpec = spec as IndexSpec
+
+    const overviewText = joinText([indexSpec.info?.title, indexSpec.info?.description])
+    if (overviewText) {
+      docs.push({
+        id: `${namespace}::overview`,
+        title: indexSpec.info?.title ?? namespace,
+        text: overviewText,
+        kind: 'overview',
+        namespace,
+      })
+    }
+
+    for (const tag of indexSpec.tags ?? []) {
+      if (!tag?.name)
+        continue
+      docs.push({
+        id: `${namespace}::topic::${tag.name}`,
+        title: tag.name,
+        text: joinText([tag.name, tag.description]),
+        kind: 'topic',
+        namespace,
+      })
+    }
+  }
+
+  return docs
+}
+
+const indexCache = new WeakMap<object, DocsIndex>()
+
+/**
+ * Build (or return the cached) docs index for a stable cache key — callers
+ * pass the resolved-specs object, so the index lives exactly as long as the
+ * tenant's spec resolution.
+ * @param cacheKey
+ * @param entries
+ */
+export function getDocsIndex(cacheKey: object, entries: () => readonly DocsIndexEntry[]): DocsIndex {
+  const cached = indexCache.get(cacheKey)
+  if (cached)
+    return cached
+
+  const docs = buildSpecDocs(entries())
+  // Hits are hydrated from the docs map, so nothing needs storeFields.
+  const mini = new MiniSearch({
+    fields: ['title', 'text'],
+  })
+  mini.addAll(docs)
+
+  const index: DocsIndex = { mini, docs: new Map(docs.map((d) => [d.id, d])) }
+  indexCache.set(cacheKey, index)
+  return index
+}
+
+/**
+ * Ranked fuzzy/prefix search over the docs. Long matches are truncated to a
+ * preview wrapped with markers naming the `docs.read(id)` call that returns
+ * the full text.
+ * @param index
+ * @param query
+ * @param options
+ */
+export function searchDocs(index: DocsIndex, query: string, options: DocsSearchOptions = {}): DocsSearchHit[] {
+  if (typeof query !== 'string' || query.trim() === '')
+    throw new TypeError('docs.search(query): query must be a non-empty string')
+
+  const limit = options.limit ?? 10
+  const maxText = options.maxTextLength && options.maxTextLength > 0 ? options.maxTextLength : DEFAULT_PREVIEW_LENGTH
+
+  let results = index.mini.search(query, {
+    fuzzy: options.fuzzy ?? 0.2,
+    prefix: options.prefix !== false,
+    boost: { title: 2 },
+  })
+  if (typeof options.minScore === 'number')
+    results = results.filter((r) => r.score >= options.minScore!)
+
+  const hits: DocsSearchHit[] = []
+  for (const result of results) {
+    if (hits.length >= limit)
+      break
+    const doc = index.docs.get(String(result.id))
+    if (!doc)
+      continue
+
+    const truncated = doc.text.length > maxText
+    const text = truncated
+      ? `[TRUNCATED PREVIEW — showing first ${maxText} of ${doc.text.length} chars; this text is INCOMPLETE. Read the full text via: docs.read(${JSON.stringify(doc.id)})]\n\n${doc.text.slice(0, maxText)}\n\n[END TRUNCATED PREVIEW — read the full text via: docs.read(${JSON.stringify(doc.id)})]`
+      : doc.text
+
+    hits.push({
+      id: doc.id,
+      title: doc.title,
+      text,
+      truncated,
+      kind: doc.kind,
+      namespace: doc.namespace,
+      score: result.score,
+    })
+  }
+
+  return hits
+}
+
+/**
+ * Return the full, untruncated doc for an id from a search hit.
+ * @param index
+ * @param id
+ */
+export function readDoc(index: DocsIndex, id: string): SpecDoc | null {
+  if (typeof id !== 'string' || id.trim() === '')
+    throw new TypeError('docs.read(id): id must be a non-empty string')
+  return index.docs.get(id) ?? null
+}

--- a/src/codemode/execute.ts
+++ b/src/codemode/execute.ts
@@ -3,14 +3,22 @@ import { encode } from '@toon-format/toon'
 import { createSafeFetch } from '@iso4/fetch'
 import type { SafeFetchGlobal } from '@iso4/fetch'
 import { createSandbox } from '@iso4/sandbox'
-import type { HostGlobals, Sandbox } from '@iso4/sandbox'
+import type { HostModuleObject, Sandbox } from '@iso4/sandbox'
+import { toRequest } from './derive-operations'
+import { describeTarget } from './describe'
+import { getDocsIndex, readDoc, searchDocs } from './docs-index'
+import { getMethodIndex, searchMethods } from './method-search'
+import type { MethodIndex } from './method-search'
+import { buildNamespaces, toSearchableMethods } from './namespaces'
+import type { CodemodeNamespace } from './namespaces'
+import type { DocsSearchOptions } from './docs-index'
 import { createC8yAuthHeaders, resolveC8yAuth } from '../utils/client'
 import { c8yMcpServer } from '../server-instance'
 import { evaluateAccessPolicy } from '../utils/restriction-matcher'
 import { HTTP_METHODS } from '../utils/restrictions'
 import type { AllowRule, RestrictionRule } from '../utils/restrictions'
+import type { ResolvedSpecs } from '../utils/spec-resolution'
 
-const QUERY_ENTRY_PATH = '/codemode-query.mjs'
 const EXECUTE_ENTRY_PATH = '/codemode-execute.mjs'
 
 export const BLOCKED_REQUEST_PREFIX = 'Request blocked by MCP connection policy.'
@@ -18,6 +26,7 @@ export const BLOCKED_REQUEST_PREFIX = 'Request blocked by MCP connection policy.
 const SANDBOX_LIMITS = {
   memoryMb: 128,
   cpuTimeMs: 50_000,
+  wallTimeMs: 120_000,
   maxBridgeCalls: 200,
 } as const
 
@@ -105,12 +114,15 @@ function formatAllowBlockMessage(
 // ─────────────────────────────────────────────────────────────────────────
 // safeFetch wiring
 //
-// All host-side responsibilities live as origin middleware:
+// All request-time responsibilities live as origin middleware:
 //   1. restriction / allow-rule enforcement (throws blocked-policy message)
 //   2. auth header injection (last write wins so agent cannot override)
 //   3. response unwrap: parse body, throw on non-2xx, replace ctx.res.body
-//      with the parsed value so the sandbox-side wrapper can return it
-//      directly without ever calling res.json() / res.text().
+//      with the parsed value.
+//
+// The safeFetch is never exposed to the sandbox: every live call — derived
+// namespace method or `.request` escape hatch — is dispatched host-side and
+// invokes `handler` directly, so the sandbox has no fetch surface at all.
 // ─────────────────────────────────────────────────────────────────────────
 
 export function createCumulocitySafeFetch(
@@ -179,8 +191,84 @@ export function createCumulocitySafeFetch(
 }
 
 // ─────────────────────────────────────────────────────────────────────────
-// Code generation
+// Host-side request dispatch
 // ─────────────────────────────────────────────────────────────────────────
+
+interface OutgoingRequest {
+  method: string
+  path: string
+  query?: Record<string, unknown>
+  body?: unknown
+  headers?: Record<string, string>
+}
+
+/**
+ * Build the final URL and invoke the safeFetch handler directly (host-side).
+ * Policy enforcement, auth injection, and response parsing all happen in the
+ * safeFetch middleware — this is the single funnel every live request goes
+ * through, derived method and escape hatch alike.
+ * @param safeFetch
+ * @param tenantUrl
+ * @param request
+ */
+async function performRequest(safeFetch: SafeFetchGlobal, tenantUrl: string, request: OutgoingRequest): Promise<unknown> {
+  const base = tenantUrl.endsWith('/') ? tenantUrl : `${tenantUrl}/`
+  let url = base + (request.path.startsWith('/') ? request.path.slice(1) : request.path)
+
+  const search = new URLSearchParams()
+  for (const [key, value] of Object.entries(request.query ?? {})) {
+    if (value === undefined || value === null)
+      continue
+    if (Array.isArray(value)) {
+      for (const item of value) search.append(key, String(item))
+    } else {
+      search.append(key, String(value))
+    }
+  }
+  const queryString = search.toString()
+  if (queryString)
+    url += (url.includes('?') ? '&' : '?') + queryString
+
+  const headers: Record<string, string> = {}
+  for (const [key, value] of Object.entries(request.headers ?? {})) {
+    if (typeof value === 'string')
+      headers[key] = value
+  }
+
+  let body: unknown = request.body ?? null
+  if (body !== null && typeof body !== 'string' && !(body instanceof Uint8Array)) {
+    if (!Object.keys(headers).some((k) => k.toLowerCase() === 'content-type'))
+      headers['content-type'] = 'application/json'
+    body = JSON.stringify(body)
+  }
+
+  const response = await safeFetch.handler(url, { method: request.method, headers, body })
+  return response.body
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Sandbox module assembly
+//
+// iso4 host modules replace string preambles: the api module below is a
+// plain object whose function leaves become bridge stubs inside a generated
+// ESM module. The static entry module wires those exports onto globalThis
+// and calls the agent's function, which arrives as its own source module.
+// ─────────────────────────────────────────────────────────────────────────
+
+const API_MODULE_SPECIFIER = 'mc8yp:api'
+const AGENT_MODULE_SPECIFIER = 'mc8yp:agent'
+
+// Import order matters for evaluation, not for safety: both imported modules
+// only *define* values at evaluation time — the agent function body runs
+// after the globalThis wiring below it.
+const ENTRY_SOURCE = [
+  `import * as __api from '${API_MODULE_SPECIFIER}'`,
+  `import __run from '${AGENT_MODULE_SPECIFIER}'`,
+  'globalThis.codemode = __api.codemode',
+  'globalThis.docs = __api.docs',
+  'for (const [name, namespace] of Object.entries(__api.namespaces)) globalThis[name] = namespace',
+  'export default await __run()',
+].join('\n')
 
 function normalizeCode(functionCode: string): string {
   return functionCode
@@ -190,8 +278,131 @@ function normalizeCode(functionCode: string): string {
     .trim()
 }
 
-function buildQueryScript(sourceCode: string): string {
-  const functionExpression = normalizeCode(sourceCode)
+function buildAgentModule(functionCode: string): string {
+  return [
+    `const __mc8ypExecute = (${normalizeCode(functionCode)});`,
+    'if (typeof __mc8ypExecute !== "function") { throw new TypeError("Execute code must evaluate to a function.") }',
+    'export default __mc8ypExecute',
+  ].join('\n')
+}
+
+/**
+ * A live-call dispatcher; degraded to a throwing stub when no tenant is active.
+ */
+interface LiveCalls {
+  operation: (namespace: CodemodeNamespace, opName: string, input: unknown) => Promise<unknown>
+  request: (options: unknown) => Promise<unknown>
+}
+
+function createLiveCalls(safeFetch: SafeFetchGlobal, tenantUrl: string): LiveCalls {
+  return {
+    operation: async (namespace, opName, input) => {
+      const op = namespace.operations.find((o) => o.name === opName)!
+      return performRequest(safeFetch, tenantUrl, toRequest(op, input))
+    },
+    request: async (rawOptions) => {
+      if (!rawOptions || typeof rawOptions !== 'object')
+        throw new TypeError('request options must be an object')
+      const options = rawOptions as { method?: unknown, path?: unknown, params?: unknown, body?: unknown, headers?: unknown }
+      if (typeof options.path !== 'string' || options.path.length === 0)
+        throw new TypeError('request path must be a non-empty string')
+      if (typeof options.method !== 'string' || options.method.trim().length === 0)
+        throw new TypeError('request method must be a non-empty string')
+      const method = options.method.trim().toUpperCase()
+      if (!HTTP_METHODS.includes(method as typeof HTTP_METHODS[number]))
+        throw new TypeError(`request method must be one of: ${HTTP_METHODS.join(', ')}`)
+      return performRequest(safeFetch, tenantUrl, {
+        method,
+        path: options.path,
+        query: options.params && typeof options.params === 'object' ? options.params as Record<string, unknown> : undefined,
+        body: options.body,
+        headers: options.headers && typeof options.headers === 'object' ? options.headers as Record<string, string> : undefined,
+      })
+    },
+  }
+}
+
+function createUnauthenticatedCalls(message: string): LiveCalls {
+  const fail = async (): Promise<never> => {
+    throw new Error(message)
+  }
+  return { operation: fail, request: fail }
+}
+
+function buildApiModule(
+  namespaces: readonly CodemodeNamespace[],
+  methodIndex: MethodIndex,
+  docsIndex: ReturnType<typeof getDocsIndex>,
+  live: LiveCalls,
+): HostModuleObject {
+  const visibleTargets = new Set(namespaces.flatMap((ns) => ns.operations.map((op) => `${ns.name}.${op.name}`)))
+
+  return {
+    codemode: {
+      search: async (...args: unknown[]) => {
+        const [query] = args
+        const valid = typeof query === 'string'
+          ? query.trim() !== ''
+          : Array.isArray(query) && query.some((q) => typeof q === 'string' && q.trim() !== '')
+        if (!valid)
+          throw new TypeError('codemode.search(query): pass a non-empty string or an array of query phrasings')
+        return searchMethods(methodIndex, query as string | string[], (target) => visibleTargets.has(target))
+      },
+      describe: async (...args: unknown[]) => {
+        const [target] = args
+        // Array form: describe a SHORTLIST of methods in one call so their
+        // input types can be compared side by side. Capped so it cannot
+        // become a namespace dump through the back door.
+        if (Array.isArray(target)) {
+          const targets = target.filter((t) => typeof t === 'string' && t.trim() !== '')
+          if (targets.length === 0)
+            throw new TypeError('codemode.describe(targets): pass method targets like "c8y.getAlarmCollectionResource"')
+          if (targets.length > 5)
+            throw new TypeError(`codemode.describe(targets): at most 5 targets per call (got ${targets.length}) — shortlist candidates via search first`)
+          return targets.map((t) => describeTarget(namespaces, methodIndex, t))
+        }
+        return describeTarget(namespaces, methodIndex, target == null ? undefined : String(target))
+      },
+    },
+    docs: {
+      search: async (...args: unknown[]) => {
+        const [query, options] = args
+        return searchDocs(
+          docsIndex,
+          String(query ?? ''),
+          options && typeof options === 'object' ? options as DocsSearchOptions : {},
+        )
+      },
+      read: async (...args: unknown[]) => {
+        const [id] = args
+        const doc = readDoc(docsIndex, String(id ?? ''))
+        if (!doc)
+          throw new Error(`No documentation with id "${String(id)}". Ids come from docs.search results and codemode.describe output.`)
+        return doc
+      },
+    },
+    namespaces: Object.fromEntries(namespaces.map((namespace) => [namespace.name, {
+      request: async (...args: unknown[]) => live.request(args[0]),
+      ...Object.fromEntries(namespace.operations.map((op) => [
+        op.name,
+        async (...args: unknown[]) => live.operation(namespace, op.name, args[0]),
+      ])),
+    }])),
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Runtime context resolution
+// ─────────────────────────────────────────────────────────────────────────
+
+interface CodemodeRuntime {
+  resolved: ResolvedSpecs
+  namespaces: CodemodeNamespace[]
+  restrictions: readonly RestrictionRule[]
+  allowRules: readonly AllowRule[]
+}
+
+function resolveRuntime(): CodemodeRuntime {
   const custom = c8yMcpServer.ctx.custom
   const resolved = custom?.specs
   if (!resolved) {
@@ -201,59 +412,9 @@ function buildQueryScript(sourceCode: string): string {
         : 'No tenant specs available for this MCP connection. This usually means the request reached the server without a resolvable tenant context (e.g. a platform probe). Reconnect with valid tenant auth.',
     )
   }
-  return [
-    `const coreSpec = ${JSON.stringify(resolved.core)};`,
-    `const serviceSpecs = ${JSON.stringify(resolved.specs)};`,
-    `const __mc8ypQuery = (${functionExpression});`,
-    'if (typeof __mc8ypQuery !== "function") { throw new TypeError("Query code must evaluate to a function.") }',
-    'export default await __mc8ypQuery();',
-  ].join('\n')
-}
-
-/**
- * String-form HostGlobalValue for `cumulocity`.
- *
- * Installed by iso4 as `globalThis.cumulocity = (<expr>)`. Thin sandbox-side
- * wrapper that validates input, normalises object bodies to JSON, builds the
- * tenant-relative URL, and calls the bridged safeFetch. Everything else
- * (policy enforcement, auth injection, response parsing, error mapping) runs
- * host-side in the middleware above.
- * @param tenantUrl - canonical tenant origin used to resolve agent-supplied
- *   relative paths.
- */
-function buildCumulocityPreamble(tenantUrl: string): string {
-  const baseUrl = tenantUrl.endsWith('/') ? tenantUrl : `${tenantUrl}/`
-  return `(() => {
-  const BASE_URL = ${JSON.stringify(baseUrl)};
-  const HTTP_METHODS = ${JSON.stringify(HTTP_METHODS)};
-  return Object.freeze({
-    request: async (opts) => {
-      if (!opts || typeof opts !== 'object') throw new TypeError('request options must be an object');
-      if (typeof opts.path !== 'string' || opts.path.length === 0) throw new TypeError('request path must be a non-empty string');
-      if (typeof opts.method !== 'string' || opts.method.trim().length === 0) throw new TypeError('request method must be a non-empty string');
-      const method = opts.method.trim().toUpperCase();
-      if (!HTTP_METHODS.includes(method)) throw new TypeError('request method must be one of: ' + HTTP_METHODS.join(', '));
-      // BASE_URL is normalised to end with '/'. iso4 does not expose URL as
-      // a sandbox global, so resolve relative paths via string concat.
-      const path = opts.path.startsWith('/') ? opts.path.slice(1) : opts.path;
-      const url = BASE_URL + path;
-      const headers = {};
-      if (opts.headers && typeof opts.headers === 'object') {
-        for (const [k, v] of Object.entries(opts.headers)) {
-          if (typeof v === 'string') headers[k] = v;
-        }
-      }
-      let body = opts.body == null ? null : opts.body;
-      if (body !== null && typeof body !== 'string' && !(body instanceof Uint8Array)) {
-        const hasCT = Object.keys(headers).some((k) => k.toLowerCase() === 'content-type');
-        if (!hasCT) headers['content-type'] = 'application/json';
-        body = JSON.stringify(body);
-      }
-      const res = await __c8y_fetch(url, { method, headers, body });
-      return res.body;
-    },
-  });
-})()`
+  const restrictions = custom?.restrictions ?? []
+  const allowRules = custom?.allowRules ?? []
+  return { resolved, restrictions, allowRules, namespaces: buildNamespaces(resolved, restrictions, allowRules) }
 }
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -273,72 +434,59 @@ function extractDefaultExport(exportsObject: unknown): unknown {
   throw new Error(NO_DEFAULT_EXPORT_MESSAGE)
 }
 
-export async function query(functionCode: string): Promise<string> {
-  const sandbox = await getSandbox()
-  const result = await sandbox.run({
-    code: buildQueryScript(functionCode),
-    filename: QUERY_ENTRY_PATH,
-    limits: SANDBOX_LIMITS,
-    // No globals → no fetch surface; the query sandbox cannot reach the network.
-  })
-
-  if (!result.ok) {
-    throw new Error(`Execution failed with code ${result.error.code}: ${result.error.message}`)
-  }
-
-  const value = extractDefaultExport(result.exports)
-  const body = typeof value === 'string' ? value : JSON.stringify(value)
-  // The tenant footer is a CLI-only affordance: in CLI mode the active tenant
-  // is global session state that can flip between calls, so the agent needs a
-  // visible marker to verify which tenant a result reflects. In server mode
-  // the tenant is fixed by deployment and request auth, so the footer would
-  // just be noise.
+function withCliTenantMarker(text: string, tenantUrl: string | null): string {
   if (c8yMcpServer.ctx.custom?.env !== 'cli')
-    return body
-  const tenantUrl = c8yMcpServer.ctx.custom?.auth?.tenantUrl
-  const footer = tenantUrl
-    ? `Query ran against tenant: ${tenantUrl}. Visible specs are everything currently available for that tenant.`
-    : 'Query ran against bundled OpenAPI snapshots only — no active tenant. Visibility here does NOT guarantee any service is installed on a tenant.'
-  return `${body}\n\n---\n${footer}`
-}
-
-function withCliTenantMarker(text: string, tenantUrl: string): string {
-  return c8yMcpServer.ctx.custom?.env === 'cli'
-    ? `Executed against tenant: ${tenantUrl}\n\n${text}`
-    : text
+    return text
+  const marker = tenantUrl
+    ? `Executed against tenant: ${tenantUrl}`
+    : 'No active tenant — discovery only. Live API calls require set-active-tenant, and visible specs are bundled reference snapshots that may not exist on any tenant.'
+  return `${marker}\n\n${text}`
 }
 
 export async function execute(functionCode: string): Promise<string> {
-  const auth = await resolveC8yAuth()
-  const authHeaders = createC8yAuthHeaders(auth)
-  const restrictions = c8yMcpServer.ctx.custom?.restrictions ?? []
-  const allowRules = c8yMcpServer.ctx.custom?.allowRules ?? []
+  const { resolved, namespaces, restrictions, allowRules } = resolveRuntime()
 
-  const functionExpression = normalizeCode(functionCode)
-  const code = [
-    `const __mc8ypExecute = (${functionExpression});`,
-    'if (typeof __mc8ypExecute !== "function") { throw new TypeError("Execute code must evaluate to a function.") }',
-    'export default await __mc8ypExecute();',
-  ].join('\n')
+  // The docs index (topic/overview documentation only — no endpoints, so no
+  // per-connection policy concerns) is cached per resolved-specs object; its
+  // entries come from an unfiltered namespace list so the cache stays
+  // policy-independent.
+  const docsIndex = getDocsIndex(resolved, () =>
+    buildNamespaces(resolved).map((ns) => ({ namespace: ns.name, spec: ns.spec })))
+  // Same pattern for the method index: built from an unfiltered namespace
+  // list (policy-independent, cached per tenant); the connection's policy is
+  // applied at query time via the visible-targets predicate.
+  const methodIndex = getMethodIndex(resolved, () => toSearchableMethods(buildNamespaces(resolved)))
 
-  const globals: HostGlobals = {
-    __c8y_fetch: createCumulocitySafeFetch(auth.tenantUrl, authHeaders, restrictions, allowRules),
-    cumulocity: buildCumulocityPreamble(auth.tenantUrl),
+  // In CLI mode discovery must keep working before a tenant is active (the
+  // bundled-only fallback), so a missing tenant degrades the live-call
+  // dispatchers instead of failing the whole run.
+  let tenantUrl: string | null = null
+  let live: LiveCalls
+  try {
+    const auth = await resolveC8yAuth()
+    tenantUrl = auth.tenantUrl
+    const safeFetch = createCumulocitySafeFetch(auth.tenantUrl, createC8yAuthHeaders(auth), restrictions, allowRules)
+    live = createLiveCalls(safeFetch, auth.tenantUrl)
+  } catch (error) {
+    live = createUnauthenticatedCalls(error instanceof Error ? error.message : String(error))
   }
 
   const sandbox = await getSandbox()
   const result = await sandbox.run({
-    code,
+    code: ENTRY_SOURCE,
     filename: EXECUTE_ENTRY_PATH,
     limits: SANDBOX_LIMITS,
-    globals,
+    imports: {
+      [API_MODULE_SPECIFIER]: buildApiModule(namespaces, methodIndex, docsIndex, live),
+      [AGENT_MODULE_SPECIFIER]: buildAgentModule(functionCode),
+    },
   })
 
   if (!result.ok) {
     // User error or blocked-policy throw — surface the raw message so the
     // BLOCKED_REQUEST_PREFIX prefix stays intact for callers that branch on it.
-    return withCliTenantMarker(result.error.message, auth.tenantUrl)
+    return withCliTenantMarker(result.error.message, tenantUrl)
   }
 
-  return withCliTenantMarker(encode(extractDefaultExport(result.exports)), auth.tenantUrl)
+  return withCliTenantMarker(encode(extractDefaultExport(result.exports)), tenantUrl)
 }

--- a/src/codemode/method-search.ts
+++ b/src/codemode/method-search.ts
@@ -1,0 +1,142 @@
+import MiniSearch from 'minisearch'
+
+// ─────────────────────────────────────────────────────────────────────────
+// Ranked search over derived namespace methods, backed by MiniSearch — the
+// same engine as the docs index. Chosen over hand-tuned token scoring
+// because specs are discovered at runtime: fuzzy matching absorbs
+// singular/plural and typo drift generically, and OR-combination keeps
+// recall when one query word has no counterpart in the spec vocabulary
+// ("list assets" still ranks everything matching "assets"). The calling
+// agent is the semantic layer — it reformulates queries; this engine just
+// has to be forgiving enough that one phrasing hits.
+//
+// The index is cached by caller-supplied object identity (the resolved-specs
+// object) and MUST stay policy-independent: restriction/allow rules differ
+// per connection in server mode, so hits are filtered at query time via the
+// `isVisible` predicate, never at build time.
+// ─────────────────────────────────────────────────────────────────────────
+
+const SEARCH_RESULT_LIMIT = 20
+
+/**
+ * One searchable derived method, flattened across namespaces.
+ */
+export interface SearchableMethod {
+  /**
+   * Describe target, e.g. `c8y.getAlarmCollectionResource`. Doubles as the
+   * index id.
+   */
+  target: string
+  namespace: string
+  method: string
+  /**
+   * Uppercase HTTP method of the underlying operation.
+   */
+  httpMethod: string
+  /**
+   * REST path of the underlying operation, e.g. `/alarm/alarms`.
+   */
+  apiPath: string
+  summary?: string
+}
+
+export interface MethodSearchResult extends SearchableMethod {
+  score: number
+}
+
+export interface MethodSearchOutput {
+  results: MethodSearchResult[]
+  total: number
+  truncated: boolean
+}
+
+export interface MethodIndex {
+  mini: MiniSearch
+  methods: Map<string, SearchableMethod>
+}
+
+/**
+ * Split camelCase and path/identifier separators into searchable terms.
+ * @param text
+ */
+function tokenize(text: string): string[] {
+  return text
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .split(/[^a-z0-9]+/i)
+    .filter(Boolean)
+}
+
+const indexCache = new WeakMap<object, MethodIndex>()
+
+/**
+ * Build (or return the cached) method index for a stable cache key — callers
+ * pass the resolved-specs object, so the index lives exactly as long as the
+ * tenant's spec resolution. Items must come from an unfiltered namespace
+ * list to keep the cache policy-independent.
+ * @param cacheKey
+ * @param items
+ */
+export function getMethodIndex(cacheKey: object, items: () => readonly SearchableMethod[]): MethodIndex {
+  const cached = indexCache.get(cacheKey)
+  if (cached)
+    return cached
+
+  const list = items()
+  const mini = new MiniSearch({
+    idField: 'target',
+    fields: ['method', 'apiPath', 'summary', 'namespace'],
+    tokenize,
+  })
+  mini.addAll([...list])
+
+  const index: MethodIndex = { mini, methods: new Map(list.map((m) => [m.target, m])) }
+  indexCache.set(cacheKey, index)
+  return index
+}
+
+/**
+ * Search the method index with one query or several phrasings at once
+ * (results are unioned, deduped by best score). The agent is encouraged to
+ * pass variants — `["list assets", "asset collection"]` — in a single call.
+ * @param index
+ * @param query
+ * @param isVisible Query-time policy filter — methods blocked for the
+ *   current connection must not surface.
+ */
+export function searchMethods(
+  index: MethodIndex,
+  query: string | readonly string[],
+  isVisible?: (target: string) => boolean,
+): MethodSearchOutput {
+  const queries = (Array.isArray(query) ? query : [query])
+    .map((q) => typeof q === 'string' ? q.trim() : '')
+    .filter(Boolean)
+  if (queries.length === 0)
+    return { results: [], total: 0, truncated: false }
+
+  const bestScore = new Map<string, number>()
+  for (const q of queries) {
+    for (const hit of index.mini.search(q, {
+      fuzzy: 0.2,
+      prefix: true,
+      boost: { method: 3, apiPath: 2, namespace: 1.5 },
+    })) {
+      const target = String(hit.id)
+      if (isVisible && !isVisible(target))
+        continue
+      const previous = bestScore.get(target)
+      if (previous === undefined || hit.score > previous)
+        bestScore.set(target, hit.score)
+    }
+  }
+
+  const ranked = [...bestScore.entries()]
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .map(([target, score]) => ({ ...index.methods.get(target)!, score }))
+
+  return {
+    results: ranked.slice(0, SEARCH_RESULT_LIMIT),
+    total: ranked.length,
+    truncated: ranked.length > SEARCH_RESULT_LIMIT,
+  }
+}

--- a/src/codemode/namespaces.ts
+++ b/src/codemode/namespaces.ts
@@ -1,0 +1,105 @@
+import consola from 'consola'
+import { deriveOperations } from './derive-operations'
+import { sanitizeToolName } from './operation-naming'
+import { evaluateAccessPolicy } from '../utils/restriction-matcher'
+import type { DerivedOperation } from './derive-operations'
+import type { SearchableMethod } from './method-search'
+import type { ResolvedSpecs } from '../utils/spec-resolution'
+import type { AllowRule, RestrictionRule } from '../utils/restrictions'
+
+// ─────────────────────────────────────────────────────────────────────────
+// Namespace assembly — the per-connection view over derived operations.
+//
+// Derivation (deriveOperations) is cached and policy-independent; THIS is the
+// layer that applies the connection's restriction/allow rules, so blocked
+// operations never appear in namespaces, search results, or describe output.
+// A blocked operation is never retryable through the same connection, so
+// advertising it would only send the agent down a dead end. Enforcement
+// still happens host-side at request time as the second layer (which also
+// covers the `.request` escape hatch and template-vs-concrete path gaps).
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * The core spec's sandbox namespace.
+ */
+export const CORE_NAMESPACE = 'c8y'
+
+/**
+ * Namespaces that can never be taken by a discovered service contextPath.
+ * `codemode`/`docs` are the platform SDK, `c8y` is core, and `cumulocity` is
+ * reserved so a service cannot impersonate the historical request global.
+ */
+export const RESERVED_NAMESPACES = new Set(['codemode', 'docs', 'c8y', 'cumulocity'])
+
+export interface CodemodeNamespace {
+  /**
+   * Sandbox global name, e.g. `c8y` or `dtm`.
+   */
+  name: string
+  /**
+   * Key in the resolved specs: `core` or a service contextPath.
+   */
+  specKey: string
+  /**
+   * The spec object the operations were derived from.
+   */
+  spec: ResolvedSpecs['core']
+  /**
+   * Policy-filtered operations visible to this connection.
+   */
+  operations: DerivedOperation[]
+}
+
+/**
+ * Build the per-connection namespace list: core as `c8y` plus one namespace
+ * per available service spec (sanitized contextPath). Operations blocked by
+ * the connection policy are omitted. Path templates are matched as-is —
+ * a rule targeting a concrete id (e.g. `/inventory/managedObjects/123`) does
+ * not hide the templated method; request-time enforcement still applies.
+ * @param resolved
+ * @param restrictions
+ * @param allowRules
+ */
+export function buildNamespaces(
+  resolved: ResolvedSpecs,
+  restrictions: readonly RestrictionRule[] = [],
+  allowRules: readonly AllowRule[] = [],
+): CodemodeNamespace[] {
+  const visibleOperations = (spec: ResolvedSpecs['core']): DerivedOperation[] =>
+    deriveOperations(spec).filter((op) => !evaluateAccessPolicy(restrictions, allowRules, op.method, op.path).blocked)
+
+  const namespaces: CodemodeNamespace[] = [
+    { name: CORE_NAMESPACE, specKey: 'core', spec: resolved.core, operations: visibleOperations(resolved.core) },
+  ]
+  const used = new Set([CORE_NAMESPACE])
+
+  for (const [contextPath, spec] of Object.entries(resolved.specs)) {
+    const name = sanitizeToolName(contextPath)
+    if (RESERVED_NAMESPACES.has(name) || used.has(name)) {
+      consola.warn(
+        `[codemode] service "${contextPath}" maps to namespace "${name}", which is `
+        + `${RESERVED_NAMESPACES.has(name) ? 'reserved' : 'already used'} — skipping this service.`,
+      )
+      continue
+    }
+    used.add(name)
+    namespaces.push({ name, specKey: contextPath, spec, operations: visibleOperations(spec) })
+  }
+
+  return namespaces
+}
+
+/**
+ * Flatten namespaces into the method-search item list.
+ * @param namespaces
+ */
+export function toSearchableMethods(namespaces: readonly CodemodeNamespace[]): SearchableMethod[] {
+  return namespaces.flatMap((ns) => ns.operations.map((op) => ({
+    target: `${ns.name}.${op.name}`,
+    namespace: ns.name,
+    method: op.name,
+    httpMethod: op.method,
+    apiPath: op.path,
+    summary: op.summary,
+  })))
+}

--- a/src/codemode/operation-naming.ts
+++ b/src/codemode/operation-naming.ts
@@ -1,0 +1,138 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Operation and identifier naming.
+//
+// These names are the primary human/agent-facing surface of the derived
+// namespaces — everything an agent reads in search results, describe output,
+// and code it writes goes through here.
+//
+// Naming rules:
+//   1. An operation with an `operationId` uses it, sanitized into a valid JS
+//      identifier. Verb disambiguation on a shared URL comes from the spec
+//      author's convention (Cumulocity embeds it: getAlarmCollectionResource
+//      vs postAlarmCollectionResource on the same /alarm/alarms path).
+//   2. Without an `operationId`, a readable camelCase name is synthesized
+//      from the HTTP method and path: static segments are PascalCased and
+//      concatenated, `{param}` segments become `By<Param>`:
+//        GET  /alarm/alarms          → getAlarmAlarms
+//        POST /alarm/alarms          → postAlarmAlarms
+//        GET  /alarm/alarms/{id}     → getAlarmAlarmsById
+//        GET  /service/dtm/assets    → getServiceDtmAssets
+//      The verb prefix keeps methods on the same path distinct.
+// ─────────────────────────────────────────────────────────────────────────
+
+const JS_RESERVED = new Set([
+  'abstract',
+  'arguments',
+  'await',
+  'boolean',
+  'break',
+  'byte',
+  'case',
+  'catch',
+  'char',
+  'class',
+  'const',
+  'continue',
+  'debugger',
+  'default',
+  'delete',
+  'do',
+  'double',
+  'else',
+  'enum',
+  'eval',
+  'export',
+  'extends',
+  'false',
+  'final',
+  'finally',
+  'float',
+  'for',
+  'function',
+  'goto',
+  'if',
+  'implements',
+  'import',
+  'in',
+  'instanceof',
+  'int',
+  'interface',
+  'let',
+  'long',
+  'native',
+  'new',
+  'null',
+  'package',
+  'private',
+  'protected',
+  'public',
+  'return',
+  'short',
+  'static',
+  'super',
+  'switch',
+  'synchronized',
+  'this',
+  'throw',
+  'throws',
+  'transient',
+  'true',
+  'try',
+  'typeof',
+  'undefined',
+  'var',
+  'void',
+  'volatile',
+  'while',
+  'with',
+  'yield',
+])
+
+/**
+ * Sanitize a name into a valid JavaScript identifier: separators become `_`,
+ * invalid characters are stripped, digit-leading names get a `_` prefix, and
+ * JS reserved words get a `_` suffix.
+ * @param name
+ */
+export function sanitizeToolName(name: string): string {
+  if (!name)
+    return '_'
+  let sanitized = name.replace(/[-.\s]/g, '_').replace(/[^\w$]/g, '')
+  if (!sanitized)
+    return '_'
+  if (/^\d/.test(sanitized))
+    sanitized = `_${sanitized}`
+  if (JS_RESERVED.has(sanitized))
+    sanitized = `${sanitized}_`
+  return sanitized
+}
+
+export function toPascalCase(value: string): string {
+  return value
+    .replace(/_([a-z])/g, (_, letter: string) => letter.toUpperCase())
+    .replace(/^[a-z]/, (letter) => letter.toUpperCase())
+}
+
+/**
+ * Resolve the namespace method name for one operation: the sanitized
+ * `operationId` when present, otherwise a camelCase name synthesized from
+ * the HTTP method and path (see module header for the rules).
+ * @param method
+ * @param path
+ * @param operationId
+ */
+export function operationName(method: string, path: string, operationId?: string): string {
+  if (operationId)
+    return sanitizeToolName(operationId)
+
+  let name = method.toLowerCase()
+  for (const segment of path.split('/')) {
+    if (!segment)
+      continue
+    if (segment.startsWith('{') && segment.endsWith('}'))
+      name += `By${toPascalCase(sanitizeToolName(segment.slice(1, -1)))}`
+    else
+      name += toPascalCase(sanitizeToolName(segment))
+  }
+  return sanitizeToolName(name)
+}

--- a/src/codemode/type-render.ts
+++ b/src/codemode/type-render.ts
@@ -1,0 +1,318 @@
+import { sanitizeToolName, toPascalCase } from './operation-naming'
+
+// ─────────────────────────────────────────────────────────────────────────
+// JSON Schema → TypeScript declaration rendering.
+//
+// Renders compact inline TS declarations for LLM context on demand —
+// deliberately dependency-free (no json-schema-to-typescript/quicktype:
+// those are file codegen tools, not inline renderers) with a depth guard,
+// cycle detection, and per-method graceful degradation to `unknown`.
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Loose local JSON Schema view — only the fields the renderer reads. Bundled
+ * and discovered OpenAPI schemas arrive as `unknown`; callers cast into this.
+ */
+export interface JsonSchema {
+  $ref?: string
+  anyOf?: JsonSchemaDefinition[]
+  oneOf?: JsonSchemaDefinition[]
+  allOf?: JsonSchemaDefinition[]
+  enum?: unknown[]
+  const?: unknown
+  type?: string | string[]
+  properties?: Record<string, JsonSchemaDefinition>
+  required?: string[]
+  items?: JsonSchemaDefinition | JsonSchemaDefinition[]
+  prefixItems?: JsonSchemaDefinition[]
+  additionalProperties?: JsonSchemaDefinition
+  description?: string
+  format?: string
+  nullable?: boolean
+  minimum?: number
+  maximum?: number
+  example?: unknown
+}
+
+export type JsonSchemaDefinition = JsonSchema | boolean
+
+export interface MethodDescriptor {
+  description?: string
+  inputSchema: JsonSchema
+  outputSchema?: JsonSchema
+}
+
+function escapeControlChar(ch: string): string {
+  const code = ch.charCodeAt(0)
+  return code <= 0x1F || code === 0x7F ? `\\u${code.toString(16).padStart(4, '0')}` : ch
+}
+
+function escapeStringLiteral(value: string): string {
+  let out = ''
+  for (const ch of value) {
+    if (ch === '\\')
+      out += '\\\\'
+    else if (ch === '"')
+      out += '\\"'
+    else if (ch === '\n')
+      out += '\\n'
+    else if (ch === '\r')
+      out += '\\r'
+    else if (ch === '\t')
+      out += '\\t'
+    else if (ch === '\u2028')
+      out += '\\u2028'
+    else if (ch === '\u2029')
+      out += '\\u2029'
+    else out += escapeControlChar(ch)
+  }
+  return out
+}
+
+function quoteProp(name: string): string {
+  if (/^[a-z_$][\w$]*$/i.test(name))
+    return name
+  return `"${escapeStringLiteral(name)}"`
+}
+
+/**
+ * Prevent premature JSDoc closure from star-slash sequences.
+ * @param text
+ */
+function escapeJsDoc(text: string): string {
+  return text.replace(/\*\//g, '*\\/')
+}
+
+interface ConversionContext {
+  root: JsonSchema
+  depth: number
+  seen: Set<unknown>
+  maxDepth: number
+}
+
+/**
+ * Resolve an internal JSON Pointer `$ref` (e.g. `#/definitions/Foo`) against
+ * the root schema. Returns null for external URLs or unresolvable paths.
+ * @param ref
+ * @param root
+ */
+function resolveRef(ref: string, root: JsonSchema): JsonSchemaDefinition | null {
+  if (ref === '#')
+    return root
+  if (!ref.startsWith('#/'))
+    return null
+
+  const segments = ref.slice(2).split('/').map((s) => s.replace(/~1/g, '/').replace(/~0/g, '~'))
+  let current: unknown = root
+  for (const segment of segments) {
+    if (current === null || typeof current !== 'object')
+      return null
+    current = (current as Record<string, unknown>)[segment]
+    if (current === undefined)
+      return null
+  }
+
+  if (typeof current === 'boolean')
+    return current
+  if (current === null || typeof current !== 'object')
+    return null
+  return current as JsonSchema
+}
+
+/**
+ * Apply OpenAPI 3.0 `nullable: true` to a rendered type.
+ * @param result
+ * @param schema
+ */
+function applyNullable(result: string, schema: unknown): string {
+  if (result !== 'unknown' && result !== 'never' && (schema as JsonSchema | undefined)?.nullable === true)
+    return `${result} | null`
+  return result
+}
+
+function renderEnumMember(value: unknown): string {
+  if (value === null)
+    return 'null'
+  if (typeof value === 'string')
+    return `"${escapeStringLiteral(value)}"`
+  if (typeof value === 'object')
+    return JSON.stringify(value) ?? 'unknown'
+  return String(value)
+}
+
+export function jsonSchemaToTypeString(schema: JsonSchemaDefinition, indent: string, ctx: ConversionContext): string {
+  if (typeof schema === 'boolean')
+    return schema ? 'unknown' : 'never'
+  if (ctx.depth >= ctx.maxDepth)
+    return 'unknown'
+  if (ctx.seen.has(schema))
+    return 'unknown'
+
+  ctx.seen.add(schema)
+  const nextCtx: ConversionContext = { ...ctx, depth: ctx.depth + 1 }
+
+  try {
+    if (schema.$ref) {
+      const resolved = resolveRef(schema.$ref, ctx.root)
+      if (!resolved)
+        return 'unknown'
+      return applyNullable(jsonSchemaToTypeString(resolved, indent, nextCtx), schema)
+    }
+
+    if (schema.anyOf)
+      return applyNullable(schema.anyOf.map((s) => jsonSchemaToTypeString(s, indent, nextCtx)).join(' | '), schema)
+    if (schema.oneOf)
+      return applyNullable(schema.oneOf.map((s) => jsonSchemaToTypeString(s, indent, nextCtx)).join(' | '), schema)
+    if (schema.allOf)
+      return applyNullable(schema.allOf.map((s) => jsonSchemaToTypeString(s, indent, nextCtx)).join(' & '), schema)
+
+    if (schema.enum) {
+      if (schema.enum.length === 0)
+        return 'never'
+      return applyNullable(schema.enum.map(renderEnumMember).join(' | '), schema)
+    }
+
+    if (schema.const !== undefined)
+      return applyNullable(renderEnumMember(schema.const), schema)
+
+    const type = schema.type
+
+    if (type === 'string')
+      return applyNullable('string', schema)
+    if (type === 'number' || type === 'integer')
+      return applyNullable('number', schema)
+    if (type === 'boolean')
+      return applyNullable('boolean', schema)
+    if (type === 'null')
+      return 'null'
+
+    if (type === 'array') {
+      if (Array.isArray(schema.prefixItems))
+        return applyNullable(`[${schema.prefixItems.map((s) => jsonSchemaToTypeString(s, indent, nextCtx)).join(', ')}]`, schema)
+      if (Array.isArray(schema.items))
+        return applyNullable(`[${schema.items.map((s) => jsonSchemaToTypeString(s, indent, nextCtx)).join(', ')}]`, schema)
+      if (schema.items)
+        return applyNullable(`${jsonSchemaToTypeString(schema.items, indent, nextCtx)}[]`, schema)
+      return applyNullable('unknown[]', schema)
+    }
+
+    if (type === 'object' || schema.properties) {
+      const props = schema.properties ?? {}
+      const required = new Set(schema.required ?? [])
+      const lines: string[] = []
+
+      for (const [propName, propSchema] of Object.entries(props)) {
+        const optionalMark = required.has(propName) ? '' : '?'
+
+        if (typeof propSchema === 'boolean') {
+          lines.push(`${indent}    ${quoteProp(propName)}${optionalMark}: ${propSchema ? 'unknown' : 'never'};`)
+          continue
+        }
+
+        const propType = jsonSchemaToTypeString(propSchema, `${indent}    `, nextCtx)
+        const desc = propSchema.description ? escapeJsDoc(propSchema.description.replace(/\r?\n/g, ' ')) : undefined
+        // One compact tag line for what the type cannot express: numeric
+        // bounds, a usage example (nearly every core parameter ships one —
+        // for query-language params it is a working expression), and the
+        // format marker (`@format c8y:query` is the hook that sends an
+        // agent to docs.search for the grammar).
+        const tags: string[] = []
+        if (propSchema.minimum !== undefined)
+          tags.push(`@minimum ${propSchema.minimum}`)
+        if (propSchema.maximum !== undefined)
+          tags.push(`@maximum ${propSchema.maximum}`)
+        if (propSchema.example !== undefined) {
+          const example = typeof propSchema.example === 'string' ? propSchema.example : JSON.stringify(propSchema.example) ?? ''
+          tags.push(`@example ${escapeJsDoc(example.replace(/\s*\n\s*/g, ' '))}`)
+        }
+        if (propSchema.format)
+          tags.push(`@format ${escapeJsDoc(propSchema.format)}`)
+        const tagLine = tags.length > 0 ? tags.join(' ') : undefined
+
+        if (desc && tagLine) {
+          lines.push(`${indent}    /**`, `${indent}     * ${desc}`, `${indent}     * ${tagLine}`, `${indent}     */`)
+        } else if (desc || tagLine) {
+          lines.push(`${indent}    /** ${desc ?? tagLine} */`)
+        }
+
+        lines.push(`${indent}    ${quoteProp(propName)}${optionalMark}: ${propType};`)
+      }
+
+      if (schema.additionalProperties) {
+        const valueType = schema.additionalProperties === true
+          ? 'unknown'
+          : jsonSchemaToTypeString(schema.additionalProperties, `${indent}    `, nextCtx)
+        lines.push(`${indent}    [key: string]: ${valueType};`)
+      }
+
+      if (lines.length === 0)
+        return applyNullable(schema.additionalProperties === false ? '{}' : 'Record<string, unknown>', schema)
+
+      return applyNullable(`{\n${lines.join('\n')}\n${indent}}`, schema)
+    }
+
+    if (Array.isArray(type)) {
+      const types = type.map((t) => {
+        if (t === 'string')
+          return 'string'
+        if (t === 'number' || t === 'integer')
+          return 'number'
+        if (t === 'boolean')
+          return 'boolean'
+        if (t === 'null')
+          return 'null'
+        if (t === 'array')
+          return 'unknown[]'
+        if (t === 'object')
+          return 'Record<string, unknown>'
+        return 'unknown'
+      })
+      return applyNullable(types.join(' | '), schema)
+    }
+
+    return 'unknown'
+  } finally {
+    ctx.seen.delete(schema)
+  }
+}
+
+export function jsonSchemaToType(schema: JsonSchema, typeName: string): string {
+  const typeBody = jsonSchemaToTypeString(schema, '', {
+    root: schema,
+    depth: 0,
+    seen: new Set(),
+    maxDepth: 20,
+  })
+  return `type ${typeName} = ${typeBody}`
+}
+
+/**
+ * Render a single method's input/output type aliases and its bare signature
+ * line. No JSDoc wrapper and no `@param` lines — property descriptions
+ * already live as JSDoc inside the input type, so repeating them would only
+ * bloat describe output. Malformed schemas degrade this one method to
+ * `unknown` types instead of failing the whole render.
+ * @param namespace Sandbox namespace the method lives on (for the signature).
+ * @param methodName
+ * @param descriptor
+ */
+export function renderMethodDeclaration(namespace: string, methodName: string, descriptor: MethodDescriptor): { types: string, signature: string } {
+  const typeName = toPascalCase(sanitizeToolName(methodName))
+
+  let inputType: string
+  let outputType: string
+  try {
+    inputType = jsonSchemaToType(descriptor.inputSchema, `${typeName}Input`)
+    outputType = descriptor.outputSchema
+      ? jsonSchemaToType(descriptor.outputSchema, `${typeName}Output`)
+      : `type ${typeName}Output = unknown`
+  } catch {
+    inputType = `type ${typeName}Input = unknown`
+    outputType = `type ${typeName}Output = unknown`
+  }
+
+  return {
+    types: `${inputType}\n${outputType}`,
+    signature: `${sanitizeToolName(namespace)}.${sanitizeToolName(methodName)}(input: ${typeName}Input): Promise<${typeName}Output>`,
+  }
+}

--- a/src/prompts/codemode.ts
+++ b/src/prompts/codemode.ts
@@ -1,206 +1,105 @@
 import { definePrompt } from 'tmcp/prompt'
 import { prompt } from 'tmcp/utils'
 import { c8yMcpServer } from '../server-instance'
+import { buildNamespaces } from '../codemode/namespaces'
 
 function getRuntimeSection(): string {
   return c8yMcpServer.ctx.custom?.env === 'cli'
-    ? '## CLI Runtime\nUse `status` to see the active tenant, stored tenant URLs, and the specs visible to query right now. Use `set-active-tenant` to connect to a tenant. Once set, query and execute use that tenant automatically. When no tenant is active, query falls back to all bundled OpenAPI snapshots for reference and execute is unavailable. If a microservice was just (un)subscribed in the tenant, call `status` with `refresh: true` to bust the 30-minute discovery cache.'
+    ? '## CLI Runtime\nUse `status` to see the active tenant, stored tenant URLs, and the API surface visible right now. Use `set-active-tenant` to connect to a tenant. Once set, codemode uses that tenant automatically. When no tenant is active, discovery (`codemode.search`/`describe`, `docs`) falls back to bundled reference snapshots and live API calls fail with a missing-auth error. If a microservice was just (un)subscribed in the tenant, call `status` with `refresh: true` to bust the 30-minute discovery cache.'
     : '## Server Runtime\nThis deployed MCP server uses the current tenant and the service user attached to this MCP connection. Do not pass tenant-specific credentials or tenant URLs yourself.'
-}
-
-function getOpenApiSection(): string {
-  return `## OpenAPI Specs\nThe query tool exposes a bundled Cumulocity core snapshot via \`coreSpec\`, and any microservice APIs (bundled or live-discovered) available on the tenant via \`serviceSpecs\`.`
 }
 
 export function createCodeModeGuidePrompt() {
   return definePrompt({
     name: 'code-mode-guide',
-    description: 'Guide for the two code-mode tools: query and execute, including available shapes and examples.',
+    description: 'Guide for the codemode tool: discovery, documentation search, and typed API calls in one sandboxed function.',
   }, () => {
     const restrictions = c8yMcpServer.ctx.custom?.restrictions ?? []
     const allowRules = c8yMcpServer.ctx.custom?.allowRules ?? []
-    const resolvedSpecs = c8yMcpServer.ctx.custom?.specs!
-    const serviceKeys = Object.keys(resolvedSpecs.specs)
-    const serviceSpecsType = serviceKeys.length === 0
-      ? 'Record<string, Spec>'
-      : `{\n${serviceKeys.map((k) => `  ${k}: Spec`).join('\n')}\n}`
+    const resolvedSpecs = c8yMcpServer.ctx.custom?.specs
+    const namespaceNames = resolvedSpecs
+      ? buildNamespaces(resolvedSpecs, restrictions, allowRules).map((ns) => ns.name)
+      : ['c8y']
     const policyLines = [
       ...restrictions.map((rule) => `- deny: \`${rule.source}\``),
       ...allowRules.map((rule) => `- allow: \`${rule.source}\``),
     ]
     const restrictionSection = policyLines.length > 0
-      ? `\n## Current Connection Access Policy\n${policyLines.join('\n')}\n\nThe \`query\` tool still shows the raw bundled OpenAPI specs for this connection. These rules are enforced when requests are executed. Disabled bundled OpenAPI parts affect execute policy rather than hiding specs from query.\n`
+      ? `\n## Current Connection Access Policy\n${policyLines.join('\n')}\n\nOperations blocked by these rules are omitted from discovery (search/describe) entirely, and any live request that matches a deny rule (or misses the allow list) fails before reaching the tenant.\n`
       : ''
 
     return prompt.message(
       `# Cumulocity Code Mode
 
-You have two MCP tools available.
+One MCP tool: \`codemode\`. It runs an async JavaScript function in a sandbox where API discovery, documentation, and live Cumulocity API calls are all available as globals — a full find-inspect-call cycle fits in a single tool invocation.
 
-## query
-Use \`query\` to inspect OpenAPI specs (bundled core or discovered microservices).
-
-- Input: a **zero-parameter** JavaScript function expression
-- Do NOT declare \`coreSpec\` or \`serviceSpecs\` as function parameters — they are already declared as top-level constants in the surrounding scope
-- \`coreSpec\` is for the main Cumulocity REST surface: inventory, alarms, events, measurements, identity, device control, users, tenants, audit
-- \`serviceSpecs\` contains microservice APIs available on the current tenant, keyed by contextPath (e.g. \`serviceSpecs.dtm\`). An entry is present if the service is actually reachable on this tenant — use \`serviceSpecs.<key>\` or \`'<key>' in serviceSpecs\` to check availability. Paths are already prefixed for direct use with \`cumulocity.request()\`
-- Return the exact value you want back from that function
-- Sync and async functions are both supported
-- Strings are returned as-is; other results are returned as JSON text
-- The \`query\` tool shows the raw bundled OpenAPI specs for the selected build
-- The current MCP connection may still block \`execute\` requests through deny rules and/or an allow list even when an operation exists in a visible spec
-- Prefer endpoint-native filters/expansions/selectors over manual traversal loops when they can express the same result
-- Inspect operation \`parameters\` first, then use referenced \`tags\` documentation to discover domain query-language features and constraints
-- Fall back to custom traversal/aggregation only when endpoint-native options cannot express the required output
-
-### Available Shape
-
-The function must accept **no parameters**. The bindings below are scope-level constants, not function arguments.
+## Globals
 
 \`\`\`ts
-type OperationInfo = {
-  summary?: string
-  description?: string
-  tags?: string[]
-  parameters?: Array<{ name: string, in: string, required?: boolean, schema?: unknown, description?: string }>
-  requestBody?: { required?: boolean, content?: Record<string, { schema?: unknown }> }
-  responses?: Record<string, { description?: string, content?: Record<string, { schema?: unknown }> }>
+declare const codemode: {
+  search: (query: string | string[]) => Promise<{ results: Array<{ target: string, namespace: string, method: string, httpMethod: string, apiPath: string, summary?: string, score: number }>, total: number, truncated: boolean }>
+  describe: (target?: string | string[]) => Promise<{ target: string, kind: 'overview' | 'method', content: string } | Array<{ target: string, kind: 'overview' | 'method', content: string }>>
 }
 
-type PathItem = {
-  get?: OperationInfo
-  post?: OperationInfo
-  put?: OperationInfo
-  patch?: OperationInfo
-  delete?: OperationInfo
-}
-
-type Spec = {
-  paths: Record<string, PathItem>
-  tags?: Array<{ name: string, description?: string }>
-}
-
-declare const coreSpec: Spec
-declare const serviceSpecs: ${serviceSpecsType}
-\`\`\`
-
-### Tag Documentation
-
-Both \`coreSpec\` and each \`serviceSpecs\` entry have a top-level \`tags\` array with domain documentation. 
-Each operation may reference one or more tags by name via its \`tags[]\` field. When you need deeper context 
-about an API area or resource, look up the matching tag entry by name and read its \`description\`.
-
-\`\`\`js
-// Get all tag names to find relevant documentation areas - use first when you know the domain but not the exact path
-() => serviceSpecs.dtm?.tags?.map(t => t.name)
-\`\`\`
-
-\`\`\`js
-// Find documentation for a known tag name
-() => serviceSpecs.dtm?.tags?.find(t => t.name === 'Assets')?.description
-\`\`\`
-
-\`\`\`js
-// Follow the tag reference from a specific operation
-() => {
-  const op = serviceSpecs.dtm?.paths['/service/dtm/assets/linkedSeries']?.get
-  const tagName = op?.tags?.[0]
-  return tagName ? serviceSpecs.dtm?.tags?.find(t => t.name === tagName)?.description : null
+declare const docs: {
+  search: (query: string, opts?: { limit?: number, fuzzy?: number, prefix?: boolean, minScore?: number, maxTextLength?: number }) => Promise<Array<{ id: string, title: string, text: string, truncated: boolean, kind: 'topic' | 'overview', namespace: string, score: number }>>
+  read: (id: string) => Promise<{ id: string, title: string, text: string, kind: string, namespace: string }>
 }
 \`\`\`
 
-Examples (all zero-parameter — note no arguments in the arrow function signatures):
-\`\`\`js
-() => Object.keys(coreSpec.paths).filter((path) => path.includes('inventory'))
-\`\`\`
+API namespaces currently visible: ${namespaceNames.map((n) => `\`${n}\``).join(', ')}.
 
-\`\`\`js
-() => {
-  const op = serviceSpecs.dtm?.paths['/service/dtm/assets']?.get
-  return op?.parameters
-}
-\`\`\`
+- \`c8y\` is the Cumulocity core REST surface (inventory, alarms, events, measurements, identity, device control, users, tenants, audit). Always present.
+- Each additional namespace is a microservice available on the current tenant (e.g. \`dtm\`). A namespace exists only when the service is actually reachable.
+- Every namespace has one typed method per API operation plus a low-level escape hatch: \`<ns>.request({ method, path, params?, body?, headers? })\` with tenant-relative paths. The escape hatch is a last resort — reach for it only after repeated searches found no derived method.
+- Method inputs are a single flat object: path/query/header parameters as top-level keys, the request payload under \`body\`.
 
-\`\`\`js
-() => coreSpec.paths['/inventory/managedObjects']?.get
-\`\`\`
+## Discovery Workflow — ALWAYS in this order: describe() → search → describe(shortlist) → call.
 
-\`\`\`js
-() => {
-  const op = coreSpec.paths['/inventory/managedObjects']?.get
-  const tagName = op?.tags?.[0]
-  return tagName ? coreSpec.tags?.find((t) => t.name === tagName)?.description : null
-}
-\`\`\`
+The expensive mistake is a hasty API call: an unparameterized request returns large payloads that flood your context. Search and describe are cheap — spend calls there first.
 
-## execute
-Use \`execute\` when you want to call the real Cumulocity API.
+Do NOT rely on prior knowledge of these APIs and do not assume anything: the available namespaces and their capabilities are tenant-specific and discovered at runtime. What you think you know about an API may be outdated or outclassed by a service on this tenant you have never seen. Verify through search, describe, and docs.
 
-- Input: a JavaScript function expression
-- The top-level binding \`cumulocity\` is available automatically
-- It can call \`await cumulocity.request({ method, path, ... })\`
-- Do not build auth headers or tenant URLs yourself
-- Return the value you want from that function; async functions are usually the right choice here
-- On success, the returned value is sent back in Toon format
-- If execution is blocked or fails, execute returns a plain text error message
-- If a request is blocked by MCP connection policy, \`execute\` returns an explanatory text message — that is an access restriction, not a Cumulocity API failure
+1. \`codemode.describe()\` (no target) — ALWAYS start here. It lists the API namespaces on THIS tenant with their responsibilities. A domain service (asset management, data preparation, …) usually has a far better API for its domain — server-side hierarchy queries, bulk operations — than composing the generic core API. Decide which namespaces could own the problem's domain, and search with each of their vocabularies.
+2. \`codemode.search(["phrasing 1", "phrasing 2"])\` — ranked fuzzy search over method names, REST paths, and summaries (top 20 by score); multiple phrasings are unioned. Results usually contain several overlapping endpoints (single-item, collection, count, by-external-id, bulk variants) — read all summaries and shortlist every candidate that could satisfy the request in ONE call, don't grab the first hit. If all results come from one namespace, re-check the overview — another namespace may own the domain with a stronger API. If the expected method is missing, re-search with other domain words before concluding it does not exist.
+3. \`codemode.describe(["<ns>.<methodA>", "<ns>.<methodB>"])\` (max 5) — ALWAYS describe before calling, and describe the whole shortlist in one call. Compare the input types: prefer the method whose parameters push the work to the server — query/filter parameters (especially ones documenting a query grammar), hierarchy/recursive selectors, bulk endpoints — over methods that would force per-item calls or client-side filtering. Describe is method-only by design — there is no whole-namespace dump.
+4. \`docs.search("keywords")\` — fuzzy full-text search over documentation topics: domain query languages, concepts, API-area guides. When a parameter description references a concept, read the docs before guessing values.
+5. \`docs.read(id)\` — returns the FULL text; read it to the END and never \`.slice()\` it. The operator or function you need is often documented in the later sections — a blind cut loses exactly the crucial part. Long doc topics are the one output where length is justified.
 
-### Available Shape
-\`\`\`ts
-interface CumulocityRequestOptions {
-  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
-  path: string
-  body?: unknown
-  headers?: Record<string, string>
-}
+## Execution Guidance
 
-declare const cumulocity: {
-  request<T = unknown>(options: CumulocityRequestOptions): Promise<T>
-}
-\`\`\`
+- Prefer ONE call that pushes the work to the server (filters, query parameters, pageSize, sorting, expansions) over fetching broadly and filtering in your code, and over chains of per-item calls.
+- If you catch yourself looping over items to call an API for each one, go back to search — a collection, query, or bulk endpoint usually exists.
+- Return only the data needed to answer — never return raw unfiltered collections.
+- On success the returned value is encoded in Toon format. Errors return plain text.
+- A blocked request message means a connection-level access restriction — not a Cumulocity API failure. Retrying through the same connection will not succeed.
 
-Examples:
+## Examples
+
 \`\`\`js
 async () => {
-  return await cumulocity.request({
-    method: 'GET',
-    path: '/inventory/managedObjects?pageSize=5',
-  })
+  const { results } = await codemode.search('managed objects by fragment')
+  return (await codemode.describe(results[0].target)).content
 }
 \`\`\`
 
 \`\`\`js
 async () => {
-  const alarms = await cumulocity.request({
-    method: 'GET',
-    path: '/alarm/alarms?pageSize=10',
-  })
-
-  return alarms.alarms
+  const hits = await docs.search('inventory query language')
+  const grammar = hits.length > 0 ? (await docs.read(hits[0].id)).text : null
+  const devices = await c8y.getManagedObjectCollectionResource({ query: "$filter=(type eq 'c8y_Device')", pageSize: 5 })
+  return { grammar: grammar?.slice(0, 200), devices }
 }
 \`\`\`
 
 \`\`\`js
 async () => {
-  return await cumulocity.request({
-    method: 'GET',
-    path: '/service/dtm/assets?pageSize=20',
-  })
+  return await c8y.request({ method: 'GET', path: '/service/dtm/assets', params: { pageSize: 20 } })
 }
 \`\`\`
 
 ${getRuntimeSection()}
-
-${getOpenApiSection()}
-
-## Working Pattern
-1. Use \`query\` to find the right endpoint, parameters, and response shape.
-2. Use operation tags and tag documentation to discover domain-specific query language/functions before implementing custom control flow.
-3. Prefer endpoint-native filters/expansions/selectors before manual traversal.
-4. Use \`execute\` with a small async function expression that calls that endpoint and returns only the needed result.
-5. Keep functions small and return only the data needed for the next reasoning step.
-${restrictionSection}
-`,
+${restrictionSection}`,
     )
   })
 }

--- a/src/tools/active-tenant.ts
+++ b/src/tools/active-tenant.ts
@@ -9,9 +9,9 @@ import { getBundledOnlySpecs } from '../utils/spec-resolution'
 /**
  * Clear the active tenant everywhere it is recorded: persistence file,
  * in-memory CLI context, and the shared MCP custom context. The custom-
- * context update is what makes subsequent `query` / `execute` calls observe
- * the no-tenant state — query falls back to bundled-only specs, execute
- * errors loudly on missing auth.
+ * context update is what makes subsequent `codemode` calls observe the
+ * no-tenant state — discovery falls back to bundled-only specs, live API
+ * calls error loudly on missing auth.
  *
  * Exported so the drift-recovery paths (status, CLI startup) can reuse
  * the same teardown the explicit reset uses.
@@ -31,7 +31,7 @@ export function createSetActiveTenantTool() {
     {
       name: 'set-active-tenant',
       title: 'Set Active Tenant',
-      description: 'Set the Cumulocity tenant for this CLI session, or pass tenantUrl: null to clear the active tenant. The tenantUrl must match one returned by the status tool. The selection is persisted across sessions so you only need to call this once (or when switching tenants). Clearing falls back to bundled-only browsing — query still works but execute is unavailable until a tenant is set again.',
+      description: 'Set the Cumulocity tenant for this CLI session, or pass tenantUrl: null to clear the active tenant. The tenantUrl must match one returned by the status tool. The selection is persisted across sessions so you only need to call this once (or when switching tenants). Clearing falls back to bundled-only browsing — codemode discovery still works but live API calls are unavailable until a tenant is set again.',
       schema: v.object({
         tenantUrl: v.nullable(
           v.pipe(
@@ -47,7 +47,7 @@ export function createSetActiveTenantTool() {
         if (input.tenantUrl === null) {
           resetActiveTenant()
           return tool.text(
-            'Active tenant cleared. Query now falls back to all bundled OpenAPI snapshots; execute is unavailable until you set a tenant. Call set-active-tenant with a tenantUrl from the status tool to reconnect.',
+            'Active tenant cleared. Codemode discovery now falls back to all bundled OpenAPI snapshots; live API calls are unavailable until you set a tenant. Call set-active-tenant with a tenantUrl from the status tool to reconnect.',
           )
         }
 
@@ -66,7 +66,7 @@ export function createSetActiveTenantTool() {
         const ctx = await setCliTenantContext(input.tenantUrl)
 
         // Push auth and specs into the shared MCP context so all subsequent
-        // tool calls (query, execute) read from it without needing to re-resolve.
+        // codemode calls read from it without needing to re-resolve.
         const custom = c8yMcpServer.ctx.custom
         if (!custom) {
           // should never happen
@@ -80,7 +80,7 @@ export function createSetActiveTenantTool() {
           .filter(([, v]) => v !== null)
           .map(([k]) => k)
         return tool.text(
-          `Active tenant set to ${input.tenantUrl}. Available specs: ${specKeys.join(', ') || '(none)'}. You can now use query and execute.`,
+          `Active tenant set to ${input.tenantUrl}. Available specs: ${specKeys.join(', ') || '(none)'}. You can now use the codemode tool.`,
         )
       } catch (error) {
         return tool.error(error instanceof Error ? error.message : String(error))

--- a/src/tools/codemode.ts
+++ b/src/tools/codemode.ts
@@ -1,187 +1,120 @@
 import { defineTool } from 'tmcp/tool'
 import { tool } from 'tmcp/utils'
 import * as v from 'valibot'
-import { execute, query } from '../codemode/execute'
+import { execute } from '../codemode/execute'
 import type { Env } from '../types'
 
-function createCodeSchema(description: string) {
-  return v.pipe(v.string(), v.minLength(1), v.description(description))
-}
-
-function getOpenApiNote(): string {
-  return 'This MCP exposes a bundled Cumulocity core OpenAPI snapshot. Use `coreSpec` for inventory, alarms, events, measurements, users, tenants, and the broader Cumulocity REST surface. Bundled and discovered microservice APIs available on the current tenant are exposed via `serviceSpecs` (keyed by contextPath). Prefer endpoint-native parameters (filters, expansions, paging, sorting) over manual multi-call traversal when they can express the request.'
-}
-
-function getQuerySafetyPreface(env: Env): string {
-  if (env === 'server')
-    return 'Searches the bundled and discovered OpenAPI specs available to the current connection.'
-  return '**Read first.** The active tenant is global to this CLI session and can be flipped between calls by `set-active-tenant`. Every result ends with a footer line naming the active tenant (or noting there is none) so you can verify which tenant the result reflects before acting on it. If the footer says "no active tenant" you are looking at bundled reference snapshots — call `status` to see stored credentials and `set-active-tenant` to connect before relying on the result.'
-}
-
-function getExecuteSafetyPreface(env: Env): string {
-  const sharedFooter = 'An endpoint visible in `query` may still return 404 from `execute` when the service is not actually installed on the current tenant.'
+function getSafetyPreface(env: Env): string {
+  const sharedFooter = 'A method visible in discovery may still return 404 when the service is not actually installed on the current tenant.'
   if (env === 'server')
     return sharedFooter
   return [
-    '**Read first.** Every result starts with an `Executed against tenant: <url>` marker line followed by a blank line. Verify it matches the tenant you intend to mutate before reporting the result. The active tenant is global to this CLI session and can be flipped between calls by `set-active-tenant`. If no tenant is active `execute` fails with a missing-auth error — call `status` and `set-active-tenant` to connect first.',
+    '**Read first.** Every result starts with a marker line: either `Executed against tenant: <url>` or a no-active-tenant notice. Verify it matches the tenant you intend to act on before reporting the result. The active tenant is global to this CLI session and can be flipped between calls by `set-active-tenant`. Without an active tenant, discovery (codemode/docs) works against bundled reference snapshots but live API calls fail with a missing-auth error — call `status` and `set-active-tenant` to connect.',
     '',
     sharedFooter,
   ].join('\n')
 }
 
-function getQueryResultDescription(env: Env): string {
-  if (env === 'server')
-    return 'If your function returns a string it is returned as-is. Any other value is returned as JSON.'
-  return 'If your function returns a string it is returned as-is. Any other value is returned as JSON. A footer line naming the active tenant (or noting there is none) is appended after a `---` separator on every successful result.'
-}
-
-export function createQueryTool(env: Env) {
+export function createCodemodeTool(env: Env) {
   return defineTool({
-    name: 'query',
-    title: 'Query OpenAPI Specs',
-    description: `${getQuerySafetyPreface(env)}
+    name: 'codemode',
+    title: 'Cumulocity Code Mode',
+    description: `${getSafetyPreface(env)}
 
-Search the bundled and discovered OpenAPI specs by evaluating a JavaScript function.
+Run an async JavaScript function against the Cumulocity API. Discovery, documentation, and typed API calls all happen inside one function — find what you need and call it in the same run.
 
-${getOpenApiNote()}
+The expensive mistake is a hasty API call: an unparameterized request returns large payloads that flood your context. \`search\` and \`describe\` are cheap — spend calls there first.
 
-Available bindings (all zero-parameter — do NOT declare these as function parameters):
+Do NOT rely on prior knowledge of these APIs and do not assume anything: the available namespaces and their capabilities are tenant-specific and discovered at runtime. What you think you know about an API may be outdated or may be outclassed by a service on this tenant you have never seen. Verify through search, describe, and docs.
+
+Available globals (do NOT declare these as function parameters):
 
 \`\`\`ts
-type OperationInfo = {
-  summary?: string
-  description?: string
-  tags?: string[]
-  parameters?: Array<{ name: string, in: string, required?: boolean, schema?: unknown, description?: string }>
-  requestBody?: { required?: boolean, content?: Record<string, { schema?: unknown }> }
-  responses?: Record<string, { description?: string, content?: Record<string, { schema?: unknown }> }>
+declare const codemode: {
+  /** Ranked fuzzy search over API method names, REST paths, and summaries. Returns the top 20 by score. Pass several phrasings at once — results are unioned. */
+  search: (query: string | string[]) => Promise<{
+    results: Array<{ target: string, namespace: string, method: string, httpMethod: string, apiPath: string, summary?: string, score: number }>
+    total: number
+    truncated: boolean
+  }>
+  /**
+   * No target: overview of the namespaces on THIS tenant and their
+   * responsibilities — ALWAYS your first call.
+   * "namespace.method": the typed interface for ONE method — signature,
+   * input/output types with OpenAPI docs as JSDoc, related doc ids.
+   * Array of method targets (max 5): describe a shortlist in one call and
+   * COMPARE their input types before picking.
+   * Namespace-only targets are rejected — use search to find methods.
+   */
+  describe: (target?: string | string[]) => Promise<
+    { target: string, kind: 'overview' | 'method', content: string }
+    | Array<{ target: string, kind: 'overview' | 'method', content: string }>
+  >
 }
 
-type PathItem = {
-  get?: OperationInfo
-  post?: OperationInfo
-  put?: OperationInfo
-  patch?: OperationInfo
-  delete?: OperationInfo
+declare const docs: {
+  /** Fuzzy full-text search over prose documentation topics: domain query languages, concepts, API-area guides. Per-method details live in codemode.describe instead. */
+  search: (query: string, opts?: { limit?: number, fuzzy?: number, prefix?: boolean, minScore?: number, maxTextLength?: number }) => Promise<Array<{
+    id: string, title: string, text: string, truncated: boolean, kind: 'topic' | 'overview', namespace: string, score: number
+  }>>
+  /**
+   * Full untruncated text of a documentation entry. Return it WHOLE — never
+   * slice or truncate doc text: the crucial capability (an operator, a
+   * function, a constraint) is often documented near the end, and a blind
+   * cut loses exactly the part you searched for. Long doc topics are the
+   * one output where length is justified.
+   */
+  read: (id: string) => Promise<{ id: string, title: string, text: string, kind: string, namespace: string }>
 }
 
-type Spec = {
-  paths: Record<string, PathItem>
-  tags?: Array<{ name: string, description?: string }>
-}
-
-declare const coreSpec: Spec
-declare const serviceSpecs: Record<string, Spec>
+// API namespaces: \`c8y\` (Cumulocity core — always present) plus one global
+// per microservice available on the current tenant (e.g. \`dtm\`), each with
+// one typed method per operation and a low-level escape hatch:
+//   await c8y.getManagedObjectCollectionResource({ pageSize: 5 })
+//   await c8y.request({ method: 'GET', path: '/inventory/managedObjects', params: { pageSize: 5 } })
+// The request escape hatch is a LAST resort: use it only after repeated
+// searches found no method — a derived method exists for nearly every operation.
 \`\`\`
 
-- \`coreSpec\` — the main Cumulocity REST surface. Always present.
-- \`serviceSpecs\` — microservice APIs available on the active tenant, keyed by contextPath. An entry is **present iff** the service is reachable on this tenant. Paths are already prefixed (e.g. \`/service/myservice/items\`). Check with \`serviceSpecs.dtm\` (or \`'dtm' in serviceSpecs\`) before reaching in.
-- Prefer checking operation \`parameters\` before designing multi-step logic. If filters, expansions, or selectors exist, use them first.
-- When an operation has \`tags\`, read the matching tag descriptions to discover domain-specific query language/functions and recommended usage patterns.
-- Fall back to custom traversal/aggregation only when endpoint-native options cannot express the needed result shape.
+Workflow — ALWAYS in this order: describe() → search → describe(shortlist) → call.
+1. \`codemode.describe()\` (no target) — ALWAYS start here. It lists the API namespaces on THIS tenant with their responsibilities. A domain service (asset management, data preparation, …) usually has a far better API for its domain — server-side hierarchy queries, bulk operations — than composing the generic core API. Decide which namespaces could own the problem's domain, and search with each of their vocabularies.
+2. \`codemode.search(["phrasing 1", "phrasing 2"])\` — find candidate methods (top 20 by score). Results usually contain several overlapping endpoints (single-item, collection, count, by-external-id, bulk variants) — read all summaries and shortlist every candidate that could satisfy the request in ONE call, don't grab the first hit. If all results come from one namespace, re-check the overview — another namespace may own the domain with a stronger API. If the expected method is missing, re-search with other domain words before concluding it does not exist — check \`total\` too.
+3. \`codemode.describe(["ns.methodA", "ns.methodB"])\` (max 5) — ALWAYS describe before calling, and describe the whole shortlist in one call. Compare the input types: prefer the method whose parameters push the work to the server — query/filter parameters (especially ones marked \`@format c8y:query\` or documenting a query grammar), hierarchy/recursive selectors, bulk endpoints — over methods that would force per-item calls or client-side filtering. Describing five candidates costs almost nothing; one wrong or unfiltered API call costs more context than all your discovery combined.
+4. \`docs.search("...")\` / \`docs.read(id)\` — when a parameter references domain syntax you don't know, read the docs before guessing values. Read doc texts to the END — never \`.slice()\` them: the operator or function you need is often documented in the later sections, and a blind cut loses exactly the crucial part.
+5. Call the winner: \`await c8y.someMethod({ ...params, body })\` (path/query/header parameters and \`body\` share one flat input object). ONE well-parameterized call beats fetching broadly and filtering in your code, and beats chains of per-item calls. If you catch yourself looping over items to call an API for each one, go back to step 1 — a collection, query, or bulk endpoint usually exists.
+6. Return only the data needed to answer — never return raw unfiltered collections.
 
-Both \`coreSpec\` and each \`serviceSpecs\` entry have a top-level \`tags\` array with domain documentation. Each operation may reference one or more tags by name via its \`tags[]\` field. When you need deeper context about an API area or resource, look up the matching tag entry by name and read its \`description\`.
+Discovery and API calls can be combined in a single run. Methods blocked by the connection access policy are omitted from discovery entirely; a blocked live request fails with an explanatory message — that is a connection-level access restriction, not a Cumulocity API failure, and retrying will not help.
 
-\`\`\`js
-// Get all tag names to find relevant documentation areas — use first when you know the domain but not the exact path
-() => serviceSpecs.dtm?.tags?.map(t => t.name)
-\`\`\`
-
-\`\`\`js
-// Find documentation for a known tag name
-() => serviceSpecs.dtm?.tags?.find(t => t.name === 'Assets')?.description
-\`\`\`
-
-\`\`\`js
-// Follow the tag reference from a specific operation
-() => {
-  const op = serviceSpecs.dtm?.paths['/service/dtm/assets/linkedSeries']?.get
-  const tagName = op?.tags?.[0]
-  return tagName ? serviceSpecs.dtm?.tags?.find(t => t.name === tagName)?.description : null
-}
-\`\`\`
-
-${getQueryResultDescription(env)}
-The current MCP connection may still block \`execute\` calls even when an operation is visible in a spec.
-
-Examples:
-\`() => Object.keys(serviceSpecs)\`
-\`() => Object.keys(coreSpec.paths).filter((p) => p.includes('inventory'))\`
-\`() => serviceSpecs.dtm?.paths['/service/dtm/assets']?.get\`
-
-\`\`\`js
-() => {
-  const op = coreSpec.paths['/inventory/managedObjects']?.get
-  return { summary: op?.summary, parameters: op?.parameters }
-}
-\`\`\`
-`,
-    schema: v.object({
-      code: createCodeSchema(
-        'A zero-parameter JavaScript function expression. coreSpec and serviceSpecs are already declared as top-level constants — do not redeclare them as function parameters. Return the final result. Async functions are supported.',
-      ),
-    }),
-  }, async (input) => {
-    try {
-      return tool.text(await query(input.code))
-    } catch (error) {
-      return tool.error(error instanceof Error ? error.message : String(error))
-    }
-  })
-}
-
-export function createExecuteTool(env: Env) {
-  return defineTool({
-    name: 'execute',
-    title: 'Execute Cumulocity API Call',
-    description: `${getExecuteSafetyPreface(env)}
-
-Execute JavaScript code against the Cumulocity API. Use the query tool first to find the right endpoint, then write an async function that calls cumulocity.request().
-
-${getOpenApiNote()}
-
-Available in your function:
-
-\`\`\`ts
-type CumulocityRequestOptions = {
-  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE'
-  path: string
-  body?: unknown
-  headers?: Record<string, string>
-}
-
-declare const cumulocity: {
-  request<T = unknown>(options: CumulocityRequestOptions): Promise<T>
-}
-\`\`\`
-
-Your code must evaluate to an async function. Return the final value you want.
-
-Execution strategy:
-- First inspect endpoint parameters with \`query\` and choose the lowest-call approach.
-- Read relevant tag documentation to discover domain query language/features before writing custom control flow.
-- Prefer native API filters/expansions/selectors over manual traversal loops when both satisfy the request.
-- Use manual traversal only when endpoint-native options cannot express the needed result shape.
-
-On success the result is returned in Toon format. On a blocked or failed execution a plain text message is returned. A blocked message means the operation was denied by connection policy — retrying through the same connection will not help.
+Your code must evaluate to an async function. Return the final value you want; on success it is returned in Toon format.
 
 Examples:
 \`\`\`js
 async () => {
-  return await cumulocity.request({ method: 'GET', path: '/inventory/managedObjects?pageSize=5' })
+  const { results } = await codemode.search('alarms by severity')
+  const { content } = await codemode.describe(results[0].target)
+  return content
 }
+\`\`\`
 
+\`\`\`js
 async () => {
-  return await cumulocity.request({
-    method: 'GET',
-    path: '/alarm/alarms?pageSize=10&type=myAlarmType',
-  })
+  return await c8y.getAlarmCollectionResource({ pageSize: 10, severity: 'MAJOR' })
+}
+\`\`\`
+
+\`\`\`js
+async () => {
+  const hits = await docs.search('inventory query language syntax')
+  return hits.length > 0 ? (await docs.read(hits[0].id)).text : 'no docs found'
 }
 \`\`\`
 `,
     schema: v.object({
-      code: createCodeSchema(
-        'An async JavaScript function expression. The top-level binding `cumulocity` is available automatically. Return the final result. `await` is supported.',
+      code: v.pipe(
+        v.string(),
+        v.minLength(1),
+        v.description('An async JavaScript function expression. The globals codemode, docs, c8y, and per-service namespaces are available automatically — do not declare them as parameters. Return the final result.'),
       ),
     }),
   }, async (input) => {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,8 +1,7 @@
-import { createExecuteTool, createQueryTool } from './codemode'
+import { createCodemodeTool } from './codemode'
 
 export function createTools(env: 'cli' | 'server') {
   return [
-    createQueryTool(env),
-    createExecuteTool(env),
+    createCodemodeTool(env),
   ]
 }

--- a/src/tools/status.ts
+++ b/src/tools/status.ts
@@ -4,13 +4,13 @@ import { tool } from 'tmcp/utils'
 import * as v from 'valibot'
 import { getCliTenantContext } from '../cli/tenant-context'
 import { c8yMcpServer } from '../server-instance'
-import { getCachedDiscovery, refreshApiSpecs } from '../utils/api-discovery'
+import { refreshApiSpecs } from '../utils/api-discovery'
 import { resolveSpecs } from '../utils/spec-resolution'
 import { resetActiveTenant } from './active-tenant'
 
 const STATUS_TOOL_DESCRIPTION
-  = 'Show the current CLI status: stored tenant credentials, which tenant query and execute will hit, and the specs visible to query right now. '
-    + 'If no tenant is active, query falls back to all bundled OpenAPI snapshots and execute is unavailable — set-active-tenant must be called first. '
+  = 'Show the current CLI status: stored tenant credentials, which tenant the codemode tool will hit, and the API namespaces visible right now. '
+    + 'If no tenant is active, codemode discovery falls back to all bundled OpenAPI snapshots and live API calls are unavailable — set-active-tenant must be called first. '
     + 'This tool also self-heals: if the active tenant has lost its stored credentials it is automatically reset before the status is reported.\n\n'
     + 'Pass `refresh: true` to force a fresh API spec discovery against the active tenant. Use this after subscribing or unsubscribing a microservice in the tenant — otherwise discovered specs stay cached for 30 minutes. '
     + 'If no tenant is active, `refresh: true` is a noop.'
@@ -50,7 +50,7 @@ async function buildCliStatus(refresh: boolean): Promise<string> {
     active = null
     sections.push(
       `Active tenant ${cleared} was cleared automatically because no credentials are stored for it. `
-      + 'Query now falls back to all bundled OpenAPI snapshots; execute is unavailable until you set a tenant.',
+      + 'Codemode discovery now falls back to all bundled OpenAPI snapshots; live API calls are unavailable until you set a tenant.',
     )
   }
 
@@ -67,7 +67,7 @@ async function buildCliStatus(refresh: boolean): Promise<string> {
   if (active) {
     sections.push(`Active tenant: ${active.tenantUrl}`)
   } else {
-    sections.push('Active tenant: (none) — query falls back to all bundled OpenAPI snapshots; execute is unavailable until set-active-tenant is called. Visibility in the bundled-only mode does NOT guarantee any service is installed on any tenant.')
+    sections.push('Active tenant: (none) — codemode discovery falls back to all bundled OpenAPI snapshots; live API calls are unavailable until set-active-tenant is called. Visibility in the bundled-only mode does NOT guarantee any service is installed on any tenant.')
   }
 
   if (creds.length === 0) {
@@ -77,21 +77,8 @@ async function buildCliStatus(refresh: boolean): Promise<string> {
     sections.push(`Stored credentials:\n${lines}`)
   }
 
-  // For label enrichment, look up the active tenant's tenantId from the
-  // keyring. The CLI tenant context only carries tenantUrl, so we rely on
-  // the credentials lookup. Best-effort: failure just drops the labels.
-  let activeTenantId: string | undefined
-  if (active) {
-    try {
-      activeTenantId = (await globalThis._getCredentialsByTenantUrl(active.tenantUrl)).tenantId
-    } catch {
-      activeTenantId = undefined
-    }
-  }
-  sections.push(await buildVisibleSpecsSection(activeTenantId))
-
   if (!active && creds.length > 0) {
-    sections.push('Next step: call set-active-tenant with one of the tenant URLs above before using query or execute.')
+    sections.push('Next step: call set-active-tenant with one of the tenant URLs above before making live API calls through codemode.')
   }
 
   return sections.join('\n\n')
@@ -114,7 +101,7 @@ async function refreshCliActiveTenant(tenantUrl: string): Promise<string> {
     const resolved = resolveSpecs(result.specs, result.installedContextPaths)
 
     // Update both the CLI-local context and the shared MCP custom context
-    // so subsequent query/execute calls see the new surface immediately.
+    // so subsequent codemode calls see the new surface immediately.
     const cliCtx = getCliTenantContext()
     if (cliCtx) {
       cliCtx.specs = resolved
@@ -126,59 +113,5 @@ async function refreshCliActiveTenant(tenantUrl: string): Promise<string> {
     return `Refreshed API discovery for ${tenantUrl}: ${result.specs.length} spec(s) downloaded, ${result.installedContextPaths.size} subscribed application(s).`
   } catch (err) {
     return `Refresh failed for ${tenantUrl}: ${err instanceof Error ? err.message : String(err)}`
-  }
-}
-
-/**
- * Render the "Visible specs" block. Awaits the cached discovery promise
- * (if any) to enrich entries with app/spec labels; falls back to a bare
- * contextPath list when the cache is cold or the lookup fails.
- * @param tenantId - Tenant ID used as the discovery cache key for label enrichment.
- */
-async function buildVisibleSpecsSection(tenantId: string | undefined): Promise<string> {
-  const specs = c8yMcpServer.ctx.custom?.specs
-  if (!specs) {
-    return 'Visible specs: (none) — no tenant context resolved.'
-  }
-
-  const labels = await getDiscoveryLabels(tenantId)
-
-  const lines: string[] = ['- core (Cumulocity core API, always present as `coreSpec`)']
-  const serviceKeys = Object.keys(specs.specs).sort()
-  if (serviceKeys.length === 0) {
-    lines.push('  (no service specs available)')
-  } else {
-    for (const key of serviceKeys) {
-      const meta = labels?.get(key)
-      const label = meta
-        ? ` — ${meta.appLabel}${meta.specLabel !== meta.appLabel ? ` / ${meta.specLabel}` : ''}`
-        : ''
-      lines.push(`- serviceSpecs.${key}${label}`)
-    }
-  }
-  return `Visible specs (use in query as \`coreSpec\` / \`serviceSpecs.<key>\`):\n${lines.join('\n')}`
-}
-
-/**
- * Best-effort discovery metadata lookup. Returns undefined when the cache
- * has no entry for the tenant or when reading it throws — the caller
- * gracefully falls back to a label-less listing.
- * @param tenantId - Tenant ID used as the discovery cache key.
- */
-async function getDiscoveryLabels(
-  tenantId: string | undefined,
-): Promise<Map<string, { appLabel: string, specLabel: string }> | undefined> {
-  if (!tenantId)
-    return undefined
-  const cached = getCachedDiscovery(tenantId)
-  if (!cached)
-    return undefined
-  try {
-    const result = await cached
-    const map = new Map<string, { appLabel: string, specLabel: string }>()
-    for (const s of result.specs) map.set(s.contextPath, { appLabel: s.appLabel, specLabel: s.specLabel })
-    return map
-  } catch {
-    return undefined
   }
 }

--- a/src/utils/openapi-preprocessor.ts
+++ b/src/utils/openapi-preprocessor.ts
@@ -1,6 +1,9 @@
 import { resolveInternalRefs } from './resolve-refs.ts'
 
-const PRESERVED_EXTENSION = 'x-codemode'
+// `x-mc8yp-exclude` hides an operation from codemode derivation/discovery —
+// stripping it here would silently disable the feature at runtime, since both
+// runtime call sites preprocess with dropVendorExtensions enabled.
+const PRESERVED_EXTENSIONS = new Set(['x-codemode', 'x-mc8yp-exclude'])
 
 // `required: false` matches only the parameter boolean form — the schema's
 // `required: string[]` array never compares equal to `false`.
@@ -23,7 +26,7 @@ export interface PreprocessOptions {
   dereference?: boolean
   // Keep only 2xx responses (falls back to `default` when none).
   dropNon2xxResponses?: boolean
-  // Drop `x-*` keys except `x-codemode`.
+  // Drop `x-*` keys except `x-codemode` and `x-mc8yp-exclude`.
   dropVendorExtensions?: boolean
   // Drop the JSON Schema dialect marker `$schema`. `example` / `examples` are preserved.
   dropSchemaMeta?: boolean
@@ -81,7 +84,7 @@ function cleanValues(node: unknown, opts: Required<PreprocessOptions>): void {
   if (!isObject(node))
     return
   for (const key of Object.keys(node)) {
-    if (opts.dropVendorExtensions && key.startsWith('x-') && key !== PRESERVED_EXTENSION) {
+    if (opts.dropVendorExtensions && key.startsWith('x-') && !PRESERVED_EXTENSIONS.has(key)) {
       delete node[key]
       continue
     }

--- a/src/utils/restrictions.ts
+++ b/src/utils/restrictions.ts
@@ -1,4 +1,4 @@
-export const HTTP_METHODS = ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'TRACE'] as const
+export const HTTP_METHODS = ['DELETE', 'GET', 'HEAD', 'OPTIONS', 'PATCH', 'POST', 'PUT', 'QUERY', 'TRACE'] as const
 export const RESTRICTION_QUERY_KEYS = ['restriction', 'restrict', 'r'] as const
 export const ALLOW_QUERY_KEYS = ['allowed', 'allow', 'a'] as const
 export const RESTRICTION_HEADER = 'mc8yp-restriction'

--- a/src/utils/spec-resolution.ts
+++ b/src/utils/spec-resolution.ts
@@ -61,10 +61,29 @@ export interface ResolvedSpecs {
  * @param installedContextPaths Context paths of microservices the tenant owns
  *   or is subscribed to (discovery filters to type=MICROSERVICE).
  */
+// Memoized per (discoveredSpecs, installedContextPaths) object pair — both
+// come from the same per-tenant discovery cache entry, so in server mode the
+// H3 handler gets the SAME ResolvedSpecs object back for every request of a
+// tenant until its discovery refreshes. That identity is what the codemode
+// layer's WeakMap caches (derived operations, docs index) key on; without it
+// they would rebuild on every request. A refresh produces a fresh discovery
+// result → fresh resolved object → caches repopulate lazily and old entries
+// are garbage-collected.
+const resolvedSpecsCache = new WeakMap<object, WeakMap<object, ResolvedSpecs>>()
+
 export function resolveSpecs(
   discoveredSpecs: readonly DiscoveredApiSpec[],
   installedContextPaths: ReadonlySet<string>,
 ): ResolvedSpecs {
+  let byInstalled = resolvedSpecsCache.get(discoveredSpecs)
+  if (!byInstalled) {
+    byInstalled = new WeakMap()
+    resolvedSpecsCache.set(discoveredSpecs, byInstalled)
+  }
+  const cached = byInstalled.get(installedContextPaths)
+  if (cached)
+    return cached
+
   const specs: ServiceSpecs = {}
   const bundledContextPaths = new Set<string>()
 
@@ -85,7 +104,9 @@ export function resolveSpecs(
     }
   }
 
-  return { core: getCoreOpenApiSpec(), specs }
+  const resolved: ResolvedSpecs = { core: getCoreOpenApiSpec(), specs }
+  byInstalled.set(installedContextPaths, resolved)
+  return resolved
 }
 
 /**

--- a/test/derive-operations.test.ts
+++ b/test/derive-operations.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest'
+import { deriveOperations, toRequest } from '../src/codemode/derive-operations'
+import type { Spec } from '../src/utils/spec-resolution'
+
+function specOf(paths: Record<string, Record<string, unknown>>): Spec {
+  return { paths } as unknown as Spec
+}
+
+describe('deriveOperations', () => {
+  it('derives one operation per method with the sanitized operationId as name', () => {
+    const spec = specOf({
+      '/alarm/alarms': {
+        get: { operationId: 'getAlarmCollectionResource', summary: 'Retrieve all alarms' },
+        post: { operationId: 'postAlarmCollectionResource', summary: 'Create an alarm' },
+      },
+    })
+
+    const ops = deriveOperations(spec)
+    expect(ops.map((o) => o.name)).toEqual(['getAlarmCollectionResource', 'postAlarmCollectionResource'])
+    expect(ops[0]!.method).toBe('GET')
+    expect(ops[0]!.path).toBe('/alarm/alarms')
+    expect(ops[0]!.summary).toBe('Retrieve all alarms')
+  })
+
+  it('falls back to method_path naming when operationId is missing', () => {
+    const spec = specOf({ '/service/x/items': { get: { summary: 'List' } } })
+    expect(deriveOperations(spec)[0]!.name).toBe('getServiceXItems')
+  })
+
+  it('flattens path/query params and body into one input schema', () => {
+    const spec = specOf({
+      '/alarm/alarms/{id}': {
+        put: {
+          operationId: 'putAlarmResource',
+          parameters: [
+            { name: 'id', in: 'path', required: true, schema: { type: 'string' }, description: 'Alarm id' },
+            { name: 'withTotal', in: 'query', schema: { type: 'boolean' } },
+          ],
+          requestBody: { required: true, content: { 'application/json': { schema: { type: 'object', properties: { severity: { type: 'string' } } } } } },
+        },
+      },
+    })
+
+    const op = deriveOperations(spec)[0]!
+    expect(Object.keys(op.inputSchema.properties!)).toEqual(['id', 'withTotal', 'body'])
+    expect(op.inputSchema.required).toEqual(['id', 'body'])
+    expect((op.inputSchema.properties!.id as { description?: string }).description).toBe('Alarm id')
+  })
+
+  it('derives the output schema from the first 2xx application/json response', () => {
+    const spec = specOf({
+      '/x': {
+        get: {
+          operationId: 'getX',
+          responses: {
+            401: { content: { 'application/json': { schema: { type: 'string' } } } },
+            200: { content: { 'application/json': { schema: { type: 'object', properties: { total: { type: 'number' } } } } } },
+          },
+        },
+        post: { operationId: 'postX', responses: { 204: {} } },
+      },
+    })
+
+    const [get, post] = deriveOperations(spec)
+    expect(get!.outputSchema).toEqual({ type: 'object', properties: { total: { type: 'number' } } })
+    expect(post!.outputSchema).toBeUndefined()
+  })
+
+  it('skips operations annotated with x-mc8yp-exclude', () => {
+    const spec = specOf({
+      '/x': {
+        get: { operationId: 'getX' },
+        delete: { 'operationId': 'deleteX', 'x-mc8yp-exclude': true },
+      },
+    })
+    expect(deriveOperations(spec).map((o) => o.name)).toEqual(['getX'])
+  })
+
+  it('skips reserved and duplicate method names', () => {
+    const spec = specOf({
+      '/a': { get: { operationId: 'request' } },
+      '/b': { get: { operationId: 'getThing' } },
+      '/c': { get: { operationId: 'getThing' } },
+    })
+    expect(deriveOperations(spec).map((o) => o.name)).toEqual(['getThing'])
+  })
+
+  it('inlines local $refs in input schemas', () => {
+    const spec = {
+      paths: {
+        '/x': {
+          post: {
+            operationId: 'postX',
+            requestBody: { content: { 'application/json': { schema: { $ref: '#/components/schemas/Thing' } } } },
+          },
+        },
+      },
+      components: { schemas: { Thing: { type: 'object', properties: { name: { type: 'string' } } } } },
+    } as unknown as Spec
+
+    const op = deriveOperations(spec)[0]!
+    expect(op.inputSchema.properties!.body).toEqual({ type: 'object', properties: { name: { type: 'string' } } })
+  })
+
+  it('caches derivation by spec object identity', () => {
+    const spec = specOf({ '/x': { get: { operationId: 'getX' } } })
+    expect(deriveOperations(spec)).toBe(deriveOperations(spec))
+  })
+})
+
+describe('deriveOperations after real preprocessing', () => {
+  it('x-mc8yp-exclude survives preprocessing and still hides the operation', async () => {
+    const { preprocessOpenApi } = await import('../src/utils/openapi-preprocessor')
+    const spec = await preprocessOpenApi({
+      paths: {
+        '/visible': { get: { operationId: 'getVisible' } },
+        '/hidden': { get: { 'operationId': 'getHidden', 'x-mc8yp-exclude': true } },
+      },
+    } as unknown as Spec)
+    // The preprocessor drops vendor extensions by default — x-mc8yp-exclude
+    // must be on its preserved list or exclusion silently dies at runtime.
+    expect(deriveOperations(spec).map((o) => o.name)).toEqual(['getVisible'])
+  })
+
+  it('accepts 2XX range response keys for the output schema', () => {
+    const spec = specOf({
+      '/x': {
+        get: {
+          operationId: 'getX',
+          responses: { '2XX': { content: { 'application/json': { schema: { type: 'object', properties: { ok: { type: 'boolean' } } } } } } },
+        },
+      },
+    })
+    expect(deriveOperations(spec)[0]!.outputSchema).toEqual({ type: 'object', properties: { ok: { type: 'boolean' } } })
+  })
+})
+
+describe('toRequest', () => {
+  const spec = specOf({
+    '/alarm/alarms/{id}': {
+      put: {
+        operationId: 'putAlarmResource',
+        parameters: [
+          { name: 'id', in: 'path', required: true, schema: { type: 'string' } },
+          { name: 'withTotal', in: 'query', schema: { type: 'boolean' } },
+          { name: 'X-Custom', in: 'header', schema: { type: 'string' } },
+        ],
+        requestBody: { content: { 'application/json': { schema: { type: 'object' } } } },
+      },
+    },
+  })
+
+  it('substitutes path params and splits query/header/body', () => {
+    const op = deriveOperations(spec)[0]!
+    const request = toRequest(op, { 'id': 'my id', 'withTotal': true, 'X-Custom': 'v', 'body': { severity: 'MAJOR' } })
+
+    expect(request.method).toBe('PUT')
+    expect(request.path).toBe('/alarm/alarms/my%20id')
+    expect(request.query).toEqual({ withTotal: true })
+    expect(request.headers).toEqual({ 'X-Custom': 'v' })
+    expect(request.body).toEqual({ severity: 'MAJOR' })
+  })
+
+  it('serializes explode:false array params as one comma-joined value', () => {
+    const explodeSpec = specOf({
+      '/alarm/alarms': {
+        get: {
+          operationId: 'getAlarms',
+          parameters: [
+            { name: 'severity', in: 'query', explode: false, schema: { type: 'array', items: { type: 'string' } } },
+            { name: 'series', in: 'query', explode: true, schema: { type: 'array', items: { type: 'string' } } },
+            { name: 'tags', in: 'query', schema: { type: 'array', items: { type: 'string' } } },
+          ],
+        },
+      },
+    })
+    const op = deriveOperations(explodeSpec)[0]!
+    const request = toRequest(op, { severity: ['MAJOR', 'MINOR'], series: ['a', 'b'], tags: ['x', 'y'] })
+    expect(request.query.severity).toBe('MAJOR,MINOR')
+    // explode true and the OpenAPI default stay arrays → repeated keys.
+    expect(request.query.series).toEqual(['a', 'b'])
+    expect(request.query.tags).toEqual(['x', 'y'])
+  })
+
+  it('omits undefined params and body entirely', () => {
+    const op = deriveOperations(spec)[0]!
+    const request = toRequest(op, { id: '1' })
+    expect(request.query).toEqual({})
+    expect('body' in request).toBe(false)
+  })
+})

--- a/test/describe.test.ts
+++ b/test/describe.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { describeTarget } from '../src/codemode/describe'
+import { getMethodIndex } from '../src/codemode/method-search'
+import { buildNamespaces, toSearchableMethods } from '../src/codemode/namespaces'
+import { parseRestrictionRule } from '../src/utils/restrictions'
+import type { ResolvedSpecs, Spec } from '../src/utils/spec-resolution'
+
+const CORE_SPEC = {
+  info: { title: 'Cumulocity Core', description: 'The core REST surface: inventory, alarms, events.' },
+  tags: [{ name: 'Alarms', description: 'Alarm domain docs.' }],
+  paths: {
+    '/alarm/alarms': {
+      get: {
+        operationId: 'getAlarmCollectionResource',
+        summary: 'Retrieve all alarms',
+        tags: ['Alarms'],
+        parameters: [{ name: 'severity', in: 'query', schema: { type: 'string' }, description: 'Severity filter' }],
+        responses: { 200: { content: { 'application/json': { schema: { type: 'object', properties: { alarms: { type: 'array', items: { type: 'object' } } } } } } } },
+      },
+    },
+    '/alarm/alarms/{id}': {
+      delete: { operationId: 'deleteAlarmResource', summary: 'Delete an alarm' },
+    },
+  },
+} as unknown as Spec
+
+const DTM_SPEC = {
+  paths: {
+    '/service/dtm/assets': {
+      get: { operationId: 'getAssets', summary: 'List assets' },
+    },
+  },
+} as unknown as Spec
+
+function resolved(): ResolvedSpecs {
+  return { core: CORE_SPEC, specs: { dtm: DTM_SPEC } }
+}
+
+describe('buildNamespaces', () => {
+  it('names core c8y and services by sanitized contextPath', () => {
+    const namespaces = buildNamespaces(resolved())
+    expect(namespaces.map((ns) => ns.name)).toEqual(['c8y', 'dtm'])
+    expect(namespaces[0]!.operations.map((o) => o.name)).toEqual(['getAlarmCollectionResource', 'deleteAlarmResource'])
+  })
+
+  it('skips services that collide with reserved namespaces', () => {
+    const withReserved: ResolvedSpecs = { core: CORE_SPEC, specs: { codemode: DTM_SPEC, docs: DTM_SPEC } }
+    expect(buildNamespaces(withReserved).map((ns) => ns.name)).toEqual(['c8y'])
+  })
+
+  it('omits policy-blocked operations from namespaces', () => {
+    const { parsedRules } = parseRestrictionRule(['DELETE:/alarm/**'])
+    const namespaces = buildNamespaces(resolved(), parsedRules)
+    expect(namespaces[0]!.operations.map((o) => o.name)).toEqual(['getAlarmCollectionResource'])
+  })
+
+  it('honours allow lists', () => {
+    const allow = parseRestrictionRule(['GET:/service/dtm/**'])
+    const namespaces = buildNamespaces(resolved(), [], allow.parsedRules)
+    expect(namespaces.find((ns) => ns.name === 'c8y')!.operations).toHaveLength(0)
+    expect(namespaces.find((ns) => ns.name === 'dtm')!.operations).toHaveLength(1)
+  })
+})
+
+describe('describeTarget', () => {
+  const namespaces = buildNamespaces(resolved())
+  const methodIndex = getMethodIndex({}, () => toSearchableMethods(namespaces))
+
+  it('renders an overview when no target is given', () => {
+    const output = describeTarget(namespaces, methodIndex)
+    expect(output.kind).toBe('overview')
+    expect(output.content).toContain('c8y — Cumulocity Core (2 methods): The core REST surface: inventory, alarms, events.')
+    expect(output.content).toContain('dtm')
+    expect(output.content).toContain('codemode.search')
+  })
+
+  it('rejects namespace-only targets and redirects to search', () => {
+    const output = describeTarget(namespaces, methodIndex, 'c8y')
+    expect(output.kind).toBe('method')
+    expect(output.content).toContain('not a method target')
+    expect(output.content).toContain('codemode.search')
+    // No method dump — the listing must not leak through the redirect.
+    expect(output.content).not.toContain('Retrieve all alarms')
+  })
+
+  it('renders lean types with JSDoc and doc pointers for a method target', () => {
+    const output = describeTarget(namespaces, methodIndex, 'c8y.getAlarmCollectionResource')
+    expect(output.kind).toBe('method')
+    expect(output.content).toContain('GET /alarm/alarms — Retrieve all alarms')
+    expect(output.content).toContain('c8y.getAlarmCollectionResource(input: GetAlarmCollectionResourceInput): Promise<GetAlarmCollectionResourceOutput>')
+    expect(output.content).toContain('type GetAlarmCollectionResourceInput =')
+    expect(output.content).toContain('/** Severity filter */')
+    expect(output.content).toContain('type GetAlarmCollectionResourceOutput =')
+    expect(output.content).toContain('docs.read("c8y::topic::Alarms")')
+    // Lean output: no declare-const wrapper, no @param duplication.
+    expect(output.content).not.toContain('declare const')
+    expect(output.content).not.toContain('@param')
+  })
+
+  it('resolves bare method names across namespaces', () => {
+    const output = describeTarget(namespaces, methodIndex, 'getAssets')
+    expect(output.target).toBe('dtm.getAssets')
+    expect(output.kind).toBe('method')
+  })
+
+  it('suggests close matches for unknown targets', () => {
+    const output = describeTarget(namespaces, methodIndex, 'c8y.getAlarmCollection')
+    expect(output.content).toContain('not a method target')
+    expect(output.content).toContain('c8y.getAlarmCollectionResource')
+  })
+})

--- a/test/docs-index.test.ts
+++ b/test/docs-index.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { buildSpecDocs, getDocsIndex, readDoc, searchDocs } from '../src/codemode/docs-index'
+import type { DocsIndexEntry } from '../src/codemode/docs-index'
+
+const CORE_SPEC = {
+  info: { title: 'Cumulocity Core', description: 'The core REST API.' },
+  tags: [
+    { name: 'Alarms', description: 'Alarm handling. Query grammar: severity eq MAJOR, status eq ACTIVE.' },
+    { name: 'Inventory', description: 'Managed objects. The query parameter accepts the Cumulocity query language, e.g. $filter=(type eq c8y_Device).' },
+  ],
+  paths: {
+    '/alarm/alarms': {
+      get: {
+        operationId: 'getAlarmCollectionResource',
+        summary: 'Retrieve all alarms',
+        tags: ['Alarms'],
+        parameters: [{ name: 'severity', description: 'Alarm severity filter', schema: { format: 'string' } }],
+      },
+    },
+  },
+}
+
+function entries(): DocsIndexEntry[] {
+  return [{ namespace: 'c8y', spec: CORE_SPEC }]
+}
+
+describe('buildSpecDocs', () => {
+  it('creates only overview and topic docs — endpoints contribute nothing', () => {
+    const docs = buildSpecDocs(entries())
+    expect(docs.map((d) => d.id)).toEqual([
+      'c8y::overview',
+      'c8y::topic::Alarms',
+      'c8y::topic::Inventory',
+    ])
+    expect(docs.every((d) => d.kind === 'overview' || d.kind === 'topic')).toBe(true)
+  })
+
+  it('skips specs without info blocks or tags entirely', () => {
+    const docs = buildSpecDocs([{ namespace: 'svc', spec: { paths: { '/x': { get: { operationId: 'getX' } } } } }])
+    expect(docs).toEqual([])
+  })
+})
+
+describe('getDocsIndex / searchDocs / readDoc', () => {
+  it('finds topic documentation by fuzzy keywords', () => {
+    const index = getDocsIndex({}, entries)
+    const hits = searchDocs(index, 'query language')
+    expect(hits.length).toBeGreaterThan(0)
+    expect(hits[0]!.id).toBe('c8y::topic::Inventory')
+  })
+
+  it('never returns endpoint prose — that lives in codemode.describe', () => {
+    const index = getDocsIndex({}, entries)
+    // "severity filter" only appears in the endpoint's parameter description,
+    // which is not indexed; only the Alarms topic (whose text mentions
+    // severity) may match.
+    const hits = searchDocs(index, 'severity')
+    expect(hits.map((h) => h.kind)).toEqual(['topic'])
+    expect(hits[0]!.id).toBe('c8y::topic::Alarms')
+  })
+
+  it('truncates long texts in search hits and points at docs.read', () => {
+    const longSpec = {
+      tags: [{ name: 'Long', description: `query ${'x'.repeat(2000)}` }],
+    }
+    const index = getDocsIndex({}, () => [{ namespace: 'c8y', spec: longSpec }])
+    const hits = searchDocs(index, 'query', { maxTextLength: 100 })
+    expect(hits[0]!.truncated).toBe(true)
+    expect(hits[0]!.text).toContain('TRUNCATED PREVIEW')
+    expect(hits[0]!.text).toContain('docs.read("c8y::topic::Long")')
+
+    const full = readDoc(index, 'c8y::topic::Long')
+    expect(full!.text.length).toBeGreaterThan(2000)
+    expect(full!.text).not.toContain('TRUNCATED')
+  })
+
+  it('caches the index by cache-key identity', () => {
+    const key = {}
+    expect(getDocsIndex(key, entries)).toBe(getDocsIndex(key, entries))
+    expect(getDocsIndex({}, entries)).not.toBe(getDocsIndex({}, entries))
+  })
+
+  it('rejects empty queries and ids', () => {
+    const index = getDocsIndex({}, entries)
+    expect(() => searchDocs(index, ' ')).toThrow(TypeError)
+    expect(() => readDoc(index, '')).toThrow(TypeError)
+    expect(readDoc(index, 'c8y::topic::Nope')).toBeNull()
+  })
+})

--- a/test/excute.test.ts
+++ b/test/excute.test.ts
@@ -1,12 +1,10 @@
-/* eslint-disable no-template-curly-in-string */
 import type { Buffer } from 'node:buffer'
 import http from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { encode } from '@toon-format/toon'
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { BLOCKED_REQUEST_PREFIX, disposeSandbox, execute, query } from '../src/codemode/execute'
-import type { ResolvedSpecs } from '../src/utils/spec-resolution'
-import { resolveSpecs } from '../src/utils/spec-resolution'
+import { BLOCKED_REQUEST_PREFIX, disposeSandbox, execute } from '../src/codemode/execute'
+import type { Spec } from '../src/utils/spec-resolution'
 import { bustApiSpecCache, setCachedApiSpecs } from '../src/utils/api-discovery'
 import { c8yMcpServer } from '../src/server-instance'
 import { parseAllowRule, parseRestrictionRule } from '../src/utils/restrictions'
@@ -35,6 +33,7 @@ function parseSingleAllowRule(input: string): AllowRule {
 
 const INVALID_RESTRICTION_QUERY_PAYLOADS = [
   '/inventory/managedObjects");globalThis.pwned=true;("',
+  // eslint-disable-next-line no-template-curly-in-string
   '/inventory/${globalThis.pwned=true}',
   '/inventory/managedObjects`);globalThis.pwned=true;//',
   '/inventory/*/..//*/**',
@@ -42,6 +41,7 @@ const INVALID_RESTRICTION_QUERY_PAYLOADS = [
   '/inventory/managedObjects\u2028globalThis.pwned=true',
   '/inventory/managedObjects\u2029globalThis.pwned=true',
   'GET:/inventory/managedObjects");globalThis.pwned=true;("',
+  // eslint-disable-next-line no-template-curly-in-string
   'POST:/inventory/${globalThis.pwned=true}',
   '/inventory/managedObjects?x=1',
   '/inventory/managedObjects#frag',
@@ -90,6 +90,43 @@ function expectedAllowedRequestMessage(method: string, path: string, allowRules:
 }
 
 // ─────────────────────────────────────────────────────────────────────────
+// Test spec — a small core spec exercising derivation, discovery, docs,
+// and policy filtering inside the real sandbox.
+// ─────────────────────────────────────────────────────────────────────────
+
+const TEST_CORE_SPEC = {
+  info: { title: 'Cumulocity Core', description: 'Test core spec.' },
+  tags: [
+    { name: 'Alarms', description: 'Alarm domain documentation. Query grammar: severity eq MAJOR.' },
+  ],
+  paths: {
+    '/alarm/alarms': {
+      get: {
+        operationId: 'getAlarmCollectionResource',
+        summary: 'Retrieve all alarms',
+        tags: ['Alarms'],
+        parameters: [{ name: 'pageSize', in: 'query', schema: { type: 'number' }, description: 'Page size' }],
+      },
+    },
+    '/alarm/alarms/{id}': {
+      get: {
+        operationId: 'getAlarmResource',
+        summary: 'Retrieve a specific alarm',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+      },
+      delete: {
+        operationId: 'deleteAlarmResource',
+        summary: 'Delete an alarm',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+      },
+    },
+    '/secret': {
+      get: { 'operationId': 'getSecret', 'summary': 'Excluded op', 'x-mc8yp-exclude': true },
+    },
+  },
+} as unknown as Spec
+
+// ─────────────────────────────────────────────────────────────────────────
 // Shared harness: stub the MCP context so execute() picks up restrictions
 // and stub resolveC8yAuth so it does not look in the keychain.
 // ─────────────────────────────────────────────────────────────────────────
@@ -99,13 +136,15 @@ function stubExecuteCtx(opts: {
   allowRules?: readonly AllowRule[]
   env?: 'cli' | 'server'
   auth?: { tenantUrl: string, authorizationHeader: string } | undefined
+  core?: Spec
+  services?: Record<string, Spec>
 } = {}): () => void {
   const ctxSpy = vi.spyOn(c8yMcpServer, 'ctx', 'get').mockReturnValue({
     custom: {
       env: opts.env ?? 'cli',
       restrictions: opts.restrictions ?? [],
       allowRules: opts.allowRules ?? [],
-      specs: { core: { paths: {} }, specs: {} },
+      specs: { core: opts.core ?? ({ paths: {} } as unknown as Spec), specs: opts.services ?? {} },
       auth: opts.auth,
     },
   } as unknown as ReturnType<typeof c8yMcpServer['ctx']['valueOf']>)
@@ -130,32 +169,25 @@ afterAll(async () => {
   await disposeSandbox()
 })
 
-// CLI-mode execute prepends `Executed against tenant: <url>\n\n`. query
-// appends `\n\n---\n<tenant-aware footer>`. The behavioural tests below
-// strip those off so they keep asserting on the actual function body;
-// dedicated tests further down cover the marker / footer presence
-// explicitly so they cannot regress silently.
+// CLI-mode execute prepends a marker line followed by a blank line. The
+// behavioural tests below strip it so they keep asserting on the actual
+// function result; dedicated tests further down cover the marker explicitly
+// so it cannot regress silently.
 function stripCliTenantMarker(text: string): string {
-  const match = /^Executed against tenant: [^\n]+\n\n/.exec(text)
+  const match = /^(?:Executed against tenant: [^\n]+|No active tenant[^\n]+)\n\n/.exec(text)
   return match ? text.slice(match[0].length) : text
 }
 
-function stripQueryFooter(text: string): string {
-  const idx = text.lastIndexOf('\n\n---\n')
-  return idx === -1 ? text : text.slice(0, idx)
-}
-
 // ─────────────────────────────────────────────────────────────────────────
-// Sandbox-side wrapper validation — these errors happen *before* any bridge
-// call, so they never touch the network.
+// request escape hatch — input validation (host-side, before any network).
 // ─────────────────────────────────────────────────────────────────────────
 
-describe('cumulocity.request — sandbox-side input validation', () => {
+describe('c8y.request — input validation', () => {
   it('rejects requests without an explicit method', async () => {
     const restore = stubExecuteCtx()
     try {
       mockAuth(TEST_TENANT)
-      const result = await execute(`async () => await cumulocity.request({ path: '/event/events' })`)
+      const result = await execute(`async () => await c8y.request({ path: '/event/events' })`)
       expect(stripCliTenantMarker(result)).toBe('request method must be a non-empty string')
     } finally {
       restore()
@@ -166,8 +198,8 @@ describe('cumulocity.request — sandbox-side input validation', () => {
     const restore = stubExecuteCtx()
     try {
       mockAuth(TEST_TENANT)
-      const result = await execute(`async () => await cumulocity.request({ method: 'MERGE', path: '/event/events' })`)
-      expect(stripCliTenantMarker(result)).toBe('request method must be one of: DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT, TRACE')
+      const result = await execute(`async () => await c8y.request({ method: 'MERGE', path: '/event/events' })`)
+      expect(stripCliTenantMarker(result)).toBe('request method must be one of: DELETE, GET, HEAD, OPTIONS, PATCH, POST, PUT, QUERY, TRACE')
     } finally {
       restore()
     }
@@ -177,7 +209,7 @@ describe('cumulocity.request — sandbox-side input validation', () => {
     const restore = stubExecuteCtx()
     try {
       mockAuth(TEST_TENANT)
-      const result = await execute(`async () => await cumulocity.request('hello')`)
+      const result = await execute(`async () => await c8y.request('hello')`)
       expect(stripCliTenantMarker(result)).toBe('request options must be an object')
     } finally {
       restore()
@@ -188,7 +220,7 @@ describe('cumulocity.request — sandbox-side input validation', () => {
     const restore = stubExecuteCtx()
     try {
       mockAuth(TEST_TENANT)
-      const result = await execute(`async () => await cumulocity.request({ method: 'GET', path: '' })`)
+      const result = await execute(`async () => await c8y.request({ method: 'GET', path: '' })`)
       expect(stripCliTenantMarker(result)).toBe('request path must be a non-empty string')
     } finally {
       restore()
@@ -202,13 +234,13 @@ describe('cumulocity.request — sandbox-side input validation', () => {
 // HTTP server.
 // ─────────────────────────────────────────────────────────────────────────
 
-describe('cumulocity.request — policy enforcement (middleware)', () => {
+describe('c8y.request — policy enforcement (middleware)', () => {
   it('blocks restricted requests before any HTTP call', async () => {
     const restore = stubExecuteCtx({ restrictions: [parseSingleRule('GET:/inventory/**')] })
     try {
       mockAuth(TEST_TENANT)
       const result = await execute(
-        `async () => await cumulocity.request({ method: 'GET', path: '/inventory/managedObjects?pageSize=5' })`,
+        `async () => await c8y.request({ method: 'GET', path: '/inventory/managedObjects', params: { pageSize: 5 } })`,
       )
       expect(stripCliTenantMarker(result)).toBe(
         expectedRestrictedRequestMessage('GET', '/inventory/managedObjects', ['GET:/inventory/**']),
@@ -223,7 +255,7 @@ describe('cumulocity.request — policy enforcement (middleware)', () => {
     try {
       mockAuth(TEST_TENANT)
       const result = await execute(
-        `async () => await cumulocity.request({ method: 'GET', path: '/alarm/alarms?pageSize=5' })`,
+        `async () => await c8y.request({ method: 'GET', path: '/alarm/alarms?pageSize=5' })`,
       )
       expect(stripCliTenantMarker(result)).toBe(
         expectedAllowedRequestMessage('GET', '/alarm/alarms', ['GET:/inventory/**']),
@@ -241,7 +273,7 @@ describe('cumulocity.request — policy enforcement (middleware)', () => {
     try {
       mockAuth(TEST_TENANT)
       const result = await execute(
-        `async () => await cumulocity.request({ method: 'GET', path: '/inventory/managedObjects?pageSize=5' })`,
+        `async () => await c8y.request({ method: 'GET', path: '/inventory/managedObjects?pageSize=5' })`,
       )
       expect(stripCliTenantMarker(result)).toBe(
         expectedRestrictedRequestMessage('GET', '/inventory/managedObjects', ['GET:/inventory/managedObjects']),
@@ -254,8 +286,8 @@ describe('cumulocity.request — policy enforcement (middleware)', () => {
 
 // ─────────────────────────────────────────────────────────────────────────
 // Success-path tests — run a local HTTP server and point the tenant URL at
-// it so the full sandbox → bridge → safeFetch → undici → server roundtrip
-// is exercised.
+// it so the full sandbox → host dispatch → safeFetch → undici → server
+// roundtrip is exercised.
 // ─────────────────────────────────────────────────────────────────────────
 
 interface CapturedHttpRequest {
@@ -325,7 +357,7 @@ async function startTestServer(): Promise<TestServer> {
   }
 }
 
-describe('cumulocity.request — success path', () => {
+describe('live requests — success path', () => {
   let testServer: TestServer
 
   beforeEach(async () => {
@@ -341,7 +373,7 @@ describe('cumulocity.request — success path', () => {
     try {
       mockAuth(testServer.url, 'Bearer host-token')
       const result = await execute(
-        `async () => await cumulocity.request({ method: 'POST', path: '/event/events' })`,
+        `async () => await c8y.request({ method: 'POST', path: '/event/events' })`,
       )
 
       expect(stripCliTenantMarker(result)).toBe(encode({ ok: true }))
@@ -354,12 +386,45 @@ describe('cumulocity.request — success path', () => {
     }
   })
 
+  it('serializes request params into the query string', async () => {
+    const restore = stubExecuteCtx()
+    try {
+      mockAuth(testServer.url)
+      await execute(
+        `async () => await c8y.request({ method: 'GET', path: '/inventory/managedObjects', params: { pageSize: 5, withTotalPages: true } })`,
+      )
+      expect(testServer.requests[0]!.url).toBe('/inventory/managedObjects?pageSize=5&withTotalPages=true')
+    } finally {
+      restore()
+    }
+  })
+
+  it('calls derived namespace methods with path substitution and query params', async () => {
+    const restore = stubExecuteCtx({ core: TEST_CORE_SPEC })
+    try {
+      mockAuth(testServer.url)
+      const result = await execute(
+        `async () => {
+          const list = await c8y.getAlarmCollectionResource({ pageSize: 3 })
+          const single = await c8y.getAlarmResource({ id: 'alarm 1' })
+          return { list, single }
+        }`,
+      )
+
+      expect(stripCliTenantMarker(result)).toBe(encode({ list: { ok: true }, single: { ok: true } }))
+      expect(testServer.requests[0]!.url).toBe('/alarm/alarms?pageSize=3')
+      expect(testServer.requests[1]!.url).toBe('/alarm/alarms/alarm%201')
+    } finally {
+      restore()
+    }
+  })
+
   it('allows requests that match the configured allow list', async () => {
     const restore = stubExecuteCtx({ allowRules: [parseSingleAllowRule('GET:/inventory/**')] })
     try {
       mockAuth(testServer.url)
       const result = await execute(
-        `async () => await cumulocity.request({ method: 'GET', path: '/inventory/managedObjects?pageSize=5' })`,
+        `async () => await c8y.request({ method: 'GET', path: '/inventory/managedObjects?pageSize=5' })`,
       )
 
       expect(stripCliTenantMarker(result)).toBe(encode({ ok: true }))
@@ -375,7 +440,7 @@ describe('cumulocity.request — success path', () => {
     try {
       mockAuth(testServer.url, 'Bearer host-only')
       await execute(
-        `async () => await cumulocity.request({
+        `async () => await c8y.request({
           method: 'GET',
           path: '/inventory/managedObjects',
           headers: { Authorization: 'Bearer agent-injected' },
@@ -393,7 +458,7 @@ describe('cumulocity.request — success path', () => {
     try {
       mockAuth(testServer.url)
       await execute(
-        `async () => await cumulocity.request({ method: 'POST', path: '/event/events', body: { type: 'thing' } })`,
+        `async () => await c8y.request({ method: 'POST', path: '/event/events', body: { type: 'thing' } })`,
       )
 
       expect(testServer.requests[0]!.body).toBe(JSON.stringify({ type: 'thing' }))
@@ -409,7 +474,7 @@ describe('cumulocity.request — success path', () => {
       testServer.setResponse({ status: 404, body: { message: 'no such resource' } })
       mockAuth(testServer.url)
       const result = await execute(
-        `async () => await cumulocity.request({ method: 'GET', path: '/inventory/managedObjects' })`,
+        `async () => await c8y.request({ method: 'GET', path: '/inventory/managedObjects' })`,
       )
 
       expect(result).toMatch(/Cumulocity request failed with 404[\s\S]*no such resource/)
@@ -438,89 +503,144 @@ describe('restriction & allow rule parsing rejects malicious payloads', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────
-// query — unchanged behavioural coverage.
+// In-sandbox discovery — codemode.search / codemode.describe / docs.
 // ─────────────────────────────────────────────────────────────────────────
 
-describe('query', () => {
-  function withSpecs(specs: ResolvedSpecs, auth?: { tenantUrl: string, authorizationHeader: string }): () => void {
-    const ctxSpy = vi.spyOn(c8yMcpServer, 'ctx', 'get').mockReturnValue({
-      custom: {
-        env: 'cli' as const,
-        restrictions: [],
-        allowRules: [],
-        specs,
-        auth,
-      },
-    } as unknown as ReturnType<typeof c8yMcpServer['ctx']['valueOf']>)
-    return () => ctxSpy.mockRestore()
-  }
-
-  it('exposes coreSpec and serviceSpecs through the query sandbox', async () => {
-    const restore = withSpecs({ core: { paths: {} }, specs: {} })
+describe('in-sandbox discovery', () => {
+  it('finds derived methods via codemode.search', async () => {
+    const restore = stubExecuteCtx({ core: TEST_CORE_SPEC })
     try {
-      const result = await query(
-        '() => ({ hasCore: !!coreSpec, hasServiceSpecs: typeof serviceSpecs === "object", noSpecsEnabled: typeof specsEnabled === "undefined" })',
+      mockAuth(TEST_TENANT)
+      const result = await execute(
+        `async () => {
+          const { results } = await codemode.search('retrieve alarms')
+          return results.map((r) => r.target)
+        }`,
       )
-      expect(JSON.parse(stripQueryFooter(result))).toEqual({ hasCore: true, hasServiceSpecs: true, noSpecsEnabled: true })
+      expect(stripCliTenantMarker(result)).toContain('c8y.getAlarmCollectionResource')
     } finally {
       restore()
     }
   })
 
-  it('exposes core as the coreSpec binding', async () => {
-    const restore = withSpecs({ core: { paths: { '/inventory/managedObjects': {} } }, specs: {} })
+  it('accepts multiple query phrasings in one search call', async () => {
+    const restore = stubExecuteCtx({ core: TEST_CORE_SPEC })
     try {
-      const result = await query('() => Object.keys(coreSpec.paths)')
-      expect(JSON.parse(stripQueryFooter(result))).toEqual(['/inventory/managedObjects'])
+      mockAuth(TEST_TENANT)
+      const result = await execute(
+        `async () => {
+          const { results } = await codemode.search(['list alarms', 'retrieve alarms'])
+          return results.map((r) => r.target)
+        }`,
+      )
+      expect(stripCliTenantMarker(result)).toContain('c8y.getAlarmCollectionResource')
     } finally {
       restore()
     }
   })
 
-  it('reads specs from c8yMcpServer.ctx.custom (no override path exists)', async () => {
-    const restore = withSpecs(resolveSpecs([], new Set()))
+  it('describes a shortlist of methods in one call, capped at 5', async () => {
+    const restore = stubExecuteCtx({ core: TEST_CORE_SPEC })
     try {
-      const result = await query('() => typeof coreSpec !== "undefined"')
-      expect(JSON.parse(stripQueryFooter(result))).toBe(true)
+      mockAuth(TEST_TENANT)
+      const result = await execute(
+        `async () => {
+          const pair = await codemode.describe(['c8y.getAlarmCollectionResource', 'c8y.getAlarmResource'])
+          let capError = null
+          try {
+            await codemode.describe(['a.b', 'a.c', 'a.d', 'a.e', 'a.f', 'a.g'])
+          } catch (error) {
+            capError = error.message
+          }
+          return [
+            Array.isArray(pair),
+            pair.length,
+            pair.every((d) => d.kind === 'method'),
+            pair[0].content.includes('GetAlarmCollectionResourceInput'),
+            capError,
+          ].join('|')
+        }`,
+      )
+      const body = stripCliTenantMarker(result)
+      expect(body).toContain('true|2|true|true')
+      expect(body).toContain('at most 5 targets per call')
     } finally {
       restore()
     }
   })
 
-  it('puts service-map entries into serviceSpecs keyed by contextPath', async () => {
-    const restore = withSpecs({ core: { paths: {} }, specs: { svc: { paths: {} } } })
+  it('describes methods only — namespace targets redirect to search', async () => {
+    const restore = stubExecuteCtx({ core: TEST_CORE_SPEC })
     try {
-      const result = await query('() => Object.keys(serviceSpecs)')
-      expect(JSON.parse(stripQueryFooter(result))).toEqual(['svc'])
+      mockAuth(TEST_TENANT)
+      const result = await execute(
+        `async () => {
+          const overview = await codemode.describe()
+          const namespaceAttempt = await codemode.describe('c8y')
+          const method = await codemode.describe('c8y.getAlarmCollectionResource')
+          return [
+            overview.kind,
+            namespaceAttempt.content.includes('not a method target'),
+            namespaceAttempt.content.includes('Retrieve all alarms') ? 'leaked-listing' : 'no-listing',
+            method.kind,
+            method.content.includes('GetAlarmCollectionResourceInput'),
+          ].join('|')
+        }`,
+      )
+      expect(stripCliTenantMarker(result)).toContain('overview|true|no-listing|method|true')
     } finally {
       restore()
     }
   })
 
-  it('serviceSpecs entries are bare Spec objects (no wrapper) so paths read directly', async () => {
-    const restore = withSpecs({ core: { paths: {} }, specs: { dtm: { paths: { '/service/dtm/assets': {} } } } })
+  it('searches and reads prose documentation via docs', async () => {
+    const restore = stubExecuteCtx({ core: TEST_CORE_SPEC })
     try {
-      const result = await query(`() => Object.keys(serviceSpecs.dtm.paths)`)
-      expect(JSON.parse(stripQueryFooter(result))).toEqual(['/service/dtm/assets'])
+      mockAuth(TEST_TENANT)
+      const result = await execute(
+        `async () => {
+          const hits = await docs.search('query grammar severity')
+          const doc = await docs.read(hits[0].id)
+          return doc.text
+        }`,
+      )
+      expect(stripCliTenantMarker(result)).toContain('severity eq MAJOR')
     } finally {
       restore()
     }
   })
 
-  it('unavailable services are simply absent from serviceSpecs', async () => {
-    const restore = withSpecs({ core: { paths: {} }, specs: {} })
+  it('omits policy-blocked and excluded operations from discovery', async () => {
+    const restore = stubExecuteCtx({
+      core: TEST_CORE_SPEC,
+      restrictions: [parseSingleRule('DELETE:/alarm/**')],
+    })
     try {
-      const result = await query(`() => ({ keys: Object.keys(serviceSpecs), hasDtm: 'dtm' in serviceSpecs })`)
-      expect(JSON.parse(stripQueryFooter(result))).toEqual({ keys: [], hasDtm: false })
+      mockAuth(TEST_TENANT)
+      const result = await execute(
+        `async () => {
+          return {
+            targets: (await codemode.search('alarms')).results.map((r) => r.target),
+            secretTargets: (await codemode.search('secret excluded op')).results.map((r) => r.target),
+            deleteIsFunction: typeof c8y.deleteAlarmResource === 'function',
+          }
+        }`,
+      )
+      const body = stripCliTenantMarker(result)
+      expect(body).not.toContain('deleteAlarmResource')
+      expect(body).not.toContain('getSecret')
+      expect(body).toContain('deleteIsFunction: false')
     } finally {
       restore()
     }
   })
 
-  it('cannot make network calls from the query sandbox', async () => {
-    const restore = withSpecs({ core: { paths: {} }, specs: {} })
+  it('exposes no fetch surface to the sandbox', async () => {
+    const restore = stubExecuteCtx({ core: TEST_CORE_SPEC })
     try {
-      await expect(query('() => fetch("https://example.com")')).rejects.toThrow()
+      mockAuth(TEST_TENANT)
+      const result = await execute('async () => typeof fetch')
+      expect(stripCliTenantMarker(result)).toBe(encode('undefined'))
     } finally {
       restore()
     }
@@ -528,10 +648,10 @@ describe('query', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────
-// execute — high-level behaviour (envelope contract has been removed: a
-// successful run returns the Toon-encoded function result; any thrown error
-// surfaces as plain text, with BLOCKED_REQUEST_PREFIX preserved verbatim so
-// callers can still differentiate policy denials from generic failures).
+// execute — high-level behaviour (a successful run returns the Toon-encoded
+// function result; any thrown error surfaces as plain text, with
+// BLOCKED_REQUEST_PREFIX preserved verbatim so callers can still
+// differentiate policy denials from generic failures).
 // ─────────────────────────────────────────────────────────────────────────
 
 describe('execute', () => {
@@ -572,8 +692,37 @@ describe('execute', () => {
 })
 
 // ─────────────────────────────────────────────────────────────────────────
-// Agent-facing hints — explicit coverage so the marker and footer cannot
-// regress silently when other behavioural assertions strip them off.
+// No-tenant CLI state — discovery keeps working, live calls fail loudly.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('execute — no active tenant (CLI discovery-only)', () => {
+  it('runs discovery against bundled specs and marks the output', async () => {
+    const restore = stubExecuteCtx({ core: TEST_CORE_SPEC, auth: undefined })
+    try {
+      const result = await execute(
+        `async () => (await codemode.search('alarms')).results.map((r) => r.target)`,
+      )
+      expect(result.startsWith('No active tenant — discovery only.')).toBe(true)
+      expect(result).toContain('c8y.getAlarmCollectionResource')
+    } finally {
+      restore()
+    }
+  })
+
+  it('fails live calls with the missing-auth guidance', async () => {
+    const restore = stubExecuteCtx({ core: TEST_CORE_SPEC, auth: undefined })
+    try {
+      const result = await execute(`async () => await c8y.getAlarmCollectionResource({ pageSize: 1 })`)
+      expect(stripCliTenantMarker(result)).toContain('No active tenant set')
+    } finally {
+      restore()
+    }
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────
+// Agent-facing hints — explicit coverage so the marker cannot regress
+// silently when other behavioural assertions strip it off.
 // ─────────────────────────────────────────────────────────────────────────
 
 describe('execute — CLI tenant marker', () => {
@@ -607,54 +756,6 @@ describe('execute — CLI tenant marker', () => {
       mockAuth(TEST_TENANT)
       const result = await execute('async () => ({ ok: true })')
       expect(result.startsWith('Executed against tenant:')).toBe(false)
-    } finally {
-      restore()
-    }
-  })
-})
-
-describe('query — tenant footer', () => {
-  function withAuth(tenantUrl: string | undefined, env: 'cli' | 'server' = 'cli'): () => void {
-    const ctxSpy = vi.spyOn(c8yMcpServer, 'ctx', 'get').mockReturnValue({
-      custom: {
-        env,
-        restrictions: [],
-        allowRules: [],
-        specs: { core: { paths: {} }, specs: {} },
-        auth: tenantUrl ? { tenantUrl, authorizationHeader: 'Bearer test' } : undefined,
-      },
-    } as unknown as ReturnType<typeof c8yMcpServer['ctx']['valueOf']>)
-    return () => ctxSpy.mockRestore()
-  }
-
-  it('appends "Query ran against tenant: <url>" when an auth context exists', async () => {
-    const restore = withAuth('https://acme.cumulocity.com')
-    try {
-      const result = await query('() => ({ ok: true })')
-      expect(result).toContain('\n\n---\nQuery ran against tenant: https://acme.cumulocity.com.')
-    } finally {
-      restore()
-    }
-  })
-
-  it('appends a "no active tenant" notice when auth is undefined', async () => {
-    const restore = withAuth(undefined)
-    try {
-      const result = await query('() => ({ ok: true })')
-      expect(result).toContain('\n\n---\nQuery ran against bundled OpenAPI snapshots only')
-      expect(result).toContain('no active tenant')
-    } finally {
-      restore()
-    }
-  })
-
-  it('does NOT append a footer in server mode', async () => {
-    const restore = withAuth('https://acme.cumulocity.com', 'server')
-    try {
-      const result = await query('() => ({ ok: true })')
-      expect(result).not.toContain('Query ran against')
-      expect(result).not.toContain('---')
-      expect(result).toBe(JSON.stringify({ ok: true }))
     } finally {
       restore()
     }

--- a/test/method-search.test.ts
+++ b/test/method-search.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { getMethodIndex, searchMethods } from '../src/codemode/method-search'
+import type { SearchableMethod } from '../src/codemode/method-search'
+
+const ITEMS: SearchableMethod[] = [
+  { target: 'c8y.getAlarmCollectionResource', namespace: 'c8y', method: 'getAlarmCollectionResource', httpMethod: 'GET', apiPath: '/alarm/alarms', summary: 'Retrieve all alarms' },
+  { target: 'c8y.postAlarmCollectionResource', namespace: 'c8y', method: 'postAlarmCollectionResource', httpMethod: 'POST', apiPath: '/alarm/alarms', summary: 'Create an alarm' },
+  { target: 'c8y.getManagedObjectCollectionResource', namespace: 'c8y', method: 'getManagedObjectCollectionResource', httpMethod: 'GET', apiPath: '/inventory/managedObjects', summary: 'Retrieve all managed objects' },
+  { target: 'dtm.getAssets', namespace: 'dtm', method: 'getAssets', httpMethod: 'GET', apiPath: '/service/dtm/assets', summary: 'Retrieve assets' },
+  { target: 'dtm.getAsset', namespace: 'dtm', method: 'getAsset', httpMethod: 'GET', apiPath: '/service/dtm/assets/{assetId}', summary: 'Retrieve an existing asset' },
+]
+
+function index() {
+  return getMethodIndex({}, () => ITEMS)
+}
+
+describe('searchMethods', () => {
+  it('ranks exact method-name matches first', () => {
+    const { results } = searchMethods(index(), 'getAssets')
+    expect(results[0]!.target).toBe('dtm.getAssets')
+  })
+
+  it('tokenizes camelCase and matches across singular/plural via fuzziness', () => {
+    const { results } = searchMethods(index(), 'dtm asset')
+    const targets = results.map((r) => r.target)
+    expect(targets).toContain('dtm.getAssets')
+    expect(targets).toContain('dtm.getAsset')
+  })
+
+  it('keeps recall when one query word has no counterpart in the spec vocabulary', () => {
+    // "list" appears nowhere; OR-combination still ranks the assets methods.
+    const { results } = searchMethods(index(), 'list assets')
+    expect(results.some((r) => r.target === 'dtm.getAssets')).toBe(true)
+  })
+
+  it('unions multiple query phrasings, deduped by best score', () => {
+    const single = searchMethods(index(), 'managed objects')
+    const multi = searchMethods(index(), ['managed objects', 'alarms'])
+    expect(multi.results.map((r) => r.target)).toContain('c8y.getManagedObjectCollectionResource')
+    expect(multi.results.map((r) => r.target)).toContain('c8y.getAlarmCollectionResource')
+    expect(multi.total).toBeGreaterThanOrEqual(single.total)
+  })
+
+  it('filters hidden methods at query time', () => {
+    const { results } = searchMethods(index(), 'alarms', (target) => target !== 'c8y.postAlarmCollectionResource')
+    expect(results.some((r) => r.target === 'c8y.postAlarmCollectionResource')).toBe(false)
+    expect(results.some((r) => r.target === 'c8y.getAlarmCollectionResource')).toBe(true)
+  })
+
+  it('returns empty output for empty queries', () => {
+    expect(searchMethods(index(), '')).toEqual({ results: [], total: 0, truncated: false })
+    expect(searchMethods(index(), ['   ', ''])).toEqual({ results: [], total: 0, truncated: false })
+  })
+
+  it('caps results at 20 and reports truncation', () => {
+    const many: SearchableMethod[] = Array.from({ length: 60 }, (_, i) => ({
+      target: `c8y.getAlarmThing${i}`,
+      namespace: 'c8y',
+      method: `getAlarmThing${i}`,
+      httpMethod: 'GET',
+      apiPath: `/alarm/things/${i}`,
+      summary: 'Alarm thing',
+    }))
+    const output = searchMethods(getMethodIndex({}, () => many), 'alarm thing')
+    expect(output.results).toHaveLength(20)
+    expect(output.total).toBe(60)
+    expect(output.truncated).toBe(true)
+  })
+
+  it('caches the index by cache-key identity', () => {
+    const key = {}
+    expect(getMethodIndex(key, () => ITEMS)).toBe(getMethodIndex(key, () => ITEMS))
+    expect(getMethodIndex({}, () => ITEMS)).not.toBe(getMethodIndex({}, () => ITEMS))
+  })
+})

--- a/test/operation-naming.test.ts
+++ b/test/operation-naming.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { operationName, sanitizeToolName, toPascalCase } from '../src/codemode/operation-naming'
+
+describe('sanitizeToolName', () => {
+  it('replaces separators, strips invalid chars, guards digits and reserved words', () => {
+    expect(sanitizeToolName('my-tool')).toBe('my_tool')
+    expect(sanitizeToolName('a.b c')).toBe('a_b_c')
+    expect(sanitizeToolName('3d-render')).toBe('_3d_render')
+    expect(sanitizeToolName('delete')).toBe('delete_')
+    expect(sanitizeToolName('')).toBe('_')
+    expect(sanitizeToolName('///')).toBe('_')
+  })
+})
+
+describe('toPascalCase', () => {
+  it('converts snake_case and camelCase identifiers', () => {
+    expect(toPascalCase('get_alarm')).toBe('GetAlarm')
+    expect(toPascalCase('getAlarm')).toBe('GetAlarm')
+    expect(toPascalCase('managed_objects')).toBe('ManagedObjects')
+  })
+})
+
+describe('operationName', () => {
+  it('prefers the sanitized operationId when present', () => {
+    expect(operationName('get', '/alarm/alarms', 'getAlarmCollectionResource')).toBe('getAlarmCollectionResource')
+    expect(operationName('post', '/x', 'create-thing')).toBe('create_thing')
+  })
+
+  it('synthesizes readable camelCase names from method and path', () => {
+    expect(operationName('get', '/alarm/alarms')).toBe('getAlarmAlarms')
+    expect(operationName('post', '/alarm/alarms')).toBe('postAlarmAlarms')
+    expect(operationName('get', '/service/dtm/assets')).toBe('getServiceDtmAssets')
+  })
+
+  it('renders path params as By<Param>', () => {
+    expect(operationName('get', '/alarm/alarms/{id}')).toBe('getAlarmAlarmsById')
+    expect(operationName('delete', '/inventory/managedObjects/{id}/childAssets/{childId}'))
+      .toBe('deleteInventoryManagedObjectsByIdChildAssetsByChildId')
+  })
+
+  it('keeps different HTTP methods on the same path distinct', () => {
+    const path = '/alarm/alarms'
+    const names = ['get', 'post', 'put', 'delete'].map((m) => operationName(m, path))
+    expect(new Set(names).size).toBe(names.length)
+  })
+
+  it('handles dashed segments and the root path', () => {
+    expect(operationName('get', '/managed-objects')).toBe('getManagedObjects')
+    expect(operationName('get', '/')).toBe('get')
+  })
+})

--- a/test/real-spec.test.ts
+++ b/test/real-spec.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Derivation and type rendering against the REAL bundled core spec, pushed
+ * through the same preprocessing the runtime applies (default options — no
+ * dereferencing). This is the coverage that catches structural-$ref gaps the
+ * synthetic fixtures cannot: in the raw spec, parameter entries and response
+ * objects are `$ref`s into `components`, and derivation must resolve them
+ * itself or every core method silently loses its inputs and output types.
+ */
+import { beforeAll, describe, expect, it } from 'vitest'
+import rawCoreSpec from '../openapi/core/release.json' with { type: 'json' }
+import rawDtmSpec from '../openapi/dtm/release.json' with { type: 'json' }
+import { deriveOperations } from '../src/codemode/derive-operations'
+import type { DerivedOperation } from '../src/codemode/derive-operations'
+import { getDocsIndex, readDoc, searchDocs } from '../src/codemode/docs-index'
+import { getMethodIndex, searchMethods } from '../src/codemode/method-search'
+import type { DocsIndex } from '../src/codemode/docs-index'
+import { renderMethodDeclaration } from '../src/codemode/type-render'
+import { preprocessOpenApi } from '../src/utils/openapi-preprocessor'
+import type { Spec } from '../src/utils/spec-resolution'
+
+let ops: DerivedOperation[]
+let dtmOps: DerivedOperation[]
+let docsIndex: DocsIndex
+
+beforeAll(async () => {
+  // The preprocessor mutates in place and the JSON modules are cached per
+  // run — clone so other tests never see a preprocessed spec.
+  const spec = await preprocessOpenApi(structuredClone(rawCoreSpec) as unknown as Spec)
+  ops = deriveOperations(spec)
+  // DTM runs through the same servicePrefix rewrite the bundled-services
+  // build plugin and live discovery apply.
+  const dtmSpec = await preprocessOpenApi(structuredClone(rawDtmSpec) as unknown as Spec, { servicePrefix: '/service/dtm' })
+  dtmOps = deriveOperations(dtmSpec)
+  docsIndex = getDocsIndex({}, () => [{ namespace: 'c8y', spec }, { namespace: 'dtm', spec: dtmSpec }])
+})
+
+describe('deriveOperations on the real core spec', () => {
+  it('derives every operation with a unique operationId-based name', () => {
+    expect(ops.length).toBeGreaterThan(200)
+    expect(new Set(ops.map((o) => o.name)).size).toBe(ops.length)
+    expect(ops.every((o) => /^[a-z_$][\w$]*$/i.test(o.name))).toBe(true)
+  })
+
+  it('derives the alarm collection endpoint with resolved $ref parameters', () => {
+    const op = ops.find((o) => o.name === 'getAlarmCollectionResource')!
+    expect(op.method).toBe('GET')
+    expect(op.path).toBe('/alarm/alarms')
+    expect(op.summary).toBe('Retrieve all alarms')
+    expect(op.tags).toContain('Alarms')
+
+    // In the raw spec these parameters are `$ref`s into components.parameters
+    // — an unresolved ref would leave the input schema empty.
+    const props = op.inputSchema.properties!
+    expect(Object.keys(props).length).toBeGreaterThan(5)
+    expect(props).toHaveProperty('severity')
+    expect(props).toHaveProperty('pageSize')
+    expect((props.severity as { description?: string }).description).toBeTruthy()
+  })
+
+  it('derives output schemas from $ref-ed 2xx responses', () => {
+    const op = ops.find((o) => o.name === 'getAlarmCollectionResource')!
+    expect(op.outputSchema).toBeDefined()
+    expect(JSON.stringify(op.outputSchema)).toContain('alarms')
+  })
+
+  it('derives request bodies with required flags', () => {
+    const op = ops.find((o) => o.name === 'postAlarmCollectionResource')!
+    expect(op.inputSchema.properties).toHaveProperty('body')
+    expect(op.inputSchema.required).toContain('body')
+  })
+
+  it('distinguishes HTTP methods on the same path via operationIds', () => {
+    const alarmOps = ops.filter((o) => o.path === '/alarm/alarms')
+    const byMethod = new Map(alarmOps.map((o) => [o.method, o.name]))
+    expect(byMethod.get('GET')).toBe('getAlarmCollectionResource')
+    expect(byMethod.get('POST')).toBe('postAlarmCollectionResource')
+    expect(byMethod.get('PUT')).toBe('putAlarmCollectionResource')
+    expect(byMethod.get('DELETE')).toBe('deleteAlarmCollectionResource')
+  })
+
+  it('resolves path-parameter operations', () => {
+    const op = ops.find((o) => o.name === 'getAlarmResource')!
+    expect(op.path).toBe('/alarm/alarms/{id}')
+    expect(op.parameters.some((p) => p.name === 'id' && p.in === 'path')).toBe(true)
+    expect(op.inputSchema.required).toContain('id')
+  })
+})
+
+describe('renderMethodDeclaration on the real core spec', () => {
+  it('renders a full typed declaration for the alarm collection endpoint', () => {
+    const op = ops.find((o) => o.name === 'getAlarmCollectionResource')!
+    const { types, signature } = renderMethodDeclaration('c8y', op.name, {
+      inputSchema: op.inputSchema,
+      outputSchema: op.outputSchema,
+    })
+
+    expect(signature).toBe('c8y.getAlarmCollectionResource(input: GetAlarmCollectionResourceInput): Promise<GetAlarmCollectionResourceOutput>')
+    expect(types).toContain('type GetAlarmCollectionResourceInput =')
+    expect(types).toContain('severity?:')
+    expect(types).toContain('pageSize?: number;')
+    expect(types).toContain('@minimum 1 @maximum 2000 @example 10')
+    expect(types).toContain('type GetAlarmCollectionResourceOutput =')
+    expect(types).toContain('alarms?:')
+    // Property JSDoc from the real parameter descriptions must survive.
+    expect(types).toMatch(/\/\*\*[\s\S]*severity/)
+  })
+})
+
+describe('method search on the real specs', () => {
+  it('finds the collection method for the queries that failed in live usage', () => {
+    const items = [
+      ...ops.map((o) => ({ target: `c8y.${o.name}`, namespace: 'c8y', method: o.name, httpMethod: o.method, apiPath: o.path, summary: o.summary })),
+      ...dtmOps.map((o) => ({ target: `dtm.${o.name}`, namespace: 'dtm', method: o.name, httpMethod: o.method, apiPath: o.path, summary: o.summary })),
+    ]
+    const index = getMethodIndex({}, () => items)
+    // "dtm asset" buried getAssets at #10 with the old token scorer; the
+    // fuzzy engine must keep it in the visible results.
+    expect(searchMethods(index, 'dtm asset').results.map((entry) => entry.target)).toContain('dtm.getAssets')
+    // "list assets" returned unrelated noise with the old full-coverage rule.
+    expect(searchMethods(index, 'list assets').results.map((entry) => entry.target)).toContain('dtm.getAssets')
+    // Multi-phrasing union in one call.
+    const multi = searchMethods(index, ['list assets', 'retrieve assets'])
+    expect(multi.results.map((entry) => entry.target)).toContain('dtm.getAssets')
+  })
+})
+
+describe('docs flow on the real specs', () => {
+  it('the query-language pointer in a param description leads to the grammar via docs.search', () => {
+    // Core's `query` parameter description only says "Details … can be found
+    // in [Query language]" — the agent is expected to turn that phrase into a
+    // docs.search. The topic must outrank the many endpoint docs whose param
+    // prose also mentions "query language".
+    const hits = searchDocs(docsIndex, 'query language')
+    expect(hits.length).toBeGreaterThan(0)
+    expect(hits[0]!.id).toBe('c8y::topic::Query language')
+    expect(hits[0]!.kind).toBe('topic')
+
+    const doc = readDoc(docsIndex, hits[0]!.id)!
+    expect(doc.text.length).toBeGreaterThan(4000)
+    expect(doc.text).toContain('$filter')
+  })
+})
+
+describe('deriveOperations on the real DTM spec', () => {
+  it('derives service-prefixed paths with hand-authored operationId names', () => {
+    const op = dtmOps.find((o) => o.path === '/service/dtm/assets' && o.method === 'GET')!
+    expect(op.name).toBe('getAssets')
+    expect(dtmOps.every((o) => o.path.startsWith('/service/dtm/'))).toBe(true)
+  })
+
+  it('renders the DTM query parameter with its c8y:query format marker', () => {
+    const op = dtmOps.find((o) => o.path === '/service/dtm/assets' && o.method === 'GET')!
+    const { types } = renderMethodDeclaration('dtm', op.name, {
+      inputSchema: op.inputSchema,
+      outputSchema: op.outputSchema,
+    })
+    // The preprocessor stamps `format: "c8y:query"` on Cumulocity Query
+    // Language parameters ($filter grammar); the renderer surfaces it as an
+    // @format JSDoc tag — the hook that should send an agent to docs.search
+    // for the grammar.
+    expect(types).toContain('@format c8y:query')
+  })
+})

--- a/test/spec-resolution.test.ts
+++ b/test/spec-resolution.test.ts
@@ -85,3 +85,19 @@ describe('getBundledOnlySpecs', () => {
     expect(getBundledOnlySpecs().core).toEqual(resolveSpecs([], EMPTY_INSTALLED).core)
   })
 })
+
+describe('resolveSpecs — identity memoization', () => {
+  it('returns the same object for the same discovery inputs', () => {
+    const discovered = [makeDiscovered('svcA')]
+    const installed = new Set(['svcA'])
+    expect(resolveSpecs(discovered, installed)).toBe(resolveSpecs(discovered, installed))
+  })
+
+  it('returns a fresh object when either input changes identity', () => {
+    const discovered = [makeDiscovered('svcA')]
+    const installed = new Set(['svcA'])
+    const resolved = resolveSpecs(discovered, installed)
+    expect(resolveSpecs([makeDiscovered('svcA')], installed)).not.toBe(resolved)
+    expect(resolveSpecs(discovered, new Set(['svcA']))).not.toBe(resolved)
+  })
+})

--- a/test/status.test.ts
+++ b/test/status.test.ts
@@ -9,7 +9,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { c8yMcpServer } from '../src/server-instance'
 import { createStatusTool } from '../src/tools/status'
-import { bustApiSpecCache, setCachedApiSpecs } from '../src/utils/api-discovery'
+import { bustApiSpecCache } from '../src/utils/api-discovery'
 
 // Stub @c8y/client so the refresh path can build a client without a real
 // HTTP stack. discovery itself is stubbed below.
@@ -122,7 +122,7 @@ describe('status tool', () => {
     const out = await callStatus({ refresh: false })
     expect(out).toContain('Active tenant: (none)')
     expect(out).toContain('Stored credentials: (none)')
-    expect(out).toContain('coreSpec')
+    expect(out).not.toContain('Visible API namespaces')
   })
 
   it('is a noop when refresh:true is requested without an active tenant', async () => {
@@ -144,32 +144,20 @@ describe('status tool', () => {
     expect(out).toContain('call set-active-tenant')
   })
 
-  it('enriches visible service specs with appLabel/specLabel from the discovery cache', async () => {
-    // Seed the discovery cache for a tenant the CLI is currently active on
-    // by stashing matching creds and pointing the active context at it.
+  it('does not list API namespaces — discovery belongs to the codemode tool', async () => {
     globalThis._getStoredC8yAuth = vi.fn(async () => [
       { tenantUrl: 'https://t1.cumulocity.com', tenantId: 't1', user: 'u', password: 'p' },
     ])
-    globalThis._getCredentialsByTenantUrl = vi.fn(async () => ({
-      tenantUrl: 'https://t1.cumulocity.com',
-      tenantId: 't1',
-      user: 'u',
-      password: 'p',
-    }))
-    setCachedApiSpecs(
-      't1',
-      [{ contextPath: 'dtm', appLabel: 'Digital Twin Manager', specLabel: 'DTM REST', servicePrefix: '/service/dtm', spec: { paths: {} } }],
-    )
     setCustomContext({
       auth: { tenantUrl: 'https://t1.cumulocity.com', authorizationHeader: 'Basic xxx' },
       specs: { core: { paths: {} }, specs: { dtm: { paths: {} } } },
     })
-    // Mark the CLI tenant context as active so the label-enrichment path
-    // looks up the tenantId via _getCredentialsByTenantUrl.
     setActiveCliTenant('https://t1.cumulocity.com')
 
     const out = await callStatus({ refresh: false })
-    expect(out).toContain('serviceSpecs.dtm — Digital Twin Manager / DTM REST')
+    expect(out).toContain('Active tenant: https://t1.cumulocity.com')
+    expect(out).not.toContain('Visible API namespaces')
+    expect(out).not.toContain('dtm')
   })
 
   it('runs a fresh discovery when refresh:true is requested with an active tenant', async () => {
@@ -197,7 +185,7 @@ describe('status tool', () => {
     const out = await callStatus({ refresh: true })
     expect(out).toContain('Refreshed API discovery for https://t1.cumulocity.com')
     expect(out).toContain('1 spec(s) downloaded')
-    expect(out).toContain('serviceSpecs.newsvc')
+    expect(out).not.toContain('Visible API namespaces')
   })
 
   it('surfaces refresh failures without crashing the status output', async () => {

--- a/test/type-render.test.ts
+++ b/test/type-render.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest'
+import { jsonSchemaToType, renderMethodDeclaration } from '../src/codemode/type-render'
+
+describe('jsonSchemaToType', () => {
+  it('renders objects with optional markers and property JSDoc', () => {
+    const rendered = jsonSchemaToType({
+      type: 'object',
+      properties: {
+        type: { type: 'string', description: 'The alarm type.' },
+        pageSize: { type: 'number' },
+      },
+      required: ['type'],
+    }, 'Input')
+
+    expect(rendered).toContain('/** The alarm type. */')
+    expect(rendered).toContain('type: string;')
+    expect(rendered).toContain('pageSize?: number;')
+  })
+
+  it('renders enums, nullable, arrays, and unions', () => {
+    expect(jsonSchemaToType({ enum: ['A', 'B'] }, 'T')).toBe('type T = "A" | "B"')
+    expect(jsonSchemaToType({ type: 'string', nullable: true }, 'T')).toBe('type T = string | null')
+    expect(jsonSchemaToType({ type: 'array', items: { type: 'number' } }, 'T')).toBe('type T = number[]')
+    expect(jsonSchemaToType({ anyOf: [{ type: 'string' }, { type: 'number' }] }, 'T')).toBe('type T = string | number')
+    expect(jsonSchemaToType({ type: ['string', 'null'] }, 'T')).toBe('type T = string | null')
+  })
+
+  it('resolves internal $refs and degrades cycles to unknown', () => {
+    const schema = {
+      type: 'object',
+      properties: { child: { $ref: '#/definitions/Node' } },
+      definitions: { Node: { type: 'object', properties: { self: { $ref: '#/definitions/Node' } } } },
+    } as Parameters<typeof jsonSchemaToType>[0]
+
+    const rendered = jsonSchemaToType(schema, 'T')
+    expect(rendered).toContain('child?:')
+    expect(rendered).toContain('unknown')
+  })
+
+  it('renders bounds, example, and format as one compact JSDoc tag line', () => {
+    const rendered = jsonSchemaToType({
+      type: 'object',
+      properties: {
+        pageSize: { type: 'number', description: 'Entries per page.', minimum: 1, maximum: 2000, example: 10 },
+        query: { type: 'string', format: 'c8y:query', example: '$filter=(owner+eq+\'manga\')' },
+      },
+    }, 'T')
+
+    expect(rendered).toContain('* Entries per page.')
+    expect(rendered).toContain('* @minimum 1 @maximum 2000 @example 10')
+    expect(rendered).toContain('/** @example $filter=(owner+eq+\'manga\') @format c8y:query */')
+    // Not opted in: no default tag.
+    expect(rendered).not.toContain('@default')
+  })
+
+  it('quotes non-identifier property names', () => {
+    const rendered = jsonSchemaToType({ type: 'object', properties: { 'X-Custom-Header': { type: 'string' } } }, 'T')
+    expect(rendered).toContain('"X-Custom-Header"?: string;')
+  })
+})
+
+describe('renderMethodDeclaration', () => {
+  it('emits input/output aliases and a bare signature — docs live as JSDoc inside the types', () => {
+    const { types, signature } = renderMethodDeclaration('c8y', 'getAlarm', {
+      inputSchema: { type: 'object', properties: { id: { type: 'string', description: 'Alarm id' } }, required: ['id'] },
+      outputSchema: { type: 'object', properties: { severity: { type: 'string' } } },
+    })
+
+    expect(types).toContain('type GetAlarmInput =')
+    expect(types).toContain('/** Alarm id */')
+    expect(types).toContain('type GetAlarmOutput =')
+    expect(types).toContain('severity?: string;')
+    expect(signature).toBe('c8y.getAlarm(input: GetAlarmInput): Promise<GetAlarmOutput>')
+  })
+
+  it('falls back to unknown output when no outputSchema exists', () => {
+    const { types } = renderMethodDeclaration('c8y', 'getX', { inputSchema: { type: 'object' } })
+    expect(types).toContain('type GetXOutput = unknown')
+  })
+})


### PR DESCRIPTION
## What

Replaces the `query`/`execute` tool pair with a single `codemode` tool. Agent code runs in a sandbox where API discovery, documentation search, and typed live API calls are all globals — one find→inspect→call cycle per tool invocation.

## Highlights

- **Typed namespaces derived from OpenAPI**: `c8y` (core) plus one global per microservice available on the tenant (e.g. `dtm`) — one method per operation (`c8y.getAlarmCollectionResource({...})`), named by operationId, with a `request()` escape hatch. Structural `$ref`s, vendor `+json` media types, path-item parameters, and `explode:false` array serialization handled.
- **In-sandbox discovery**: `codemode.search` (MiniSearch, fuzzy, multi-phrasing, top 20) and `codemode.describe` (method-only types with OpenAPI docs as JSDoc incl. `@minimum/@maximum/@example/@format`; shortlist arrays up to 5; namespace overview). `docs.search`/`docs.read` cover tag topics (query-language grammars etc.).
- **Policy-aware discovery**: operations blocked by restriction/allow rules (or `x-mc8yp-exclude`) never appear in namespaces, search, describe, or docs; the safeFetch middleware stays the enforcement boundary.
- **Multi-tenant caching**: per-tenant discovery → memoized `resolveSpecs` → WeakMap-cached derivation, method index, and docs index; all invalidated by discovery refresh via object identity.
- **Sandbox runtime on iso4 0.2.x**: ESM host modules + a static entry module replace string preambles; the sandbox has no fetch surface.
- **Prompting**: workflow tuned against observed agent failures (describe-first orientation, shortlist comparison, server-side querying preference, read-docs-to-the-end).

## Breaking

- MCP tools `query` and `execute` are removed; the `cumulocity` sandbox global is gone (escape hatch is now `<ns>.request()`). Requires a major version bump.
- `status` (CLI) no longer lists API namespaces — discovery lives in the codemode tool.
- `HTTP_METHODS` gains `QUERY`.
