### PR TITLE
fix: add mc8yp-no-sandbox header/query to disable server-mode sandbox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ The project exposes a single code-mode tool to AI agents instead of a large fixe
   - `docs.search(query, opts?)` / `docs.read(id)` — MiniSearch-backed fuzzy full-text search over spec prose (tag docs like query-language grammars, info blocks, operation/parameter descriptions)
   - `c8y` (core, always present) plus one namespace per service available on the tenant (e.g. `dtm`) — one typed method per derived operation. Namespaces are the COMPLETE sandbox surface: there is no raw-request escape hatch, and the backing protocol (OpenAPI vs MCP) is deliberately invisible to the agent
   - services that declare `exposeMcpServers` in their manifest are wrapped from their **MCP server** instead (one typed method per MCP tool) — MCP is preferred over the OpenAPI spec when a service has both, with a per-connection opt-out (`mc8yp-no-mcp` header / `noMcp` query / `--no-mcp` CLI flag) that falls back to the spec
-  - `sandbox` (**server mode only**) — an in-memory shell + virtual filesystem (`just-bash`, core shell only: `jq`/`awk`/`grep`/`sed`/`sort`/`sqlite3`, no network, no host FS) for wrangling fetched data. Mirrors [Flue's `SandboxApi`](https://flueframework.com/docs/api/sandbox-api/) plus an mc8yp-only `clear()`. One sandbox per MCP session (persists across codemode calls, keyed by `ctx.sessionId`), idle-evicted after 15 minutes; nothing touches disk. CLI mode does not expose it — local harnesses bring their own file I/O. Backed by a swappable adapter so the provider can change later.
+  - `sandbox` (**server mode only**) — an in-memory shell + virtual filesystem (`just-bash`, core shell only: `jq`/`awk`/`grep`/`sed`/`sort`/`sqlite3`, no network, no host FS) for wrangling fetched data. Mirrors [Flue's `SandboxApi`](https://flueframework.com/docs/api/sandbox-api/) plus an mc8yp-only `clear()`. One sandbox per MCP session (persists across codemode calls, keyed by `ctx.sessionId`), idle-evicted after 15 minutes; nothing touches disk. CLI mode does not expose it — local harnesses bring their own file I/O. Backed by a swappable adapter so the provider can change later. Per-connection opt-out via the `mc8yp-no-sandbox` header / `noSandbox` query param (server mode only — same shape as the `noMcp` opt-out, but a plain boolean since there is only one sandbox per connection, not one per service); opted-out sessions never see the `sandbox` global at all.
 - `status` is available only in CLI mode: it lists the active tenant, stored credentials, and the API namespaces currently visible. It accepts `{ refresh: true }` to force a fresh API discovery on demand (noop when no tenant is active). Server mode has no in-protocol equivalent yet — use the `POST /refresh-apis` HTTP route for ops-driven refresh; an in-protocol server-side flow will land in a separate PR.
 
 The repository supports two runtime modes:
@@ -68,7 +68,7 @@ src/
     credentials.ts            OS keyring credential storage and lookup
     mcp-client.ts             Minimal streamable-HTTP MCP client (tools only, no elicitation/sampling)
     restriction-matcher.ts    Restriction compilation and path matching helpers
-    restrictions.ts           Restriction parsing, query handling, and the noMcp opt-out
+    restrictions.ts           Restriction parsing, query handling, and the noMcp/noSandbox opt-outs
     schema.ts                 Shared schema helpers
     capability-resolution.ts        `resolveCapabilities` plus the shared `Spec`/`PathItem`/`OperationInfo` types
 test/
@@ -115,7 +115,7 @@ src/openapi-modules.d.ts      Ambient type declarations for the `#core-openapi` 
 
 1. `src/index.ts` starts the HTTP server and exposes `/mcp` and `/health`.
 2. It sets `globalThis.executionEnvironment = 'server'`.
-3. It extracts auth from request headers, restrictions from `restriction`, `restrict`, and `r` query parameters plus the `mc8yp-restriction` header, and allow rules from `allowed`, `allow`, and `a` query parameters plus the `mc8yp-allow` header.
+3. It extracts auth from request headers, restrictions from `restriction`, `restrict`, and `r` query parameters plus the `mc8yp-restriction` header, allow rules from `allowed`, `allow`, and `a` query parameters plus the `mc8yp-allow` header, the MCP-wrapping opt-out from the `noMcp` query param plus the `mc8yp-no-mcp` header, and the scratch-sandbox opt-out from the `noSandbox` query param plus the `mc8yp-no-sandbox` header.
 4. It stores auth in request-local context and forwards the request to the shared MCP server.
 5. It configures the HTTP transport in POST-only mode (`disableSse: true`) because the optional long-lived GET/SSE channel proved unstable behind Cumulocity microservice ingress.
 
@@ -184,7 +184,9 @@ Build-time behaviour:
 
 ### The Sandbox Scratch Surface (`sandbox`)
 
-**Server mode only.** A non-tenant compute surface for agent data-wrangling, deliberately isolated from the live request path: no network, no host filesystem, never reaches Cumulocity. In CLI mode the `sandbox` global does not exist at all — local agent harnesses bring their own file I/O, so it would be dead weight. `execute()` builds it only when `custom.env === 'server'` and a `ctx.sessionId` is present; otherwise `buildApiModule` omits the key and the global is absent.
+**Server mode only.** A non-tenant compute surface for agent data-wrangling, deliberately isolated from the live request path: no network, no host filesystem, never reaches Cumulocity. In CLI mode the `sandbox` global does not exist at all — local agent harnesses bring their own file I/O, so it would be dead weight. `execute()` builds it only when `custom.env === 'server'`, a `ctx.sessionId` is present, and the connection has not opted out via `custom.noSandbox`; otherwise `buildApiModule` omits the key and the global is absent.
+
+- **Per-connection opt-out.** The `mc8yp-no-sandbox` header or `noSandbox` query param (`collectServerNoSandboxSources` / `parseNoSandbox` in `src/utils/restrictions.ts`, same source file as the restriction/allow/noMcp parsing) disables the sandbox for that connection. Parsed once per request in `src/index.ts` into `ctx.custom.noSandbox` (a plain boolean — unlike `noMcp` there is no per-service scoping since a connection has exactly one sandbox), and read at the `buildSandboxApi` call site in `execute.ts`. CLI mode has no equivalent flag; it never builds a sandbox regardless.
 
 - **Adapter seam.** `src/codemode/sandbox/types.ts` defines `SandboxAdapter`, kept intentionally identical to Flue's `SandboxApi` so the backend is swappable. `just-bash-adapter.ts` is the only backend today (`new Bash({ cwd: '/' })`, core shell only — `network`/`python`/`javascript` all default-off). The adapter stays Flue-pure; mc8yp-specific concerns live one layer up. `cwd: '/'` matters: just-bash resolves `fs.writeFile('foo')` against `/` but defaults the _shell_ cwd to `/home/user`, so without this a relative `writeFile` then `exec('cat foo')` would miss each other.
 - **`clear()` is NOT part of the adapter contract.** It is an mc8yp-only convenience on the agent-facing `sandbox` global, implemented in `index.ts` by swapping the session's adapter instance — trivial to remove later without touching the seam.

--- a/README.md
+++ b/README.md
@@ -295,6 +295,8 @@ The surface mirrors [Flue's `SandboxApi`](https://flueframework.com/docs/api/san
 
 **Lifecycle:** one in-memory sandbox per MCP session, so files persist across `codemode` calls within a session. It is evicted from memory 15 minutes after its last use (or immediately via `sandbox.clear()`). Nothing is ever written to disk, and sessions never share state. (Cross-call persistence relies on your MCP client maintaining the `mcp-session-id`, which standard clients do.)
 
+**Opting out:** per connection, disable the sandbox entirely with the `mc8yp-no-sandbox` header or the `noSandbox` query param (any of empty, `*`, or `true`). With it set, the `sandbox` global is absent from that session — same as CLI mode.
+
 ---
 
 ## Access policy

--- a/src/codemode/execute.ts
+++ b/src/codemode/execute.ts
@@ -526,9 +526,11 @@ export async function execute(functionCode: string): Promise<string> {
   }
 
   // Server-only scratch workspace, one in-memory sandbox per MCP session
-  // (persists across codemode calls, idle-evicted). CLI mode never exposes it.
+  // (persists across codemode calls, idle-evicted). CLI mode never exposes
+  // it, and a connection can opt out via the `mc8yp-no-sandbox` header or
+  // `noSandbox` query param (parsed into ctx.custom.noSandbox in src/index.ts).
   const sessionId = c8yMcpServer.ctx.sessionId
-  const sandboxApi = c8yMcpServer.ctx.custom?.env === 'server' && sessionId
+  const sandboxApi = c8yMcpServer.ctx.custom?.env === 'server' && sessionId && !c8yMcpServer.ctx.custom?.noSandbox
     ? buildSandboxApi(sessionId)
     : undefined
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,9 +12,11 @@ import {
   RESTRICTION_QUERY_KEYS,
   collectServerAllowSources,
   collectServerNoMcpSources,
+  collectServerNoSandboxSources,
   collectServerRestrictionSources,
   parseAllowRule,
   parseNoMcp,
+  parseNoSandbox,
   parseRestrictionRule,
 } from './utils/restrictions'
 import { BasicAuth, Client, MicroserviceClientRequestAuth } from '@c8y/client'
@@ -105,6 +107,7 @@ const app = new H3().all('/mcp', async (event) => {
   }
 
   const noMcp = parseNoMcp(collectServerNoMcpSources(query, event.req.headers))
+  const noSandbox = parseNoSandbox(collectServerNoSandboxSources(query, event.req.headers))
 
   return transport.respond(event.req, {
     env: 'server' as const,
@@ -118,6 +121,7 @@ const app = new H3().all('/mcp', async (event) => {
     restrictions,
     allowRules: parsedAllowRules,
     noMcp,
+    noSandbox,
     specs,
   })
 })

--- a/src/types/mcp-context.ts
+++ b/src/types/mcp-context.ts
@@ -31,6 +31,13 @@ export interface C8yMcpCustomContext extends Record<string, unknown> {
    */
   noMcp?: NoMcpConfig
   /**
+   * Connection-level opt-out for the server-mode scratch `sandbox` workspace
+   * (`mc8yp-no-sandbox` header, `noSandbox` query param). Server mode only —
+   * CLI mode never builds a sandbox regardless of this flag. Absent or
+   * `false` means the sandbox is built normally.
+   */
+  noSandbox?: boolean
+  /**
    * Resolved specs for the query sandbox: always-available `core` plus a
    * service-spec map keyed by contextPath (bundled service entries + any
    * non-bundled discovered services). Paths are already prefixed.

--- a/src/utils/restrictions.ts
+++ b/src/utils/restrictions.ts
@@ -5,6 +5,8 @@ export const RESTRICTION_HEADER = 'mc8yp-restriction'
 export const ALLOW_HEADER = 'mc8yp-allow'
 export const NO_MCP_QUERY_KEYS = ['noMcp'] as const
 export const NO_MCP_HEADER = 'mc8yp-no-mcp'
+export const NO_SANDBOX_QUERY_KEYS = ['noSandbox'] as const
+export const NO_SANDBOX_HEADER = 'mc8yp-no-sandbox'
 
 export type HttpMethod = (typeof HTTP_METHODS)[number]
 export type RestrictionMethod = HttpMethod | '*'
@@ -96,6 +98,37 @@ export function parseNoMcp(sources: readonly (string | boolean)[]): NoMcpConfig 
     }
   }
   return { all, contextPaths }
+}
+
+// Per-connection opt-out for the server-mode scratch `sandbox` workspace.
+// Unlike `noMcp` there is nothing to scope to a subset of — the sandbox is a
+// single per-session workspace, not one namespace per service — so the
+// opt-out is a plain boolean rather than a config object.
+export function collectServerNoSandboxSources(query: Record<string, unknown>, headers: Headers): string[] {
+  const raw: string[] = []
+  for (const key of NO_SANDBOX_QUERY_KEYS) {
+    const value = query[key]
+    if (typeof value === 'string')
+      raw.push(value)
+    else if (Array.isArray(value))
+      raw.push(...value.filter((v): v is string => typeof v === 'string'))
+    else if (value !== undefined)
+      raw.push('') // bare ?noSandbox → opt-out
+  }
+  const header = headers.get(NO_SANDBOX_HEADER)
+  if (header !== null)
+    raw.push(header)
+  return raw
+}
+
+/**
+ * Parse sandbox opt-out sources: an empty value, `*`, or `true` disables the
+ * connection's scratch sandbox; anything else (including no sources at all)
+ * leaves it enabled.
+ * @param sources Raw values from query params or headers.
+ */
+export function parseNoSandbox(sources: readonly (string | boolean)[]): boolean {
+  return sources.some((source) => source === true || source === '' || source === '*' || source === 'true')
 }
 
 interface BaseRule {

--- a/test/excute.test.ts
+++ b/test/excute.test.ts
@@ -137,6 +137,7 @@ function stubExecuteCtx(opts: {
   core?: Spec
   services?: Record<string, Spec>
   sessionId?: string
+  noSandbox?: boolean
 } = {}): () => void {
   const ctxSpy = vi.spyOn(c8yMcpServer, 'ctx', 'get').mockReturnValue({
     sessionId: opts.sessionId,
@@ -146,6 +147,7 @@ function stubExecuteCtx(opts: {
       allowRules: opts.allowRules ?? [],
       specs: { core: opts.core ?? ({ paths: {} } as unknown as Spec), specs: opts.services ?? {} },
       auth: opts.auth,
+      noSandbox: opts.noSandbox,
     },
   } as unknown as ReturnType<typeof c8yMcpServer['ctx']['valueOf']>)
   return () => ctxSpy.mockRestore()
@@ -733,6 +735,17 @@ describe('sandbox surface', () => {
 
   it('is absent in server mode without a session id', async () => {
     const restore = stubExecuteCtx({ env: 'server' })
+    try {
+      mockAuth(TEST_TENANT)
+      const result = await execute('async () => typeof sandbox')
+      expect(result).toBe(encode('undefined'))
+    } finally {
+      restore()
+    }
+  })
+
+  it('is absent in server mode when the connection opted out via noSandbox', async () => {
+    const restore = stubExecuteCtx({ env: 'server', sessionId: 's1', noSandbox: true })
     try {
       mockAuth(TEST_TENANT)
       const result = await execute('async () => typeof sandbox')

--- a/test/restrictions.test.ts
+++ b/test/restrictions.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, it } from 'vitest'
 import { findBlockingRestrictions, findMatchingRules } from '../src/utils/restriction-matcher'
 import {
   ALLOW_HEADER,
+  NO_SANDBOX_HEADER,
   RESTRICTION_HEADER,
   collectServerAllowSources,
+  collectServerNoSandboxSources,
   collectServerRestrictionSources,
   parseAllowRule,
+  parseNoSandbox,
   parseRestrictionRule,
 } from '../src/utils/restrictions'
 
@@ -268,6 +271,35 @@ describe('server access policy input collection', () => {
         { rule: '*:', reason: 'Allow path pattern must not be empty.' },
       ],
     })
+  })
+})
+
+describe('server sandbox opt-out input collection', () => {
+  it('collects a bare noSandbox query flag as a blanket opt-out', () => {
+    expect(collectServerNoSandboxSources({ noSandbox: '' }, new Headers())).toEqual([''])
+  })
+
+  it('collects an explicit noSandbox query value and the header', () => {
+    const headers = new Headers({ [NO_SANDBOX_HEADER]: 'true' })
+    expect(collectServerNoSandboxSources({ noSandbox: 'false' }, headers)).toEqual(['false', 'true'])
+  })
+
+  it('returns no sources when neither the query flag nor the header is present', () => {
+    expect(collectServerNoSandboxSources({}, new Headers())).toEqual([])
+  })
+})
+
+describe('parseNoSandbox', () => {
+  it('treats empty, star, and boolean-true values as an opt-out', () => {
+    expect(parseNoSandbox([''])).toBe(true)
+    expect(parseNoSandbox(['*'])).toBe(true)
+    expect(parseNoSandbox([true])).toBe(true)
+    expect(parseNoSandbox(['true'])).toBe(true)
+  })
+
+  it('leaves the sandbox enabled for no sources or unrecognized values', () => {
+    expect(parseNoSandbox([])).toBe(false)
+    expect(parseNoSandbox(['false'])).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary
- Adds a per-connection opt-out for the server-mode scratch `sandbox` workspace, mirroring the existing `mc8yp-no-mcp` opt-out: `mc8yp-no-sandbox` header or `noSandbox` query param (empty, `*`, or `true`).
- This was previously missing — there was no way to disable the sandbox for a connection short of it being absent by mode (CLI never has it, server always did if a session id was present).
- Parsed once per request in `src/index.ts` into `ctx.custom.noSandbox`, and read at the `buildSandboxApi` call site in `src/codemode/execute.ts` — opted-out sessions get no `sandbox` global at all, same as CLI mode.

## Test plan
- [x] `pnpm test:run` — added coverage in `test/restrictions.test.ts` (source collection + parsing) and `test/excute.test.ts` (sandbox global absent when opted out)
- [x] `pnpm lint:fix`
- [x] `pnpm typecheck`