### PR TITLE
docs: add Claude Code CLI setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,32 @@ With read-only access rules:
 }
 ```
 
+### Add to Claude Code
+
+The quickest way to register mc8yp is the [Claude Code](https://docs.claude.com/en/docs/claude-code) CLI. Everything after `--` is passed to the mc8yp subprocess, so access-policy flags go there:
+
+```sh
+# Local CLI (stdio) — default scope is this project only
+claude mcp add mc8yp -- pnpm dlx mc8yp
+
+# Make it available in every project (user scope)
+claude mcp add -s user mc8yp -- pnpm dlx mc8yp
+
+# Pin a bundled core spec and add read-only access rules
+claude mcp add mc8yp -- pnpm dlx mc8yp --spec 2025 \
+  -a "GET:/inventory/**" -a "GET:/alarm/**" -a "GET:/measurement/**"
+```
+
+For deployed **microservice mode**, add it as an HTTP server instead:
+
+```sh
+claude mcp add --transport http mc8yp \
+  https://<tenant>.cumulocity.com/service/mc8yp-server/mcp \
+  --header "Authorization: Bearer <token>"
+```
+
+Manage the entry with `claude mcp list`, `claude mcp get mc8yp`, and `claude mcp remove mc8yp`.
+
 ---
 
 ## Tools and prompts


### PR DESCRIPTION
## What

Adds a dedicated **"Add to Claude Code"** section to the README under the local CLI setup, documenting the exact `claude mcp add` invocations for registering mc8yp.

## Why

The Claude Code CLI is the most convenient way to register mc8yp, but the exact command is easy to forget. This puts it front and center.

## Covered

- **stdio (local CLI)** — `claude mcp add mc8yp -- pnpm dlx mc8yp`, plus a `-s user` variant and one showing access-policy flags (`--spec`, `-a`) passed after `--`.
- **HTTP (microservice mode)** — `claude mcp add --transport http mc8yp <url> --header "Authorization: Bearer <token>"`.
- Management commands: `claude mcp list` / `get` / `remove`.

Docs-only change.