### PR TITLE
feat: resolve external MCP server configuration before it is used

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ src/
   utils/
     capability-discovery.ts          Per-tenant live capability discovery (OpenAPI specs + MCP servers) with 30-min refresh cache
     external-mcp.ts           Connection-supplied MCP server config: header collection, JSON entry parsing/validation, auth headers, transport
+    external-mcp-resolve.ts   Configure-time resolution for those entries: namespace derivation, collision classification, uncached handshake (POST /resolve-mcp-servers)
     auth.ts                   Authorization header parsing for server mode
     c8y-types.ts              Cumulocity-specific shared types
     client.ts                 Auth/header resolution for live requests
@@ -87,7 +88,8 @@ test/
   restrictions.test.ts
   restrictions.bench.ts
   external-mcp.test.ts        External MCP config parsing, namespace assembly, per-session tool-list cache
-openapi.json                 Self-describing OpenAPI for mc8yp's non-MCP HTTP surface; referenced from cumulocity.json so the deployed microservice is discoverable via the standard openApiSpec discovery flow
+  external-mcp-resolve.test.ts  Namespace derivation, collision classification (reserved/tenant/duplicate), probe outcomes
+openapi.json                 Self-describing OpenAPI for mc8yp's non-MCP HTTP surface (/refresh-apis, /resolve-mcp-servers, /health); referenced from cumulocity.json so the deployed microservice is discoverable via the standard openApiSpec discovery flow
 openapi/
   core/
     release.json             Bundled latest Cumulocity core OpenAPI snapshot
@@ -117,7 +119,7 @@ src/openapi-modules.d.ts      Ambient type declarations for the `#core-openapi` 
 
 #### Microservice mode
 
-1. `src/index.ts` starts the HTTP server and exposes `/mcp` and `/health`.
+1. `src/index.ts` starts the HTTP server and exposes `/mcp`, `/refresh-apis`, `/resolve-mcp-servers`, `/health` and `/openapi.json`.
 2. It sets `globalThis.executionEnvironment = 'server'`.
 3. It extracts auth from request headers, restrictions from `restriction`, `restrict`, and `r` query parameters plus the `mc8yp-restriction` header, and allow rules from `allowed`, `allow`, and `a` query parameters plus the `mc8yp-allow` header. External MCP servers come from the `mc8yp-mcp-server` header only (no query equivalent — the value carries credentials); a malformed entry is a 400, not a silent skip.
 4. It stores auth in request-local context and forwards the request to the shared MCP server.
@@ -166,6 +168,11 @@ Servers the CONNECTION brings, not the tenant: `mc8yp-mcp-server` header (repeat
 - **`sendAuthentication` is hardcoded `false`** for these namespaces and tenant auth is never forwarded — a third-party host must not receive tenant credentials. They are also tenant-INDEPENDENT: dispatch works with no active tenant.
 - **`noMcp` does not apply.** That opt-out selects between a service's MCP and OpenAPI views; an external server has no spec view to fall back to.
 - **Egress is deliberately unrestricted** (owner's call, 2026-08-18): any host, `http` or `https`, no allowlist, no private-range blocking, `pinDns` not involved — external calls do not go through `createCumulocitySafeFetch` at all. The trade-off is recorded in README: whoever can set headers on the deployment can make it issue requests to any address it can reach. If this ever needs tightening, the single choke point is `createExternalMcpFetch`.
+- **`POST /resolve-mcp-servers` is the configure-time counterpart** (`src/utils/external-mcp-resolve.ts`, documented in `openapi.json`). It takes the same entries with a FREE-FORM `name`, derives the namespace each would be mounted under (`deriveExternalMcpNamespace` → `sanitizeToolName`, the same rule contextPaths get), classifies namespace collisions (`reserved` / `tenant` / `request`), and handshakes what is left — returning the tool list the agent would actually see. It exists because three things a header-building consumer needs are only knowable in here: the derivation, the tenant's namespace set, and the MCP auth semantics of these entries. Four rules hold it together:
+  - **It reuses `validateExternalMcpEntry`** (the header path's own validator, exported for exactly this). A route that green-lights an entry the header then 400s would be worse than no route.
+  - **The runtime contract is unchanged.** Derivation is configure-time only: a caller resolves a display name once, stores the returned `namespace`, and keeps sending it verbatim, so the agent-visible global cannot shift when the derivation is refined. The header still validates `name` as an identifier and uses it as given — do NOT make it derive.
+  - **The handshake is `probeExternalMcpServer`, which bypasses the session cache** in both directions: an operator asking "does this token work" must not be answered from a 15-minute-old tool list, and a candidate that may never be saved must not seed the cache.
+  - **A tenant-collision verdict needs discovery**, which can legitimately be unavailable. `tenantNamespaces: null` plus a `warnings` entry says the check did not run; reporting a namespace as free when nobody looked is the failure this route exists to remove. When nothing is warmed yet the route discovers on demand (service user, like `/refresh-apis`) rather than guessing.
 - **Method index**: external methods are connection-scoped, so they must NOT enter the per-tenant `getMethodIndex` WeakMap. `execute` reuses the cached tenant items and re-indexes them together with the external ones via the uncached `buildMethodIndex` — only when external servers are actually configured. The docs index is untouched (MCP tools carry no tag docs).
 
 ### Bundled OpenAPI Selection

--- a/README.md
+++ b/README.md
@@ -61,9 +61,45 @@ Behaviour worth knowing:
 - **The agent is told which namespaces are external.** `codemode.describe()` labels them `EXTERNAL MCP server at <url> — configured for this connection, NOT part of this tenant`, and the per-method describe repeats it. Whether a tenant namespace is backed by OpenAPI or MCP stays hidden (an implementation detail the agent cannot act on); tenant-vs-third-party is a data boundary it must be able to report on.
 - **Tool lists are fetched on first use and cached per MCP session**, then dropped 15 minutes after last use or immediately when the client closes its session cleanly. Rotating a token or changing a URL mid-session re-handshakes.
 - **A malformed entry fails the request** (HTTP 400 in server mode, a startup error in CLI) rather than silently leaving the agent without a namespace it was supposed to have. A well-formed but _unreachable_ server is reported in the `codemode.describe()` overview and retried on the next call.
-- **The tenant wins name collisions.** An external entry whose `name` matches a tenant namespace is skipped, so a header cannot shadow a real service.
+- **The tenant wins name collisions.** An external entry whose `name` matches a tenant namespace is skipped, so a header cannot shadow a real service. That skip is silent to the caller — use `POST /resolve-mcp-servers` (below) to catch it while configuring rather than discovering it as a missing namespace at run time.
 - **Egress is unrestricted by design.** The URL is used as given — any host, no allowlist, no private-range filtering. The header is part of the connection's trusted configuration (the sandbox cannot set it), but the consequence is that whoever can set headers on the deployed microservice can make it issue requests to any address it can reach, including tenant-internal ones. Front the deployment accordingly.
 - Path-based restriction/allow rules do **not** apply to these namespaces, same as for tenant-discovered MCP tools (see [Access policy](#access-policy)).
+
+#### Checking a configuration before you store it — `POST /resolve-mcp-servers`
+
+Whoever builds that header — a tenant admin UI, a deployment script — cannot answer three things on its own: which namespace an entry gets, whether that namespace is free, and whether the server actually answers with its credentials. This route answers all three in one call, so no consumer has to reimplement mc8yp's namespace rules or its MCP handshake:
+
+```http
+POST /service/mc8yp-server/resolve-mcp-servers
+Content-Type: application/json
+
+{ "servers": [{ "name": "MaStR registry", "url": "https://mastr.example/mcp", "token": "…" }] }
+```
+
+```jsonc
+{
+  "tenantUrl": "https://…cumulocity.com",
+  "tenantId": "t123",
+  "tenantNamespaces": ["c8y", "dtm", "knowledge_base_ms"], // null = the check could not run, see `warnings`
+  "warnings": [],
+  "servers": [
+    {
+      "name": "MaStR registry",
+      "namespace": "MaStR_registry", // derived — store THIS and send it in the header from now on
+      "status": "ok",                // ok | invalid | namespace-taken | unreachable
+      "server": { "name": "mastr-mcp", "version": "1.0.0" },
+      "tools": [{ "name": "search_units", "description": "…" }]
+    }
+  ]
+}
+```
+
+- **`name` may be free-form here.** It is sanitized into the namespace exactly as a contextPath is (`MaStR registry` → `MaStR_registry`, the same rule that makes `knowledge-base-ms` into `knowledge_base_ms`). An identifier passes through unchanged.
+- **`status` is the field to branch on**, and `namespace-taken` is the interesting one: reserved name, a namespace this tenant already holds, or a duplicate inside the same request. That is the collision that would otherwise be a silent skip at run time — `namespaceTakenBy` says who holds it. Tools are still reported for a taken entry, so renaming is the only fix needed.
+- **The header contract does not change.** Derivation is a configure-time convenience: resolve once, store the `namespace` you got back, keep sending it verbatim. The agent-visible namespace stays stable even if the derivation is refined later.
+- **Validation is the header's own**, so this route cannot green-light an entry the header would then 400.
+- **Nothing is persisted, and nothing is cached.** mc8yp holds no external server configuration of its own, and the handshake bypasses the per-session tool-list cache so the answer always reflects the credentials as sent.
+- Requires user auth (Authorization header or session cookie), like `POST /refresh-apis`.
 
 ## Two ways to run it
 

--- a/openapi.json
+++ b/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "mc8yp HTTP API",
     "version": "1.0.0",
-    "description": "Auxiliary REST surface of the mc8yp Cumulocity MCP microservice.\n\nThis spec intentionally documents only the non-MCP HTTP routes (`/refresh-apis`, `/health`). The MCP protocol itself is served at `POST /mcp` over JSON-RPC and is **not** documented here — MCP clients discover tools and prompts via the MCP `tools/list` / `prompts/list` flow, not via OpenAPI. If you are an agent reading this through `serviceSpecs['mc8yp-server']`, you are talking to mc8yp through mc8yp; do not call `/service/mc8yp-server/mcp` from inside `execute`.\n\nThe primary use case for this spec is letting an agent trigger a fresh API discovery in mc8yp itself after subscribing or unsubscribing a microservice in the tenant."
+    "description": "Auxiliary REST surface of the mc8yp Cumulocity MCP microservice.\n\nThis spec intentionally documents only the non-MCP HTTP routes (`/refresh-apis`, `/resolve-mcp-servers`, `/health`). The MCP protocol itself is served at `POST /mcp` over JSON-RPC and is **not** documented here — MCP clients discover tools and prompts via the MCP `tools/list` / `prompts/list` flow, not via OpenAPI. If you are an agent reading this through `serviceSpecs['mc8yp-server']`, you are talking to mc8yp through mc8yp; do not call `/service/mc8yp-server/mcp` from inside `execute`.\n\nThe primary use cases for this spec are letting an agent trigger a fresh API discovery in mc8yp itself after subscribing or unsubscribing a microservice in the tenant, and letting a management UI resolve and check external MCP server configuration before storing it."
   },
   "paths": {
     "/refresh-apis": {
@@ -40,6 +40,49 @@
           },
           "500": {
             "description": "Discovery failed for an unexpected reason.",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/Error" } }
+            }
+          }
+        }
+      }
+    },
+    "/resolve-mcp-servers": {
+      "post": {
+        "operationId": "resolveMcpServers",
+        "summary": "Resolve and check external MCP server configuration before it is used.",
+        "description": "Answers the three questions a caller building the `mc8yp-mcp-server` header cannot answer itself: **which namespace** each entry would be mounted under (derived from its free-form `name` by the same sanitization a Cumulocity contextPath gets, so `MaStR registry` becomes `MaStR_registry`), **whether that namespace is available** (reserved names, namespaces already held by this tenant, and duplicates within the request), and **whether the server answers** — the MCP handshake runs with the entry's own credentials, exactly as it would at runtime, and the tool list it returns is what the agent would see.\n\nWhy this matters: at runtime a tenant namespace always wins a collision and the external server is then **silently skipped**, so the operator believes the agent has a namespace it does not have. This route turns that into a visible `namespace-taken` verdict at configuration time.\n\nThe entry shape is the header's, except that `name` may be free-form here. It is a POST with a body rather than a GET reading the header because the entries carry credentials and the candidate is typically not configured on any connection yet.\n\n**The namespace does not become dynamic.** The header contract stays strict and verbatim: resolve a display name once, store the `namespace` you got back, and send that from then on. Nothing is persisted here — mc8yp holds no external server configuration of its own.\n\nHandshakes are neither served from nor written to the per-session tool-list cache, so the answer always reflects the credentials as sent.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/ResolveMcpServersRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "One resolution per submitted entry, in the order they were sent. A 200 does NOT mean every entry is usable — read each `status`.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ResolveMcpServersResponse" }
+              }
+            }
+          },
+          "400": {
+            "description": "Body was not an object carrying a `servers` array. Per-entry problems are reported as `invalid` inside a 200, not here.",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/Error" } }
+            }
+          },
+          "401": {
+            "description": "No Authorization header or session cookie was provided.",
+            "content": {
+              "application/json": { "schema": { "$ref": "#/components/schemas/Error" } }
+            }
+          },
+          "500": {
+            "description": "Resolution failed for an unexpected reason.",
             "content": {
               "application/json": { "schema": { "$ref": "#/components/schemas/Error" } }
             }
@@ -113,6 +156,130 @@
             "minimum": 0,
             "description": "Number of paths declared by the spec after the service-prefix rewrite."
           }
+        }
+      },
+      "ResolveMcpServersRequest": {
+        "type": "object",
+        "required": ["servers"],
+        "properties": {
+          "servers": {
+            "type": "array",
+            "description": "Candidate entries. An empty array is valid and resolves to an empty result.",
+            "items": { "$ref": "#/components/schemas/ExternalMcpServerCandidate" }
+          }
+        }
+      },
+      "ExternalMcpServerCandidate": {
+        "type": "object",
+        "description": "One external MCP server as an operator configures it — the `mc8yp-mcp-server` entry shape, except that `name` may be free-form because the namespace is derived from it here.",
+        "required": ["name", "url"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Display name. Sanitized into the namespace: spaces, hyphens and dots become underscores, other non-word characters are dropped, a leading digit gains an underscore, and a JavaScript keyword gains a trailing one. A name that is already a valid identifier passes through unchanged.",
+            "examples": ["MaStR registry", "github"]
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Absolute http/https MCP endpoint, used as provided."
+          },
+          "token": {
+            "type": "string",
+            "description": "Bearer shorthand: sent as `Authorization: Bearer <token>` to the external server. Not persisted and not logged."
+          },
+          "headers": {
+            "type": "object",
+            "additionalProperties": { "type": "string" },
+            "description": "Extra request headers, applied after `token` so an explicit `authorization` entry replaces the bearer shorthand."
+          },
+          "description": {
+            "type": "string",
+            "description": "Shown to the agent in the namespace overview; falls back to the server's own `instructions`."
+          }
+        }
+      },
+      "ResolveMcpServersResponse": {
+        "type": "object",
+        "required": ["tenantUrl", "tenantNamespaces", "warnings", "servers"],
+        "properties": {
+          "tenantUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "Base URL of the Cumulocity tenant the microservice is deployed against."
+          },
+          "tenantId": {
+            "type": "string",
+            "description": "Tenant resolved from the caller's auth. Absent when resolution failed."
+          },
+          "tenantNamespaces": {
+            "type": ["array", "null"],
+            "items": { "type": "string" },
+            "description": "Every namespace this tenant already occupies (core plus one per available service) — the set an external namespace has to fit around. **`null` means the check did not run** (see `warnings`), so a namespace reported free may still be taken at runtime."
+          },
+          "warnings": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Non-fatal problems that limit how much of the answer can be trusted. Empty on a fully checked response."
+          },
+          "servers": {
+            "type": "array",
+            "description": "One entry per submitted server, same order.",
+            "items": { "$ref": "#/components/schemas/ExternalMcpResolution" }
+          }
+        }
+      },
+      "ExternalMcpResolution": {
+        "type": "object",
+        "required": ["name", "namespace", "status"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The `name` as submitted, echoed so results can be matched to input."
+          },
+          "namespace": {
+            "type": "string",
+            "description": "The namespace this entry would be mounted under — **the value to store and to send in the `mc8yp-mcp-server` header from now on**. Empty when the entry carried no usable name."
+          },
+          "status": {
+            "type": "string",
+            "enum": ["ok", "invalid", "namespace-taken", "unreachable"],
+            "description": "The one field to branch on.\n- `ok` — valid, namespace free, server answered.\n- `invalid` — the entry is malformed; sending it in the header would fail the whole request with a 400.\n- `namespace-taken` — well-formed, but the namespace is claimed, so at runtime this server is skipped and the agent silently would not have it. Rename it.\n- `unreachable` — well-formed and free, but the handshake failed. mc8yp retries on the next codemode call, so this may be transient."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Why the status is not `ok`, phrased for an operator. Absent when it is."
+          },
+          "namespaceTakenBy": {
+            "type": "string",
+            "enum": ["reserved", "tenant", "request"],
+            "description": "Who holds the namespace: a sandbox global (`codemode`, `docs`, `sandbox`, `c8y`, `cumulocity`), a namespace of this tenant, or an earlier entry in the same request. Only set for `namespace-taken`."
+          },
+          "server": {
+            "type": "object",
+            "description": "The downstream server's own handshake identity. Present when it answered.",
+            "properties": {
+              "name": { "type": "string" },
+              "version": { "type": "string" },
+              "instructions": {
+                "type": "string",
+                "description": "The server's `instructions`, which mc8yp shows the agent when the entry has no `description`."
+              }
+            }
+          },
+          "tools": {
+            "type": "array",
+            "description": "The tools the agent would get from this namespace. Present whenever the handshake succeeded — including for `namespace-taken`, so an operator renaming the entry already knows the URL and credential are right.",
+            "items": { "$ref": "#/components/schemas/ExternalMcpResolvedTool" }
+          }
+        }
+      },
+      "ExternalMcpResolvedTool": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string", "description": "Tool name as advertised by the server." },
+          "description": { "type": "string", "description": "The tool's description, or its title when it has none." }
         }
       },
       "Error": {

--- a/src/codemode/external-mcp-session.ts
+++ b/src/codemode/external-mcp-session.ts
@@ -46,6 +46,13 @@ export interface ExternalMcpServer {
    * `description`.
    */
   instructions?: string
+  /**
+   * The downstream server's self-reported identity from the handshake. Not used
+   * for namespace assembly — it exists so a configuration check can show an
+   * operator WHICH server answered.
+   */
+  serverName?: string
+  serverVersion?: string
 }
 
 /**
@@ -80,13 +87,30 @@ function armIdleTimer(sessionKey: string): void {
   session.timer.unref?.()
 }
 
-async function listExternalTools(config: ExternalMcpServerConfig): Promise<ExternalMcpServer> {
+/**
+ * Handshake one external server and read its tool list, bypassing the session
+ * cache entirely.
+ *
+ * Exported for configuration checks (`POST /resolve-mcp-servers`): an operator
+ * asking "does this URL and token work" must not be answered from a tool list
+ * cached up to 15 minutes ago, and a candidate that may never be saved must not
+ * seed the cache either. Runtime resolution goes through
+ * {@link resolveExternalMcpServers}, which is where caching belongs.
+ * @param config One external server config.
+ */
+export async function probeExternalMcpServer(config: ExternalMcpServerConfig): Promise<ExternalMcpServer> {
   const client = new McpHttpClient({ url: config.url, fetch: createExternalMcpFetch(config) })
   try {
     const info = await client.initialize()
     const tools = await client.listTools()
     consola.info(`[external-mcp] "${config.name}" at ${config.url}: ${tools.length} tool(s)`)
-    return { config, tools, instructions: info.instructions }
+    return {
+      config,
+      tools,
+      instructions: info.instructions,
+      serverName: info.serverName,
+      serverVersion: info.serverVersion,
+    }
   } finally {
     await client.close()
   }
@@ -121,7 +145,7 @@ export async function resolveExternalMcpServers(
     const key = configKey(config)
     let pending = session!.servers.get(key)
     if (!pending) {
-      pending = listExternalTools(config)
+      pending = probeExternalMcpServer(config)
       session!.servers.set(key, pending)
       // A failed handshake must not stick: drop the entry so the next
       // codemode call retries it.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { HttpTransport } from '@tmcp/transport-http'
 import consola from 'consola'
-import { getQuery, H3, HTTPError, serve } from 'h3'
+import { getQuery, H3, HTTPError, readBody, serve } from 'h3'
 import openApiSpec from '../openapi.json' with { type: 'json' }
 import { c8yMcpServer, setupMcpServer } from './server'
 import { createSessionEvictingInfoSessionManager } from './codemode/session-eviction'
@@ -24,6 +24,8 @@ import {
   collectServerExternalMcpSources,
   parseExternalMcpServers,
 } from './utils/external-mcp'
+import { resolveExternalMcpCandidates } from './utils/external-mcp-resolve'
+import { buildNamespaces } from './codemode/namespaces'
 import { BasicAuth, Client, MicroserviceClientRequestAuth } from '@c8y/client'
 import { getCachedDiscovery, refreshCapabilities } from './utils/capability-discovery'
 import { resolveCapabilities } from './utils/capability-resolution'
@@ -206,6 +208,111 @@ app.post('/refresh-apis', async (event) => {
       status: 500,
       statusText: 'Discovery failed',
       message: err instanceof Error ? err.message : 'Failed to refresh API specs',
+    })
+  }
+})
+
+// Configuration-time check for connection-supplied external MCP servers: derive
+// the namespace each entry would be mounted under, say whether that namespace is
+// free, and report what the agent would actually get from the server.
+//
+// This exists because the `mc8yp-mcp-server` header is a strict runtime
+// contract, and the three things a caller building that header cannot know on
+// its own all live in here: the derivation, the tenant's namespace list, and the
+// MCP handshake with these entries' own auth semantics. See
+// ./utils/external-mcp-resolve.ts for the reasoning.
+//
+// It is a POST with a body rather than a GET taking the header, because entries
+// carry credentials and a management UI is testing a candidate that is not
+// configured on any connection yet.
+app.post('/resolve-mcp-servers', async (event) => {
+  try {
+    const authorizationHeader = event.req.headers.get('authorization') ?? undefined
+    const cookieHeader = event.req.headers.get('cookie') ?? undefined
+    if (!authorizationHeader && !cookieHeader) {
+      throw new HTTPError({
+        status: 401,
+        statusText: 'Unauthorized',
+        message: 'Resolving MCP servers requires user auth (Authorization header or session cookie).',
+      })
+    }
+
+    // A malformed body is the caller's mistake, so it must not fall through to
+    // the 500 handler below: readBody throws on unparseable JSON.
+    const badBody = new HTTPError({
+      status: 400,
+      statusText: 'Invalid body',
+      message: 'Body must be JSON {"servers":[{"name":"…","url":"https://…","token":"…"}]} — one entry per server, `name` free-form (the namespace is derived from it).',
+    })
+    let body: { servers?: unknown } | undefined
+    try {
+      body = await readBody<{ servers?: unknown }>(event)
+    } catch {
+      throw badBody
+    }
+    const servers = body?.servers
+    if (!Array.isArray(servers))
+      throw badBody
+
+    // The tenant namespace list is what makes a collision verdict possible, and
+    // it is the one part that can legitimately be unavailable: discovery is
+    // cached per tenant and warmed by the subscriptions refresh. When it cannot
+    // be resolved we return the resolutions WITHOUT a tenant check and say so in
+    // `warnings` — reporting a namespace as free when we could not look is the
+    // failure mode this route exists to remove.
+    const warnings: string[] = []
+    let tenantId: string | undefined
+    let tenantNamespaces: string[] | null = null
+    try {
+      const userClient = new Client(
+        new MicroserviceClientRequestAuth({ authorization: authorizationHeader, cookie: cookieHeader }),
+        C8Y_BASEURL,
+      )
+      tenantId = (await userClient.tenant.current()).data?.name
+      if (!tenantId)
+        throw new Error('could not resolve the current tenant via /tenant/currentTenant')
+
+      // Nothing warmed yet (fresh container, or a tenant whose refresh has not
+      // run) means discovering on demand: this route is an admin action, so
+      // paying the spec download once beats answering with an unchecked
+      // namespace.
+      const cached = getCachedDiscovery(tenantId)
+      let discovery
+      if (cached) {
+        discovery = await cached
+      } else {
+        const subscribedCred = await getServiceUserCredentials(tenantId)
+        if (!subscribedCred)
+          throw new Error(`tenant '${tenantId}' is not subscribed to this microservice`)
+        discovery = await refreshCapabilities(tenantId, new Client(new BasicAuth(subscribedCred), C8Y_BASEURL))
+      }
+
+      const resolved = resolveCapabilities(discovery.specs, discovery.installedContextPaths, discovery.mcpServers)
+      // Assembled the same way a real connection assembles it, with no policy:
+      // restrictions filter operations, never namespace names, so the set of
+      // names is exactly what an external entry has to fit around.
+      tenantNamespaces = buildNamespaces(resolved).map((ns) => ns.name)
+    } catch (err) {
+      warnings.push(
+        `Tenant namespace check did not run (${err instanceof Error ? err.message : String(err)}). `
+        + 'A namespace reported as free here may still be taken by a tenant namespace at runtime.',
+      )
+    }
+
+    return {
+      tenantUrl: C8Y_BASEURL,
+      ...(tenantId ? { tenantId } : {}),
+      tenantNamespaces,
+      warnings,
+      servers: await resolveExternalMcpCandidates(servers, { tenantNamespaces }),
+    }
+  } catch (err) {
+    if (err instanceof HTTPError)
+      throw err
+    throw new HTTPError({
+      status: 500,
+      statusText: 'Resolution failed',
+      message: err instanceof Error ? err.message : 'Failed to resolve external MCP servers',
     })
   }
 })

--- a/src/utils/external-mcp-resolve.ts
+++ b/src/utils/external-mcp-resolve.ts
@@ -1,0 +1,230 @@
+import { probeExternalMcpServer } from '../codemode/external-mcp-session'
+import { RESERVED_NAMESPACES } from '../codemode/namespaces'
+import { deriveExternalMcpNamespace, validateExternalMcpEntry } from './external-mcp'
+import type { ExternalMcpServer } from '../codemode/external-mcp-session'
+import type { ExternalMcpServerConfig } from './external-mcp'
+
+// ─────────────────────────────────────────────────────────────────────────
+// Configuration-time resolution for connection-supplied MCP servers.
+//
+// The `mc8yp-mcp-server` header is a RUNTIME contract: strict, verbatim, and
+// fail-loud. That leaves whoever BUILDS that header — a tenant admin UI, a
+// deployment script — with three questions it cannot answer on its own:
+//
+//   1. What namespace will this server be mounted under? Only mc8yp knows the
+//      derivation (`sanitizeToolName`, the same one that turns `knowledge-base-ms`
+//      into `knowledge_base_ms`).
+//   2. Is that namespace even available? Reserved names are static, but the
+//      TENANT namespaces depend on which applications are subscribed and on
+//      mc8yp's own discovery cache. A collision there means the server is
+//      silently skipped at assembly time (`buildNamespaces`) — the operator
+//      believes the agent has a namespace it does not have.
+//   3. Does the URL/credential combination actually work, and what tools does
+//      the agent then see? mc8yp already speaks MCP with the exact auth
+//      semantics these entries get (`token` → Bearer, then `headers` so an
+//      explicit entry wins, tenant auth never forwarded). A caller probing on
+//      its own reimplements that and drifts from it.
+//
+// So this module answers all three in one pass, and `POST /resolve-mcp-servers`
+// is the transport. It reuses the header path's own validator rather than
+// re-deriving the rules: a check that green-lights an entry the header then
+// rejects would be worse than no check at all.
+//
+// What it deliberately does NOT do is change the runtime contract. A caller
+// resolves a display name once, stores the `namespace` it got back, and keeps
+// sending that verbatim — so the agent-visible namespace is stable even if this
+// derivation is refined later.
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * The single actionable field of a resolution: would this entry give the agent a
+ * working namespace, and if not, whose fault is it?
+ *
+ * - `ok` — valid, namespace free, server answered.
+ * - `invalid` — the entry itself is malformed (bad URL, non-string header value).
+ *   Sending it in the header would 400 the whole request.
+ * - `namespace-taken` — well-formed, but the namespace is already claimed. At
+ *   runtime this server is SKIPPED, so the agent silently would not have it.
+ * - `unreachable` — well-formed and free, but the handshake failed. mc8yp mounts
+ *   nothing this run and reports it to the agent; it retries on the next call,
+ *   so this may be transient.
+ */
+export type ExternalMcpResolutionStatus = 'ok' | 'invalid' | 'namespace-taken' | 'unreachable'
+
+/**
+ * Who holds the namespace an entry wanted.
+ */
+export type NamespaceHolder = 'reserved' | 'tenant' | 'request'
+
+/**
+ * One tool as an operator needs to see it — enough to judge, not a schema dump.
+ */
+export interface ResolvedExternalMcpTool {
+  name: string
+  description?: string
+}
+
+/**
+ * The verdict for one candidate entry.
+ */
+export interface ExternalMcpResolution {
+  /**
+   * The `name` as supplied, echoed so a caller can match results to input.
+   */
+  name: string
+  /**
+   * The namespace this entry would be mounted under — derived from `name`. This
+   * is the value to STORE and to send in the `mc8yp-mcp-server` header from now
+   * on.
+   */
+  namespace: string
+  status: ExternalMcpResolutionStatus
+  /**
+   * Why the status is not `ok`. Absent when it is.
+   */
+  reason?: string
+  /**
+   * Set when `status` is `namespace-taken`.
+   */
+  namespaceTakenBy?: NamespaceHolder
+  /**
+   * The downstream server's self-reported identity, when it answered.
+   */
+  server?: { name?: string, version?: string, instructions?: string }
+  /**
+   * The tools the agent would get. Present whenever the handshake succeeded —
+   * including for a `namespace-taken` entry, because an operator renaming it
+   * still wants to know the URL and credential are right.
+   */
+  tools?: ResolvedExternalMcpTool[]
+}
+
+export interface ResolveExternalMcpOptions {
+  /**
+   * Namespaces already in use on the tenant (core, one per available service).
+   * `null` means the check could not run — no tenant namespace collision is
+   * reported in that case, and callers must say so rather than imply the
+   * namespace is free.
+   */
+  tenantNamespaces: readonly string[] | null
+  /**
+   * Injection seam for tests; defaults to a real, uncached handshake.
+   */
+  probe?: (config: ExternalMcpServerConfig) => Promise<ExternalMcpServer>
+}
+
+/**
+ * Resolve a batch of candidate entries: derive each namespace, validate the
+ * entry, classify namespace collisions, then handshake what is left.
+ *
+ * Entries are resolved as a BATCH because two of them can collide with each
+ * other — the same reason `parseExternalMcpServers` threads `usedNames` through
+ * its loop. Order matters exactly as it does in the header: the first entry to
+ * claim a namespace keeps it, later ones are `namespace-taken` by `request`.
+ * @param candidates Raw entries, shaped like the header's JSON objects but with `name` free-form.
+ * @param options Tenant namespaces to check against, plus the probe seam.
+ */
+export async function resolveExternalMcpCandidates(
+  candidates: readonly unknown[],
+  options: ResolveExternalMcpOptions,
+): Promise<ExternalMcpResolution[]> {
+  const { tenantNamespaces, probe = probeExternalMcpServer } = options
+  const tenantHeld = new Set(tenantNamespaces ?? [])
+  const claimed = new Set<string>()
+
+  // Pass 1 is sequential and synchronous: namespace claims are order-dependent,
+  // so they cannot be decided inside the concurrent probe pass below.
+  type Planned
+    = | { resolution: ExternalMcpResolution }
+      | { resolution: ExternalMcpResolution, config: ExternalMcpServerConfig }
+
+  const planned: Planned[] = candidates.map((candidate) => {
+    const rawName = typeof (candidate as { name?: unknown })?.name === 'string'
+      ? (candidate as { name: string }).name
+      : ''
+    // An empty/absent name derives to nothing rather than to sanitizeToolName's
+    // `_` placeholder: the validator's own "name is required" message is the
+    // useful answer, and reporting a namespace of `_` would invite a caller to
+    // store it.
+    const namespace = rawName ? deriveExternalMcpNamespace(rawName) : ''
+
+    // Validate with the DERIVED name in place, so the only failures reported are
+    // ones a caller can act on — a display name that needed sanitizing is not
+    // one of them. A candidate that is not an object at all is handed over
+    // untouched, so the validator can say exactly that.
+    const isObject = typeof candidate === 'object' && candidate !== null && !Array.isArray(candidate)
+    const validated = validateExternalMcpEntry(
+      isObject ? { ...candidate, name: namespace } : candidate,
+      claimed,
+    )
+    if ('reason' in validated) {
+      // A duplicate/reserved name comes back from the validator as a reason
+      // string; report those as the collision they are, not as a malformed entry.
+      const holder: NamespaceHolder | undefined = RESERVED_NAMESPACES.has(namespace)
+        ? 'reserved'
+        : claimed.has(namespace)
+          ? 'request'
+          : undefined
+      return {
+        resolution: {
+          name: rawName,
+          namespace,
+          status: holder ? 'namespace-taken' : 'invalid',
+          reason: validated.reason,
+          ...(holder ? { namespaceTakenBy: holder } : {}),
+        },
+      }
+    }
+
+    claimed.add(namespace)
+
+    // Tenant namespaces win: `buildNamespaces` appends external servers last and
+    // skips a name a tenant namespace already holds. Report that here rather
+    // than letting it become a silent absence at run time.
+    if (tenantHeld.has(namespace)) {
+      return {
+        resolution: {
+          name: rawName,
+          namespace,
+          status: 'namespace-taken',
+          namespaceTakenBy: 'tenant',
+          reason: `Namespace "${namespace}" is already used by this tenant — a tenant namespace always wins, so this server would be skipped. Rename it.`,
+        },
+        config: validated.config,
+      }
+    }
+
+    return { resolution: { name: rawName, namespace, status: 'ok' }, config: validated.config }
+  })
+
+  // Pass 2: handshake everything that is well-formed, concurrently. A
+  // `namespace-taken` entry is probed too — an operator fixing the name wants to
+  // know in the same round trip whether the URL and credential are right.
+  return Promise.all(planned.map(async (entry) => {
+    if (!('config' in entry))
+      return entry.resolution
+
+    try {
+      const probed = await probe(entry.config)
+      return {
+        ...entry.resolution,
+        server: {
+          ...(probed.serverName ? { name: probed.serverName } : {}),
+          ...(probed.serverVersion ? { version: probed.serverVersion } : {}),
+          ...(probed.instructions ? { instructions: probed.instructions } : {}),
+        },
+        tools: probed.tools.map((tool) => ({
+          name: tool.name,
+          ...(tool.description ?? tool.title ? { description: tool.description ?? tool.title } : {}),
+        })),
+      }
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err)
+      // A taken namespace is the more actionable failure of the two, so it keeps
+      // the status; the handshake failure is appended to the reason.
+      return entry.resolution.status === 'namespace-taken'
+        ? { ...entry.resolution, reason: `${entry.resolution.reason} (it also did not answer: ${reason})` }
+        : { ...entry.resolution, status: 'unreachable' as const, reason }
+    }
+  }))
+}

--- a/src/utils/external-mcp.ts
+++ b/src/utils/external-mcp.ts
@@ -1,4 +1,5 @@
 import { RESERVED_NAMESPACES } from '../codemode/namespaces'
+import { sanitizeToolName } from '../codemode/operation-naming'
 import type { McpFetch } from './mcp-client'
 
 // ─────────────────────────────────────────────────────────────────────────
@@ -173,7 +174,7 @@ export function parseExternalMcpServers(sources: readonly string[]): ExternalMcp
     }
 
     for (const candidate of Array.isArray(parsed) ? parsed : [parsed]) {
-      const result = validateEntry(candidate, usedNames)
+      const result = validateExternalMcpEntry(candidate, usedNames)
       if ('reason' in result) {
         failedEntries.push({ entry: typeof candidate === 'object' ? JSON.stringify(candidate) : String(candidate), reason: result.reason })
         continue
@@ -186,7 +187,33 @@ export function parseExternalMcpServers(sources: readonly string[]): ExternalMcp
   return { servers, failedEntries }
 }
 
-function validateEntry(candidate: unknown, usedNames: ReadonlySet<string>): { config: ExternalMcpServerConfig } | { reason: string } {
+/**
+ * Turn an operator-supplied display name into the namespace it would be mounted
+ * under — the SAME derivation a discovered service gets (`sanitizeToolName`), so
+ * `MaStR registry` becomes `MaStR_registry` exactly as `knowledge-base-ms`
+ * becomes `knowledge_base_ms`. A name that is already a valid identifier is
+ * returned unchanged.
+ *
+ * The header path deliberately does NOT call this: there, `name` must already be
+ * an identifier and is used verbatim, so what the agent sees is exactly what was
+ * configured and cannot shift when this function changes. Derivation is a
+ * CONFIGURE-TIME convenience, offered through `POST /resolve-mcp-servers` — a
+ * caller resolves a display name once, stores the namespace it got back, and
+ * keeps sending that.
+ * @param name Operator-supplied display name.
+ */
+export function deriveExternalMcpNamespace(name: string): string {
+  return sanitizeToolName(name)
+}
+
+/**
+ * Validate one entry, exported so the resolve route can answer with the exact
+ * verdict the header path would reach — a route that green-lights a server the
+ * header then rejects is worse than no route at all.
+ * @param candidate Parsed JSON entry.
+ * @param usedNames Namespaces already taken by earlier entries in the same batch.
+ */
+export function validateExternalMcpEntry(candidate: unknown, usedNames: ReadonlySet<string>): { config: ExternalMcpServerConfig } | { reason: string } {
   if (typeof candidate !== 'object' || candidate === null || Array.isArray(candidate))
     return { reason: 'Entry must be a JSON object with "name" and "url".' }
 

--- a/test/external-mcp-resolve.test.ts
+++ b/test/external-mcp-resolve.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it, vi } from 'vitest'
+import { resolveExternalMcpCandidates } from '../src/utils/external-mcp-resolve'
+import { deriveExternalMcpNamespace } from '../src/utils/external-mcp'
+import type { ExternalMcpServer } from '../src/codemode/external-mcp-session'
+import type { ExternalMcpServerConfig } from '../src/utils/external-mcp'
+
+// A probe that answers for every server, so a test only has to care about the
+// resolution logic. The real one handshakes over HTTP (covered by e2e-mcp).
+function stubProbe(
+  tools: string[] = ['search'],
+  extra: Partial<ExternalMcpServer> = {},
+): (config: ExternalMcpServerConfig) => Promise<ExternalMcpServer> {
+  return async (config) => ({
+    config,
+    tools: tools.map((name) => ({ name, description: `does ${name}` })),
+    ...extra,
+  })
+}
+
+const TENANT = ['c8y', 'dtm', 'knowledge_base_ms']
+
+describe('deriveExternalMcpNamespace', () => {
+  it('derives an identifier from a display name the same way a contextPath is derived', () => {
+    expect(deriveExternalMcpNamespace('MaStR registry')).toBe('MaStR_registry')
+    expect(deriveExternalMcpNamespace('knowledge-base-ms')).toBe('knowledge_base_ms')
+    expect(deriveExternalMcpNamespace('weather.api v2')).toBe('weather_api_v2')
+  })
+
+  it('leaves a name that is already an identifier untouched', () => {
+    expect(deriveExternalMcpNamespace('github')).toBe('github')
+    expect(deriveExternalMcpNamespace('_internal$tool')).toBe('_internal$tool')
+  })
+
+  it('keeps the result a legal global: no leading digit, no JS keyword', () => {
+    expect(deriveExternalMcpNamespace('2fast')).toBe('_2fast')
+    expect(deriveExternalMcpNamespace('class')).toBe('class_')
+  })
+})
+
+describe('resolveExternalMcpCandidates', () => {
+  it('resolves a display name to its namespace and reports the tools the agent would get', async () => {
+    const [result] = await resolveExternalMcpCandidates(
+      [{ name: 'MaStR registry', url: 'https://mastr.example/mcp', token: 'secret' }],
+      { tenantNamespaces: TENANT, probe: stubProbe(['search_units', 'get_unit']) },
+    )
+
+    expect(result).toMatchObject({
+      name: 'MaStR registry',
+      namespace: 'MaStR_registry',
+      status: 'ok',
+    })
+    expect(result!.reason).toBeUndefined()
+    expect(result!.tools).toEqual([
+      { name: 'search_units', description: 'does search_units' },
+      { name: 'get_unit', description: 'does get_unit' },
+    ])
+  })
+
+  it('passes the entry to the probe with the DERIVED name, which is what the header will carry', async () => {
+    const probe = vi.fn(stubProbe())
+    await resolveExternalMcpCandidates(
+      [{ name: 'MaStR registry', url: 'https://mastr.example/mcp' }],
+      { tenantNamespaces: TENANT, probe },
+    )
+
+    expect(probe).toHaveBeenCalledWith(expect.objectContaining({ name: 'MaStR_registry' }))
+  })
+
+  it('reports the server\'s own identity and instructions when it answers', async () => {
+    const [result] = await resolveExternalMcpCandidates(
+      [{ name: 'github', url: 'https://api.githubcopilot.com/mcp/' }],
+      {
+        tenantNamespaces: TENANT,
+        probe: stubProbe(['search'], { serverName: 'github-mcp', serverVersion: '1.2.3', instructions: 'Use for repos.' }),
+      },
+    )
+
+    expect(result!.server).toEqual({ name: 'github-mcp', version: '1.2.3', instructions: 'Use for repos.' })
+  })
+
+  // The whole point of the route: a tenant namespace wins, so at runtime this
+  // server is skipped and the agent silently does not have it.
+  it('flags a namespace held by a tenant namespace as taken, not as ok', async () => {
+    const [result] = await resolveExternalMcpCandidates(
+      [{ name: 'dtm', url: 'https://third-party.example/mcp' }],
+      { tenantNamespaces: TENANT, probe: stubProbe() },
+    )
+
+    expect(result).toMatchObject({ namespace: 'dtm', status: 'namespace-taken', namespaceTakenBy: 'tenant' })
+    expect(result!.reason).toContain('already used by this tenant')
+  })
+
+  it('still reports the tools of a taken namespace, so renaming is the only fix needed', async () => {
+    const [result] = await resolveExternalMcpCandidates(
+      [{ name: 'knowledge base ms', url: 'https://third-party.example/mcp' }],
+      { tenantNamespaces: TENANT, probe: stubProbe(['ask']) },
+    )
+
+    expect(result).toMatchObject({ namespace: 'knowledge_base_ms', status: 'namespace-taken' })
+    expect(result!.tools).toEqual([{ name: 'ask', description: 'does ask' }])
+  })
+
+  it('flags a reserved namespace as taken by the sandbox, without probing it', async () => {
+    const probe = vi.fn(stubProbe())
+    const [result] = await resolveExternalMcpCandidates(
+      [{ name: 'codemode', url: 'https://third-party.example/mcp' }],
+      { tenantNamespaces: TENANT, probe },
+    )
+
+    expect(result).toMatchObject({ namespace: 'codemode', status: 'namespace-taken', namespaceTakenBy: 'reserved' })
+    expect(probe).not.toHaveBeenCalled()
+  })
+
+  it('preserves casing, so two differently-cased names stay distinct namespaces', async () => {
+    const results = await resolveExternalMcpCandidates(
+      [
+        { name: 'Weather API', url: 'https://a.example/mcp' },
+        { name: 'weather-api', url: 'https://b.example/mcp' },
+      ],
+      { tenantNamespaces: TENANT, probe: stubProbe() },
+    )
+
+    // Derivation sanitizes, it does not lowercase: the agent-visible global is
+    // as close to what the operator typed as a JS identifier allows.
+    expect(results[0]).toMatchObject({ namespace: 'Weather_API', status: 'ok' })
+    expect(results[1]).toMatchObject({ namespace: 'weather_api', status: 'ok' })
+  })
+
+  it('flags the second of two entries deriving the same namespace', async () => {
+    const results = await resolveExternalMcpCandidates(
+      [
+        { name: 'weather api', url: 'https://a.example/mcp' },
+        { name: 'weather-api', url: 'https://b.example/mcp' },
+      ],
+      { tenantNamespaces: TENANT, probe: stubProbe() },
+    )
+
+    expect(results[0]).toMatchObject({ namespace: 'weather_api', status: 'ok' })
+    expect(results[1]).toMatchObject({ namespace: 'weather_api', status: 'namespace-taken', namespaceTakenBy: 'request' })
+    expect(results[1]!.reason).toContain('Duplicate namespace')
+  })
+
+  // Everything the header path rejects must be rejected here too — a check that
+  // green-lights an entry the header 400s would be worse than no check.
+  it('reports a malformed entry as invalid, with the header path\'s own reason', async () => {
+    const results = await resolveExternalMcpCandidates(
+      [
+        { name: 'no url' },
+        { name: 'bad scheme', url: 'ftp://files.example/mcp' },
+        { name: 'not absolute', url: '/mcp' },
+        { name: 'bad headers', url: 'https://a.example/mcp', headers: { 'x-key': 42 } },
+        { url: 'https://a.example/mcp' },
+        'nonsense',
+      ],
+      { tenantNamespaces: TENANT, probe: stubProbe() },
+    )
+
+    expect(results.map((r) => r.status)).toEqual(['invalid', 'invalid', 'invalid', 'invalid', 'invalid', 'invalid'])
+    expect(results[0]!.reason).toContain('"url" is required')
+    expect(results[1]!.reason).toContain('http or https')
+    expect(results[2]!.reason).toContain('absolute URL')
+    expect(results[3]!.reason).toContain('"headers.x-key" must be a string')
+    expect(results[4]!.reason).toContain('"name" is required')
+    expect(results[5]!.reason).toContain('JSON object')
+  })
+
+  it('does not report a namespace for an entry that has no usable name', async () => {
+    const [result] = await resolveExternalMcpCandidates([{ url: 'https://a.example/mcp' }], {
+      tenantNamespaces: TENANT,
+      probe: stubProbe(),
+    })
+
+    // `_` (sanitizeToolName's placeholder for an empty string) would look like a
+    // namespace worth storing.
+    expect(result!.namespace).toBe('')
+  })
+
+  it('reports an unreachable server as unreachable, carrying the handshake reason', async () => {
+    const [result] = await resolveExternalMcpCandidates(
+      [{ name: 'offline', url: 'https://offline.example/mcp' }],
+      {
+        tenantNamespaces: TENANT,
+        probe: async () => {
+          throw new Error('HTTP 401 Unauthorized')
+        },
+      },
+    )
+
+    expect(result).toMatchObject({ namespace: 'offline', status: 'unreachable', reason: 'HTTP 401 Unauthorized' })
+    expect(result!.tools).toBeUndefined()
+  })
+
+  it('keeps namespace-taken as the status when a taken server is also unreachable', async () => {
+    const [result] = await resolveExternalMcpCandidates(
+      [{ name: 'dtm', url: 'https://offline.example/mcp' }],
+      {
+        tenantNamespaces: TENANT,
+        probe: async () => {
+          throw new Error('connect ECONNREFUSED')
+        },
+      },
+    )
+
+    expect(result!.status).toBe('namespace-taken')
+    expect(result!.reason).toContain('already used by this tenant')
+    expect(result!.reason).toContain('did not answer: connect ECONNREFUSED')
+  })
+
+  // Reporting "free" when the tenant list could not be fetched is exactly the
+  // silent-skip failure this route removes, so the null case must stay visible
+  // to the caller (the route puts it in `warnings`).
+  it('skips the tenant check when the namespace list is unavailable', async () => {
+    const [result] = await resolveExternalMcpCandidates(
+      [{ name: 'dtm', url: 'https://third-party.example/mcp' }],
+      { tenantNamespaces: null, probe: stubProbe() },
+    )
+
+    expect(result).toMatchObject({ namespace: 'dtm', status: 'ok' })
+  })
+
+  it('returns an empty list for an empty batch without probing anything', async () => {
+    const probe = vi.fn(stubProbe())
+    expect(await resolveExternalMcpCandidates([], { tenantNamespaces: TENANT, probe })).toEqual([])
+    expect(probe).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Adds `POST /resolve-mcp-servers`: given the same entries that would go into the `mc8yp-mcp-server` header (with a free-form `name`), it reports the namespace each would be mounted under, whether that namespace is available, and what the agent would actually get from the server.

It exists because three things a consumer building that header needs are only knowable inside mc8yp: the namespace derivation, the tenant's namespace set (which depends on subscriptions and the discovery cache), and the MCP handshake with these entries' own auth semantics. A consumer that guesses at any of them drifts from what actually happens at runtime — and one of those mismatches is invisible today: an external entry whose namespace collides with a tenant namespace is SKIPPED with only a server-side warning, so the operator believes the agent has a namespace it does not have. That is now a `namespace-taken` verdict at configuration time.

Four rules hold it together:

- The runtime contract is unchanged. Derivation is configure-time only: a caller resolves a display name once, stores the returned `namespace`, and keeps sending it verbatim, so the agent-visible global cannot shift if the derivation is later refined. The header still validates `name` as an identifier and uses it as given.
- Validation reuses `validateExternalMcpEntry` — the header path's own validator, exported for this. A route that green-lights an entry the header then 400s would be worse than no route.
- The handshake is `probeExternalMcpServer` (extracted from the private `listExternalTools`), bypassing the per-session tool-list cache in both directions: "does this token work" must not be answered from a 15-minute-old handshake, and a candidate that may never be saved must not seed the cache.
- A tenant-collision verdict needs discovery, which can legitimately be unavailable. When nothing is warmed the route discovers on demand (service user, like /refresh-apis); if that fails, `tenantNamespaces: null` plus a `warnings` entry says the check did not run, rather than implying the namespace is free.

Documented in openapi.json (so it is discoverable through `serviceSpecs['mc8yp-server']`), README and AGENTS.md.